### PR TITLE
Redirected rally-tracks to opensearch-benchmark-workloads (#12)

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1792,14 +1792,9 @@ class RaceConfig:
         for task in self.track.find_challenge_or_default(self.challenge).schedule:
             for sub_task in task:
                 # We are assuming here that each task with a target throughput or target interval is interesting for latency charts.
-                #
-                # As a temporary workaround we're also treating operations of type "eql" as throttled tasks (requiring a latency
-                # or service time chart) although they are (at the moment) not throttled. These tasks originate from the EQL track
-                # available at https://github.com/elastic/rally-tracks/tree/master/eql.
-                #
                 # We should refactor the chart generator to make this classification logic more flexible so the user can specify
                 # which tasks / or types of operations should be used for which chart types.
-                if "target-throughput" in sub_task.params or "target-interval" in sub_task.params or sub_task.operation.type == "eql":
+                if "target-throughput" in sub_task.params or "target-interval" in sub_task.params:
                     task_names.append(sub_task.name)
         return task_names
 

--- a/esrally/resources/rally.ini
+++ b/esrally/resources/rally.ini
@@ -25,7 +25,7 @@ datastore.password =
 
 
 [tracks]
-default.url = https://github.com/elastic/rally-tracks
+default.url = https://github.com/opensearch-project/opensearch-benchmark-workloads
 
 [teams]
 default.url = https://github.com/elastic/rally-teams

--- a/it/resources/rally-es-it.ini
+++ b/it/resources/rally-es-it.ini
@@ -25,7 +25,7 @@ datastore.password =
 
 
 [tracks]
-default.url = https://github.com/elastic/rally-tracks
+default.url = https://github.com/opensearch-project/opensearch-benchmark-workloads
 eventdata.url = https://github.com/elastic/rally-eventdata-track
 
 [teams]

--- a/it/resources/rally-in-memory-it.ini
+++ b/it/resources/rally-in-memory-it.ini
@@ -20,7 +20,7 @@ datastore.type = in-memory
 
 
 [tracks]
-default.url = https://github.com/elastic/rally-tracks
+default.url = https://github.com/opensearch-project/opensearch-benchmark-workloads
 eventdata.url = https://github.com/elastic/rally-eventdata-track
 
 [teams]

--- a/recipes/ccr/start.sh
+++ b/recipes/ccr/start.sh
@@ -93,7 +93,7 @@ datastore.user = elastic
 datastore.password = notinuse
 
 [tracks]
-default.url = https://github.com/elastic/rally-tracks
+default.url = https://github.com/opensearch-project/opensearch-benchmark-workloads
 
 [teams]
 default.url = https://github.com/elastic/rally-teams


### PR DESCRIPTION
- Pointed the default.url to rally-tracks
- Removed eql track reference