### PR TITLE
Directly import jinja2.select_autoescape

### DIFF
--- a/osbenchmark/builder/provisioner.py
+++ b/osbenchmark/builder/provisioner.py
@@ -30,6 +30,7 @@ import shutil
 import uuid
 
 import jinja2
+from jinja2 import select_autoescape
 
 from osbenchmark import exceptions
 from osbenchmark.builder import provision_config, java_resolver
@@ -154,7 +155,7 @@ def _apply_config(source_root_path, target_root_path, config_vars):
     logger = logging.getLogger(__name__)
     for root, _, files in os.walk(source_root_path):
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=jinja2.select_autoescape(['html', 'xml']))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=select_autoescape(['html', 'xml']))
         relative_root = root[len(source_root_path) + 1:]
         absolute_target_root = os.path.join(target_root_path, relative_root)
         io.ensure_dir(absolute_target_root)
@@ -440,7 +441,7 @@ class DockerProvisioner:
 
         for provision_config_instance_config_path in self.provision_config_instance.config_paths:
             for root, _, files in os.walk(provision_config_instance_config_path):
-                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=jinja2.select_autoescape(['html', 'xml']))
+                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=select_autoescape(['html', 'xml']))
 
                 relative_root = root[len(provision_config_instance_config_path) + 1:]
                 absolute_target_root = os.path.join(self.binary_path, relative_root)
@@ -488,7 +489,7 @@ class DockerProvisioner:
 
     def _render_template(self, loader, template_name, variables):
         try:
-            env = jinja2.Environment(loader=loader, autoescape=jinja2.select_autoescape(['html', 'xml']))
+            env = jinja2.Environment(loader=loader, autoescape=select_autoescape(['html', 'xml']))
             for k, v in variables.items():
                 env.globals[k] = v
             template = env.get_template(template_name)

--- a/osbenchmark/tracker/tracker.py
+++ b/osbenchmark/tracker/tracker.py
@@ -25,7 +25,6 @@
 import logging
 import os
 
-import jinja2
 from elasticsearch import ElasticsearchException
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 

--- a/osbenchmark/tracker/tracker.py
+++ b/osbenchmark/tracker/tracker.py
@@ -27,7 +27,7 @@ import os
 
 import jinja2
 from elasticsearch import ElasticsearchException
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from osbenchmark import PROGRAM_NAME
 from osbenchmark.client import OsClientFactory
@@ -36,7 +36,7 @@ from osbenchmark.utils import io, opts, console
 
 
 def process_template(templates_path, template_filename, template_vars, output_path):
-    env = Environment(loader=FileSystemLoader(templates_path), autoescape=jinja2.select_autoescape(['html', 'xml']))
+    env = Environment(loader=FileSystemLoader(templates_path), autoescape=select_autoescape(['html', 'xml']))
     template = env.get_template(template_filename)
 
     with open(output_path, "w") as f:

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -34,7 +34,7 @@ import jinja2
 import jinja2.exceptions
 import jsonschema
 import tabulate
-from jinja2 import meta
+from jinja2 import meta, select_autoescape
 
 from osbenchmark import exceptions, time, PROGRAM_NAME, config, version
 from osbenchmark.workload import params, workload
@@ -649,7 +649,7 @@ class TemplateSource:
         loader = jinja2.FileSystemLoader(self.base_path)
         try:
             base_workload = loader.get_source(jinja2.Environment(
-                autoescape=jinja2.select_autoescape(['html', 'xml'])),
+                autoescape=select_autoescape(['html', 'xml'])),
                 self.template_file_name)
         except jinja2.TemplateNotFound:
             self.logger.exception("Could not load workload from [%s].", self.template_file_name)
@@ -733,7 +733,7 @@ def render_template(template_source, template_vars=None, template_internal_vars=
             jinja2.BaseLoader(),
             loader
         ]),
-        autoescape=jinja2.select_autoescape(['html', 'xml'])
+        autoescape=select_autoescape(['html', 'xml'])
     )
 
     if template_vars:
@@ -750,7 +750,7 @@ def render_template(template_source, template_vars=None, template_internal_vars=
 
 
 def register_all_params_in_workload(assembled_source, complete_workload_params=None):
-    j2env = jinja2.Environment(autoescape=jinja2.select_autoescape(['html', 'xml']))
+    j2env = jinja2.Environment(autoescape=select_autoescape(['html', 'xml']))
 
     # we don't need the following j2 filters/macros but we define them anyway to prevent parsing failures
     internal_template_vars = default_internal_template_vars()


### PR DESCRIPTION
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Description
Directly imports jinja2's select_autoescape method and replaces all references to jinja2.select_autoescape with select_autoescape
 
### Check List
- [x ] New functionality includes testing
  - [ x] All unit tests pass
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).