### PR TITLE
Change rally to benchmark for Jinja templating

### DIFF
--- a/osbenchmark/resources/workload.json.j2
+++ b/osbenchmark/resources/workload.json.j2
@@ -1,4 +1,4 @@
-{% raw %}{% import "rally.helpers" as rally with context %}{% endraw %}
+{% raw %}{% import "bechmark.helpers" as bechmark with context %}{% endraw %}
 {
   "version": 2,
   "description": "Tracker-generated workload for {{workload_name}}",

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -632,10 +632,10 @@ class TemplateSource:
     """
     Prepares the fully assembled workload file from file or string.
     Doesn't render using jinja2, but embeds workload fragments referenced with
-    rally.collect(parts=...
+    benchmark.collect(parts=...
     """
 
-    collect_parts_re = re.compile(r"{{\ +?rally\.collect\(parts=\"(.+?(?=\"))\"\)\ +?}}")
+    collect_parts_re = re.compile(r"{{\ +?benchmark\.collect\(parts=\"(.+?(?=\"))\"\)\ +?}}")
 
     def __init__(self, base_path, template_file_name, source=io.FileSource, fileglobber=glob.glob):
         self.base_path = base_path
@@ -727,7 +727,7 @@ def render_template(template_source, template_vars=None, template_internal_vars=
     # place helpers dict loader first to prevent users from overriding our macros.
     env = jinja2.Environment(
         loader=jinja2.ChoiceLoader([
-            jinja2.DictLoader({"rally.helpers": "".join(macros)}),
+            jinja2.DictLoader({"benchmark.helpers": "".join(macros)}),
             jinja2.BaseLoader(),
             loader
         ])

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -761,7 +761,7 @@ class TemplateSource(TestCase):
     @mock.patch.object(loader.TemplateSource, "read_glob_files")
     def test_entrypoint_of_replace_includes(self, patched_read_glob, patched_dirname):
         workload = textwrap.dedent("""
-        {% import "rally.helpers" as rally with context %}
+        {% import "benchmark.helpers" as benchmark with context %}
         {
           "version": 2,
           "description": "unittest workload",
@@ -787,10 +787,10 @@ class TemplateSource(TestCase):
             }
           ],
           "operations": [
-            {{ rally.collect(parts="operations/*.json") }}
+            {{ benchmark.collect(parts="operations/*.json") }}
           ],
           "test_procedures": [
-            {{ rally.collect(parts="test_procedures/*.json") }}
+            {{ benchmark.collect(parts="test_procedures/*.json") }}
           ]
         }
         """)
@@ -805,7 +805,7 @@ class TemplateSource(TestCase):
         tmpl_src = loader.TemplateSource(base_path, template_file_name)
         # pylint: disable=trailing-whitespace
         expected_response = textwrap.dedent("""
-            {% import "rally.helpers" as rally with context %}
+            {% import "benchmark.helpers" as benchmark with context %}
             {
               "version": 2,
               "description": "unittest workload",
@@ -911,10 +911,10 @@ class TemplateRenderTests(TestCase):
                 return []
 
         template = """
-        {% import "rally.helpers" as rally %}
+        {% import "benchmark.helpers" as benchmark %}
         {
             "key1": "static value",
-            {{ rally.collect(parts="dynamic-key-*") }}
+            {{ benchmark.collect(parts="dynamic-key-*") }}
 
         }
         """
@@ -953,7 +953,7 @@ class TemplateRenderTests(TestCase):
         template = """
         {% set _clients = clients if clients is defined else 16 %}
         {% set _bulk_size = bulk_size if bulk_size is defined else 100 %}
-        {% import "rally.helpers" as rally with context %}
+        {% import "benchmark.helpers" as benchmark with context %}
         {
             "key1": "static value",
             "dkey1": {{ _clients }},
@@ -979,7 +979,7 @@ class TemplateRenderTests(TestCase):
 
 
 class CompleteWorkloadParamsTests(TestCase):
-    assembled_source = textwrap.dedent("""{% import "rally.helpers" as rally with context %}
+    assembled_source = textwrap.dedent("""{% import "benchmark.helpers" as benchmark with context %}
         "key1": "value1",
         "key2": {{ value2 | default(3) }},
         "key3": {{ value3 | default("default_value3") }}


### PR DESCRIPTION
Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Change language around Jinja templating from "rally" to "benchmark". There is a corresponding PR for the OSB Workloads repo [here](https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/12)
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Benchmark/issues/13
 
### Check List
- [X] New functionality includes testing
  - [X] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).