### PR TITLE
Small fixes to get the integration tests working on Github Actions, adding the tests to pull_requests

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -67,12 +67,13 @@ function build_it {
   export PATH="$HOME/.pyenv/bin:$PATH"
   export TERM=dumb
   export LC_ALL=en_US.UTF-8
-  export BENCHMARK_HOME=$WORKSPACE
+  export BENCHMARK_HOME="$GITHUB_WORKSPACE"
   export JAVA_PATH="/opt/hostedtoolcache/Java_Adopt_jdk"
   export JAVA_HOME="$JAVA_PATH/15.0.2-7/x64"
   export JAVA8_HOME="$JAVA_PATH/8.0.292-1/x64"
   export JAVA11_HOME="$JAVA_PATH/11.0.11-9/x64"
   export JAVA15_HOME="$JAVA_PATH/15.0.2-7/x64"
+  export JAVA16_HOME="$JAVA_PATH/16.0.2-7/x64"
 
   update_pyenv
   eval "$(pyenv init -)"
@@ -80,11 +81,17 @@ function build_it {
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
   pip install opensearch-benchmark
+  docker pull datadog/squid:latest
 
   make prereq
   make install
   make precommit
-  make it
+
+  if [[ "$1" == "Python_3.8" ]]; then
+    make it38
+  elif [[ "$1" == "Python_3.9" ]]; then
+    make it39
+  fi
 }
 
 function license-scan {
@@ -118,7 +125,7 @@ function archive {
 }
 
 if declare -F "$1" > /dev/null; then
-    $1
+    $1 $2
     exit
 else
     echo "Please specify a function to run"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -125,11 +125,7 @@ function archive {
 }
 
 if declare -F "$1" > /dev/null; then
-    if [ -n "${2-}" ]; then
-      $1 $2
-    else
-      $1
-    fi
+    "$@"
     exit
 else
     echo "Please specify a function to run"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -125,7 +125,11 @@ function archive {
 }
 
 if declare -F "$1" > /dev/null; then
-    $1 $2
+    if [ -n "$2" ]; then
+      $1 $2
+    else
+      $1
+    fi 
     exit
 else
     echo "Please specify a function to run"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -125,11 +125,11 @@ function archive {
 }
 
 if declare -F "$1" > /dev/null; then
-    if [ -n "$2" ]; then
+    if [ -n "${2-}" ]; then
       $1 $2
     else
       $1
-    fi 
+    fi
     exit
 else
     echo "Please specify a function to run"

--- a/.github/workflows/manual-integ.yml
+++ b/.github/workflows/manual-integ.yml
@@ -1,7 +1,12 @@
 name: Integ Actions
-on: [workflow_dispatch]
+on: [workflow_dispatch, pull_request]
 jobs:
   Integration-Tests:
+    strategy:
+      matrix:
+        python-version:
+          - Python_3.8
+          - Python_3.9
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -23,7 +28,12 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '15'
+      - name: Install JDK 16
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '16'
       - name: Run the CI build_it script
-        run: bash .ci/build.sh build_it
+        run: bash .ci/build.sh build_it ${{ matrix.python-version }}
         env:
           BENCHMARK_HOME: env.GITHUB_WORKSPACE

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# tox configuration for OSBenchmark.
+# tox configuration for OpenSearch Benchmark.
 #
 # Invocation: Run `make it`
 #

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ setenv =
     # applications behave identically, we also set LANG explicitly.
     LANG=C
 commands =
-    pytest --junitxml=junit-{envname}.xml
     pytest -s it --junitxml=junit-{envname}-it.xml
 
 whitelist_externals =


### PR DESCRIPTION
### Description
This PR fills in the gaps to get the integration tests running on Github Actions. This required installing JDK16, pulling the squid container, and updating the `BENCHMARK_HOME` environment variable.

The Github Actions integration tests run in 2 parallel streams, one for python 3.8 and one for python 3.9. The unit tests have been removed from the tox.ini commands since they are run in a separate Github Actions workflow.

Potential further enhancements:
1. The current containers use Ubuntu, we may want to add a MacOS iteration as well
2. Certain integration tests [pick randomly](https://github.com/opensearch-project/opensearch-benchmark/blob/main/it/distribution_test.py#L28) between using an in-memory or OpenSearch metrics store. This can lead to different results on different runs, even with the same code. IMO we should remove the randomness and pick one or the other types of metrics stores for all currently randomized tests
3. Coverage tool to see how much of the code is actually being checked by these tests
4. Tests for ES metrics stores (large effort, contingent on the provisioning expansion)
5. Add integration tests to the Workloads repo (a simple solution could be each test/challenge run once in `test-mode`)

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#129 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).