### PR TITLE
Enable autoescaping in Jinja2 of HTML and XML content, to mitigate XSS attacks

### DIFF
--- a/osbenchmark/builder/provisioner.py
+++ b/osbenchmark/builder/provisioner.py
@@ -153,8 +153,8 @@ def cleanup(preserve, install_dir, data_paths):
 def _apply_config(source_root_path, target_root_path, config_vars):
     logger = logging.getLogger(__name__)
     for root, _, files in os.walk(source_root_path):
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(root))
 
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=jinja2.select_autoescape(['html', 'xml']))
         relative_root = root[len(source_root_path) + 1:]
         absolute_target_root = os.path.join(target_root_path, relative_root)
         io.ensure_dir(absolute_target_root)
@@ -440,7 +440,7 @@ class DockerProvisioner:
 
         for provision_config_instance_config_path in self.provision_config_instance.config_paths:
             for root, _, files in os.walk(provision_config_instance_config_path):
-                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root))
+                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=jinja2.select_autoescape(['html', 'xml']))
 
                 relative_root = root[len(provision_config_instance_config_path) + 1:]
                 absolute_target_root = os.path.join(self.binary_path, relative_root)
@@ -488,7 +488,7 @@ class DockerProvisioner:
 
     def _render_template(self, loader, template_name, variables):
         try:
-            env = jinja2.Environment(loader=loader)
+            env = jinja2.Environment(loader=loader, autoescape=jinja2.select_autoescape(['html', 'xml']))
             for k, v in variables.items():
                 env.globals[k] = v
             template = env.get_template(template_name)

--- a/osbenchmark/tracker/tracker.py
+++ b/osbenchmark/tracker/tracker.py
@@ -35,7 +35,7 @@ from osbenchmark.utils import io, opts, console
 
 
 def process_template(templates_path, template_filename, template_vars, output_path):
-    env = Environment(loader=FileSystemLoader(templates_path))
+    env = Environment(loader=FileSystemLoader(templates_path), autoescape=jinja2.select_autoescape(['html', 'xml']))
     template = env.get_template(template_filename)
 
     with open(output_path, "w") as f:

--- a/osbenchmark/tracker/tracker.py
+++ b/osbenchmark/tracker/tracker.py
@@ -25,6 +25,7 @@
 import logging
 import os
 
+import jinja2
 from elasticsearch import ElasticsearchException
 from jinja2 import Environment, FileSystemLoader
 

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -648,7 +648,7 @@ class TemplateSource:
     def load_template_from_file(self):
         loader = jinja2.FileSystemLoader(self.base_path)
         try:
-            base_workload = loader.get_source(jinja2.Environment(), self.template_file_name)
+            base_workload = loader.get_source(jinja2.Environment(autoescape=jinja2.select_autoescape(['html', 'xml'])), self.template_file_name)
         except jinja2.TemplateNotFound:
             self.logger.exception("Could not load workload from [%s].", self.template_file_name)
             raise WorkloadSyntaxError("Could not load workload from '{}'".format(self.template_file_name))
@@ -730,7 +730,8 @@ def render_template(template_source, template_vars=None, template_internal_vars=
             jinja2.DictLoader({"benchmark.helpers": "".join(macros)}),
             jinja2.BaseLoader(),
             loader
-        ])
+        ]),
+        autoescape=jinja2.select_autoescape(['html', 'xml'])
     )
 
     if template_vars:
@@ -747,7 +748,7 @@ def render_template(template_source, template_vars=None, template_internal_vars=
 
 
 def register_all_params_in_workload(assembled_source, complete_workload_params=None):
-    j2env = jinja2.Environment()
+    j2env = jinja2.Environment(autoescape=jinja2.select_autoescape(['html', 'xml']))
 
     # we don't need the following j2 filters/macros but we define them anyway to prevent parsing failures
     internal_template_vars = default_internal_template_vars()

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -648,7 +648,9 @@ class TemplateSource:
     def load_template_from_file(self):
         loader = jinja2.FileSystemLoader(self.base_path)
         try:
-            base_workload = loader.get_source(jinja2.Environment(autoescape=jinja2.select_autoescape(['html', 'xml'])), self.template_file_name)
+            base_workload = loader.get_source(jinja2.Environment(
+                autoescape=jinja2.select_autoescape(['html', 'xml'])),
+                self.template_file_name)
         except jinja2.TemplateNotFound:
             self.logger.exception("Could not load workload from [%s].", self.template_file_name)
             raise WorkloadSyntaxError("Could not load workload from '{}'".format(self.template_file_name))


### PR DESCRIPTION
Signed-off-by: Achit Ojha <achiojha@amazon.com>

### Description
Changes to jinja environments instantiation to have autoescape enabled by default for html content.
 
### Issues Resolved
#92 
 
### Check List
- [X] New functionality includes testing
  - [X ] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).