### PR TITLE
Change OpenSearch copyrights to 2022

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 OpenSearch
-Copyright 2021 OpenSearch Contributors
+Copyright 2022 OpenSearch Contributors
 
 This product includes software, including Rally source code, developed by Elasticsearch(http://www.elastic.co).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ License
 
 This software is licensed under the Apache License, version 2 ("ALv2"), quoted below.
 
-Copyright 2015-2021 OpenSearch <https://opensearch.org/>
+Copyright 2015-2022 OpenSearch <https://opensearch.org/>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
### Description
Bump OpenSearch copyright to 2022
 
### Issues Resolved
- https://github.com/opensearch-project/opensearch-benchmark/issues/94
 
### Check List
- [X] New functionality includes testing
  - [X] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).