### PR TITLE
Fixing typo in workload template 'bechmark' -> 'benchmark'

### DIFF
--- a/osbenchmark/resources/workload.json.j2
+++ b/osbenchmark/resources/workload.json.j2
@@ -1,4 +1,4 @@
-{% raw %}{% import "bechmark.helpers" as bechmark with context %}{% endraw %}
+{% raw %}{% import "benchmark.helpers" as benchmark with context %}{% endraw %}
 {
   "version": 2,
   "description": "Tracker-generated workload for {{workload_name}}",


### PR DESCRIPTION
### Description
This PR fixes a typo that was causing the `test_create_workload` integration test to fail

```
it/tracker_test.py::test_create_workload[in-memory-it]
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/


-------------------------------
[INFO] SUCCESS (took 6 seconds)
-------------------------------

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Connected to OpenSearch cluster [benchmark-node] version [1.0.0].

Extracting documents for index [geonames] for test mode...    1000/1000 docs [100.0% done]
Extracting documents for index [geonames]...                  1000/1000 docs [100.0% done]

[INFO] Workload test-workload-2f217811-ad3a-4bc3-babb-327665fcb171 has been created. Run it with: opensearch-benchmark --workload-path=/private/var/folders/gm/f1t_khjn207933m3mgrq5115yjr79_/T/pytest-of-engechas/pytest-37/test_create_workload_in_memory0/test-workload-2f217811-ad3a-4bc3-babb-327665fcb171

-------------------------------
[INFO] SUCCESS (took 0 seconds)
-------------------------------

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Preparing file offset table for [/private/var/folders/gm/f1t_khjn207933m3mgrq5115yjr79_/T/pytest-of-engechas/pytest-37/test_create_workload_in_memory0/test-workload-2f217811-ad3a-4bc3-babb-327665fcb171/geonames-documents-1k.json] ... [OK]
[INFO] Executing test with workload [test-workload-2f217811-ad3a-4bc3-babb-327665fcb171] and provision_config_instance ['external'] with version [1.0.0].

[WARNING] indexing_total_time is 1803 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 913 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running cluster-health                                                         [100% done]
Running bulk                                                                   [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |   Task |       Value |   Unit |
|---------------------------------------------------------------:|-------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |        |   0.0169333 |    min |
|             Min cumulative indexing time across primary shards |        |      0.0005 |    min |
|          Median cumulative indexing time across primary shards |        |  0.00211667 |    min |
|             Max cumulative indexing time across primary shards |        |      0.0113 |    min |
|            Cumulative indexing throttle time of primary shards |        |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |        |           0 |    min |
| Median cumulative indexing throttle time across primary shards |        |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |        |           0 |    min |
|                        Cumulative merge time of primary shards |        |           0 |    min |
|                       Cumulative merge count of primary shards |        |           0 |        |
|                Min cumulative merge time across primary shards |        |           0 |    min |
|             Median cumulative merge time across primary shards |        |           0 |    min |
|                Max cumulative merge time across primary shards |        |           0 |    min |
|               Cumulative merge throttle time of primary shards |        |           0 |    min |
|       Min cumulative merge throttle time across primary shards |        |           0 |    min |
|    Median cumulative merge throttle time across primary shards |        |           0 |    min |
|       Max cumulative merge throttle time across primary shards |        |           0 |    min |
|                      Cumulative refresh time of primary shards |        |   0.0117833 |    min |
|                     Cumulative refresh count of primary shards |        |          15 |        |
|              Min cumulative refresh time across primary shards |        | 0.000333333 |    min |
|           Median cumulative refresh time across primary shards |        | 0.000533333 |    min |
|              Max cumulative refresh time across primary shards |        |     0.00935 |    min |
|                        Cumulative flush time of primary shards |        |           0 |    min |
|                       Cumulative flush count of primary shards |        |           0 |        |
|                Min cumulative flush time across primary shards |        |           0 |    min |
|             Median cumulative flush time across primary shards |        |           0 |    min |
|                Max cumulative flush time across primary shards |        |           0 |    min |
|                                        Total Young Gen GC time |        |           0 |      s |
|                                       Total Young Gen GC count |        |           0 |        |
|                                          Total Old Gen GC time |        |           0 |      s |
|                                         Total Old Gen GC count |        |           0 |        |
|                                                     Store size |        | 7.12899e-05 |     GB |
|                                                  Translog size |        | 0.000305037 |     GB |
|                                         Heap used for segments |        |   0.0635605 |     MB |
|                                       Heap used for doc values |        |   0.0156479 |     MB |
|                                            Heap used for terms |        |   0.0389404 |     MB |
|                                            Heap used for norms |        |  0.00524902 |     MB |
|                                           Heap used for points |        |           0 |     MB |
|                                    Heap used for stored fields |        |  0.00372314 |     MB |
|                                                  Segment count |        |           8 |        |
|                                                 Min Throughput |   bulk |     3247.79 | docs/s |
|                                                Mean Throughput |   bulk |     3247.79 | docs/s |
|                                              Median Throughput |   bulk |     3247.79 | docs/s |
|                                                 Max Throughput |   bulk |     3247.79 | docs/s |
|                                        50th percentile latency |   bulk |     409.582 |     ms |
|                                       100th percentile latency |   bulk |     825.597 |     ms |
|                                   50th percentile service time |   bulk |     409.582 |     ms |
|                                  100th percentile service time |   bulk |     825.597 |     ms |
|                                                     error rate |   bulk |           0 |      % |


--------------------------------
[INFO] SUCCESS (took 11 seconds)
--------------------------------
PASSED
```

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#124 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).