### PR TITLE
Removing cluster.initial_master_nodes and adding healthcheck to docker-compose.yml.j2

### DIFF
--- a/osbenchmark/resources/docker-compose.yml.j2
+++ b/osbenchmark/resources/docker-compose.yml.j2
@@ -15,7 +15,6 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - discovery.seed_hosts=opensearch-node1
-      - cluster.initial_master_nodes=opensearch-node1
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -39,6 +38,11 @@ services:
       - 9600:9600
     networks:
       - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:{{http_port}} -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
 
 volumes:
   opensearch-data1:

--- a/tests/builder/provisioner_test.py
+++ b/tests/builder/provisioner_test.py
@@ -436,7 +436,6 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - discovery.seed_hosts=opensearch-node1
-      - cluster.initial_master_nodes=opensearch-node1
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -457,6 +456,11 @@ services:
       - 9600:9600
     networks:
       - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:39200 -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
 
 volumes:
   opensearch-data1:
@@ -503,7 +507,6 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - discovery.seed_hosts=opensearch-node1
-      - cluster.initial_master_nodes=opensearch-node1
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -524,6 +527,11 @@ services:
       - 9600:9600
     networks:
       - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:39200 -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
 
 volumes:
   opensearch-data1:


### PR DESCRIPTION
### Description
This PR fixes the Docker integration test by editing the docker-compose.yml.j2 file to remove the `cluster.initial_master_nodes` setting and adding a health check. More details about why it was failing before can be found in #117 

```
it/distribution_test.py::test_docker_distribution[os-it]
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Preparing for test execution ...
[INFO] Executing test with workload [geonames], test_procedure [append-no-conflicts-index-only] and provision_config_instance ['4gheap'] with version [1.0.0].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index-append                                                           [100% done]
Running force-merge                                                            [100% done]
Running wait-until-merges-finish                                               [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                     Task |       Value |   Unit |
|---------------------------------------------------------------:|-------------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                          |     0.02995 |    min |
|             Min cumulative indexing time across primary shards |                          |  0.00376667 |    min |
|          Median cumulative indexing time across primary shards |                          |  0.00516667 |    min |
|             Max cumulative indexing time across primary shards |                          |   0.0102667 |    min |
|            Cumulative indexing throttle time of primary shards |                          |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                          |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                          |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                          |           0 |    min |
|                        Cumulative merge time of primary shards |                          |           0 |    min |
|                       Cumulative merge count of primary shards |                          |           0 |        |
|                Min cumulative merge time across primary shards |                          |           0 |    min |
|             Median cumulative merge time across primary shards |                          |           0 |    min |
|                Max cumulative merge time across primary shards |                          |           0 |    min |
|               Cumulative merge throttle time of primary shards |                          |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                          |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                          |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                          |           0 |    min |
|                      Cumulative refresh time of primary shards |                          |     0.04015 |    min |
|                     Cumulative refresh count of primary shards |                          |          20 |        |
|              Min cumulative refresh time across primary shards |                          |  0.00361667 |    min |
|           Median cumulative refresh time across primary shards |                          |     0.00695 |    min |
|              Max cumulative refresh time across primary shards |                          |      0.0134 |    min |
|                        Cumulative flush time of primary shards |                          |           0 |    min |
|                       Cumulative flush count of primary shards |                          |           0 |        |
|                Min cumulative flush time across primary shards |                          |           0 |    min |
|             Median cumulative flush time across primary shards |                          |           0 |    min |
|                Max cumulative flush time across primary shards |                          |           0 |    min |
|                                        Total Young Gen GC time |                          |       0.034 |      s |
|                                       Total Young Gen GC count |                          |           1 |        |
|                                          Total Old Gen GC time |                          |           0 |      s |
|                                         Total Old Gen GC count |                          |           0 |        |
|                                                     Store size |                          | 0.000102188 |     GB |
|                                                  Translog size |                          | 2.56114e-07 |     GB |
|                                         Heap used for segments |                          |   0.0872192 |     MB |
|                                       Heap used for doc values |                          |   0.0168152 |     MB |
|                                            Heap used for terms |                          |   0.0571289 |     MB |
|                                            Heap used for norms |                          |  0.00769043 |     MB |
|                                           Heap used for points |                          |           0 |     MB |
|                                    Heap used for stored fields |                          |  0.00558472 |     MB |
|                                                  Segment count |                          |          12 |        |
|                                                 Min Throughput |             index-append |     1973.37 | docs/s |
|                                                Mean Throughput |             index-append |     1973.37 | docs/s |
|                                              Median Throughput |             index-append |     1973.37 | docs/s |
|                                                 Max Throughput |             index-append |     1973.37 | docs/s |
|                                        50th percentile latency |             index-append |     532.783 |     ms |
|                                       100th percentile latency |             index-append |     627.909 |     ms |
|                                   50th percentile service time |             index-append |     532.783 |     ms |
|                                  100th percentile service time |             index-append |     627.909 |     ms |
|                                                     error rate |             index-append |           0 |      % |
|                                                 Min Throughput | wait-until-merges-finish |       26.67 |  ops/s |
|                                                Mean Throughput | wait-until-merges-finish |       26.67 |  ops/s |
|                                              Median Throughput | wait-until-merges-finish |       26.67 |  ops/s |
|                                                 Max Throughput | wait-until-merges-finish |       26.67 |  ops/s |
|                                       100th percentile latency | wait-until-merges-finish |     36.7566 |     ms |
|                                  100th percentile service time | wait-until-merges-finish |     36.7566 |     ms |
|                                                     error rate | wait-until-merges-finish |           0 |      % |


--------------------------------
[INFO] SUCCESS (took 40 seconds)
--------------------------------
PASSED
```

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#117 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).