### PR TITLE
Removing --enable-assertions flag from integration test runs

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -94,7 +94,7 @@ def execute_test(cfg, command_line):
     This method should be used for benchmark invocations of the test_execution command.
     It sets up some defaults for how the integration tests expect to run test_executions.
     """
-    return osbenchmark(cfg, f"execute_test {command_line} --kill-running-processes --on-error='abort' --enable-assertions")
+    return osbenchmark(cfg, f"execute_test {command_line} --kill-running-processes --on-error='abort'")
 
 
 def shell_cmd(command_line):


### PR DESCRIPTION
### Description
Assertions can be defined in OSB workload operations to ensure the operation's result is as expected. [Example](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/http_logs/operations/default.json#L76-L82). Only `http_logs` has these assertions presently:
```
grep -rnw "assertions" *
http_logs/operations/default.json:76:      "assertions": [
http_logs/operations/default.json:99:      "assertions": [
http_logs/operations/default.json:133:      "assertions": [
http_logs/operations/default.json:167:      "assertions": [
```

Since the integration tests run in `--test-mode`, the assertions fail since the entire corpus is not ingested. This PR removes the `--enable-assertions` flag when integration tests are running

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#127 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).