### PR TITLE
Add opensearch license header to provisionconfig python files

### DIFF
--- a/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_azure/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_azure/plugin.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_gcs/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_gcs/plugin.py
@@ -1,3 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_s3/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/1.0/plugins/v1/repository_s3/plugin.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_azure/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_azure/plugin.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_gcs/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_gcs/plugin.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_s3/plugin.py
+++ b/opensearch-benchmark-provisionconfigs/main/plugins/v1/repository_s3/plugin.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright


### PR DESCRIPTION
Signed-off-by: Achit Ojha <achiojha@amazon.com>

### Description
provisionconfigs directory had some python files which didn't have the license headers. This change adds the licence headers to those files.

### Issues Resolved
#72 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).