### PR TITLE
Fix running OpenSearch Benchmark on Arm64 / Graviton

### DIFF
--- a/osbenchmark/builder/supplier.py
+++ b/osbenchmark/builder/supplier.py
@@ -263,6 +263,9 @@ class TemplateRenderer:
             self.arch = arch
         else:
             self.arch = sysstats.cpu_arch().lower()
+            # OpenSearch uses arm64 for the 64b Arm binary name
+            if self.arch == "aarch64":
+                self.arch = "arm64"
 
     def render(self, template):
         substitutions = {


### PR DESCRIPTION
### Description
Allows runnining open search benchmark on arm64 / Graviton hosts
 
### Issues Resolved
#109 
 
### Check List
- [NA ] New functionality includes testing
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).