### PR TITLE
Reverting OpenSearch metrics store to be insecure in the integration tests

### DIFF
--- a/it/resources/benchmark-os-it.ini
+++ b/it/resources/benchmark-os-it.ini
@@ -19,9 +19,9 @@ local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 datastore.type = opensearch
 datastore.host = localhost
 datastore.port = 10200
-datastore.secure = True
-datastore.user = admin
-datastore.password = admin
+datastore.secure = False
+datastore.user =
+datastore.password =
 
 
 [workloads]


### PR DESCRIPTION
### Description
The integration test metrics store is being marked as secure but not created as such. This causes an SSL error when trying to connect using https. This PR reverts the secure setting, allowing the integration tests to connect to the metrics store:
```
it/distribution_test.py::test_tar_distributions[os-it]
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/


-------------------------------
[INFO] SUCCESS (took 4 seconds)
-------------------------------

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[ERROR] Cannot execute_test. Error in test execution orchestrator (A transport error occurred while running the operation [put_template] against your OpenSearch metrics store on host [localhost] at port [10200].)

Getting further help:
*********************
* Check the log files in /Users/engechas/.benchmark/logs for errors.
* Read the documentation at https://opensearch.org/docs.
* Ask a question on the forum at https://discuss.opendistrocommunity.dev/.
* Raise an issue at https://github.com/opensearch-project/OpenSearch-Benchmark/issues and include the log files in /Users/engechas/.benchmark/logs.

-------------------------------
[INFO] FAILURE (took 5 seconds)
-------------------------------
FAILED
```

The tests are now able to connect to the metrics store. The exception about `put_template` will be fixed by #108 

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#118 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).