### PR TITLE
Revert "Ensure destructive actions work regardless of wildcard input …

### DIFF
--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -2528,9 +2528,6 @@ class DeleteIndexRunnerTests(TestCase):
     async def test_deletes_existing_indices(self, opensearch):
         opensearch.indices.exists.side_effect = [as_future(False), as_future(True)]
         opensearch.indices.delete.return_value = as_future()
-        opensearch.cluster.get_settings.return_value = as_future({"persistent": {},
-                                                          "transient": {"action.destructive_requires_name": True}})
-        opensearch.cluster.put_settings.return_value = as_future()
         r = runner.DeleteIndex()
 
         params = {
@@ -2546,18 +2543,12 @@ class DeleteIndexRunnerTests(TestCase):
             "success": True
         }, result)
 
-        opensearch.cluster.put_settings.assert_has_calls([
-            mock.call(body={"transient": {"action.destructive_requires_name": False}}),
-            mock.call(body={"transient": {"action.destructive_requires_name": True}})
-        ])
         opensearch.indices.delete.assert_called_once_with(index="indexB", params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_deletes_all_indices(self, opensearch):
         opensearch.indices.delete.return_value = as_future()
-        opensearch.cluster.get_settings.return_value = as_future({"persistent": {}, "transient": {}})
-        opensearch.cluster.put_settings.return_value = as_future()
         r = runner.DeleteIndex()
 
         params = {
@@ -2577,10 +2568,6 @@ class DeleteIndexRunnerTests(TestCase):
             "success": True
         }, result)
 
-        opensearch.cluster.put_settings.assert_has_calls([
-            mock.call(body={"transient": {"action.destructive_requires_name": False}}),
-            mock.call(body={"transient": {"action.destructive_requires_name": None}})
-        ])
         opensearch.indices.delete.assert_has_calls([
             mock.call(index="indexA", params=params["request-params"]),
             mock.call(index="indexB", params=params["request-params"])


### PR DESCRIPTION
…(#1243)"

Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Revert change that was made for Elasticsearch 8. The `PUT _cluster/settings` operation from this change was preventing tests to be run against managed OpenSearch domains. 

See original commit [here](https://github.com/opensearch-project/opensearch-benchmark/commit/40334f18f92e82686c7a1b4440d53395767d2445) 

 
### Check List
- [X] New functionality includes testing
  - [X] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).