### PR TITLE
Set MarkupSafe version to 2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,9 @@ install_requires = [
     # License: MIT
     "jsonschema==3.1.1",
     # License: BSD
-    # transitive dependency Markupsafe: BSD
     "Jinja2==2.11.3",
+    # License: BSD
+    "markupsafe==2.0.1",
     # License: MIT
     "thespian==3.10.1",
     # recommended library for thespian to identify actors more easily with `ps`


### PR DESCRIPTION
### Description
Selects a Jinja compatible version of MarkupSafe to install when `pip` installing OpenSearch Benchmark. This fix can be tested by runninng `pip3 install git+https://github.com/opensearch-project/opensearch-benchmark.git@bad3eff70a9f732ae3f2c7e7d4ac0e4f68d29c1e`

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/111
 
### Check List
- [X] New functionality includes testing
  - [X] All unit tests pass
- [X] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).