### PR TITLE
Migrate DockerLauncher logic to conform to the new Launcher interface

### DIFF
--- a/osbenchmark/builder/launchers/docker_launcher.py
+++ b/osbenchmark/builder/launchers/docker_launcher.py
@@ -1,0 +1,75 @@
+import os
+
+from osbenchmark import time, telemetry
+from osbenchmark.builder import cluster
+from osbenchmark.builder.launchers.launcher import Launcher
+from osbenchmark.exceptions import LaunchError, ExecutorError
+
+
+class DockerLauncher(Launcher):
+    # May download a Docker image and that can take some time
+    PROCESS_WAIT_TIMEOUT_SECONDS = 10 * 60
+
+    def __init__(self, pci, executor, clock=time.Clock):
+        super().__init__(executor)
+        self.clock = clock
+
+    def start(self, host, node_configurations):
+        nodes = []
+        for node_configuration in node_configurations:
+            node_name = node_configuration.node_name
+            host_name = node_configuration.ip
+            binary_path = node_configuration.binary_path
+            self.logger.info("Starting node [%s] in Docker.", node_name)
+            self._start_process(host, binary_path)
+            node_telemetry = [
+                # Don't attach any telemetry devices for now but keep the infrastructure in place
+            ]
+            t = telemetry.Telemetry(devices=node_telemetry)
+            node = cluster.Node(0, binary_path, host_name, node_name, t)
+            t.attach_to_node(node)
+            nodes.append(node)
+        return nodes
+
+    def _start_process(self, host, binary_path):
+        compose_cmd = self._docker_compose(binary_path, "up -d")
+
+        try:
+            self.executor.execute(host, compose_cmd)
+        except ExecutorError as e:
+            raise LaunchError("Exception starting OpenSearch Docker container", e)
+
+        container_id = self._get_container_id(binary_path)
+        self._wait_for_healthy_running_container(container_id, DockerLauncher.PROCESS_WAIT_TIMEOUT_SECONDS)
+
+    def _docker_compose(self, compose_config, cmd):
+        return "docker-compose -f {} {}".format(os.path.join(compose_config, "docker-compose.yml"), cmd)
+
+    def _get_container_id(self, compose_config):
+        compose_ps_cmd = self._docker_compose(compose_config, "ps -q")
+        return self.executor.execute(compose_ps_cmd, ouput=True)[0]
+
+    def _wait_for_healthy_running_container(self, container_id, timeout):
+        cmd = 'docker ps -a --filter "id={}" --filter "status=running" --filter "health=healthy" -q'.format(container_id)
+        stop_watch = self.clock.stop_watch()
+        stop_watch.start()
+        while stop_watch.split_time() < timeout:
+            containers = self.executor.execute(cmd, ouput=True)
+            if len(containers) > 0:
+                return
+            time.sleep(0.5)
+        msg = "No healthy running container after {} seconds!".format(timeout)
+        self.logger.error(msg)
+        raise LaunchError(msg)
+
+    def stop(self, host, nodes, metrics_store):
+        self.logger.info("Shutting down [%d] nodes running in Docker on this host.", len(nodes))
+        for node in nodes:
+            self.logger.info("Stopping node [%s].", node.node_name)
+            if metrics_store:
+                telemetry.add_metadata_for_node(metrics_store, node.node_name, node.host_name)
+            node.telemetry.detach_from_node(node, running=True)
+            self.executor.execute(host, self._docker_compose(node.binary_path, "down"))
+            node.telemetry.detach_from_node(node, running=False)
+            if metrics_store:
+                node.telemetry.store_system_metrics(node, metrics_store)

--- a/osbenchmark/builder/launchers/docker_launcher.py
+++ b/osbenchmark/builder/launchers/docker_launcher.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from osbenchmark import time, telemetry
@@ -12,6 +13,7 @@ class DockerLauncher(Launcher):
 
     def __init__(self, pci, executor, clock=time.Clock):
         super().__init__(executor)
+        self.logger = logging.getLogger(__name__)
         self.clock = clock
 
     def start(self, host, node_configurations):

--- a/osbenchmark/builder/launchers/launcher.py
+++ b/osbenchmark/builder/launchers/launcher.py
@@ -1,13 +1,9 @@
-import logging
-
-
 class Launcher:
     """
     Launchers are used to start and stop OpenSearch on the nodes in a self-managed cluster.
     """
     def __init__(self, executor):
         self.executor = executor
-        self.logger = logging.getLogger(__name__)
 
     def start(self, host, node_configurations):
         """

--- a/osbenchmark/builder/launchers/launcher.py
+++ b/osbenchmark/builder/launchers/launcher.py
@@ -1,9 +1,13 @@
-"""
-Launchers are used to start and stop OpenSearch on the nodes in a self-managed cluster.
-"""
+import logging
+
+
 class Launcher:
+    """
+    Launchers are used to start and stop OpenSearch on the nodes in a self-managed cluster.
+    """
     def __init__(self, executor):
         self.executor = executor
+        self.logger = logging.getLogger(__name__)
 
     def start(self, host, node_configurations):
         """
@@ -15,12 +19,13 @@ class Launcher:
         """
         raise NotImplementedError
 
-    def stop(self, host, nodes):
+    def stop(self, host, nodes, metrics_store):
         """
         Stops the OpenSearch nodes on a given host
 
         ;param host: A Host object defining the host on which to stop the nodes
         ;param nodes: A list of Node objects defining the nodes running on a host
+        ;param metrics_store: A reference to the metrics store, used for collecting telemetry data before stopping the nodes
         ;return nodes: A list of Node objects representing OpenSearch nodes that were successfully stopped on the host
         """
         raise NotImplementedError

--- a/osbenchmark/builder/launchers/launcher.py
+++ b/osbenchmark/builder/launchers/launcher.py
@@ -2,8 +2,8 @@ class Launcher:
     """
     Launchers are used to start and stop OpenSearch on the nodes in a self-managed cluster.
     """
-    def __init__(self, executor):
-        self.executor = executor
+    def __init__(self, shell_executor):
+        self.shell_executor = shell_executor
 
     def start(self, host, node_configurations):
         """

--- a/osbenchmark/builder/launchers/no_op_launcher.py
+++ b/osbenchmark/builder/launchers/no_op_launcher.py
@@ -1,0 +1,9 @@
+from osbenchmark.builder.launchers.launcher import Launcher
+
+
+class NoOpLauncher(Launcher):
+    def start(self, host, node_configurations):
+        pass
+
+    def stop(self, host, nodes, metrics_store):
+        pass

--- a/tests/builder/launchers/docker_launcher_test.py
+++ b/tests/builder/launchers/docker_launcher_test.py
@@ -1,0 +1,116 @@
+import sys
+import uuid
+from datetime import datetime
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from osbenchmark import telemetry
+from osbenchmark.builder import cluster
+from osbenchmark.builder.launchers.docker_launcher import DockerLauncher
+from osbenchmark.builder.provisioner import NodeConfiguration
+from osbenchmark.exceptions import LaunchError
+from osbenchmark.metrics import InMemoryMetricsStore
+
+
+class DockerLauncherTests(TestCase):
+    def setUp(self):
+        self.executor = Mock()
+        stop_watch = IterationBasedStopWatch(max_iterations=2)
+        clock = TestClock(stop_watch=stop_watch)
+        self.launcher = DockerLauncher(None, self.executor, clock=clock)
+
+        self.host = None
+        self.node_config = NodeConfiguration(build_type="docker",
+                                        provision_config_instance_runtime_jdks="12,11",
+                                        provision_config_instance_provides_bundled_jdk=True,
+                                        ip="127.0.0.1", node_name="testnode",
+                                        node_root_path="/tmp", binary_path="/bin",
+                                        data_paths="/tmp")
+
+    def test_starts_container_successfully(self):
+        # [Start container (from docker-compose up), Docker container id (from docker-compose ps),
+        # Docker container id (from docker ps --filter ...)]
+        self.executor.execute.side_effect = [None, ["de604d0d"], ["de604d0d"]]
+
+        nodes = self.launcher.start(self.host, [self.node_config])
+        self.assertEqual(1, len(nodes))
+        node = nodes[0]
+
+        self.assertEqual(0, node.pid)
+        self.assertEqual("/bin", node.binary_path)
+        self.assertEqual("127.0.0.1", node.host_name)
+        self.assertEqual("testnode", node.node_name)
+        self.assertIsNotNone(node.telemetry)
+
+        self.executor.execute.assert_has_calls([
+            mock.call(self.host, "docker-compose -f /bin/docker-compose.yml up -d"),
+            mock.call(self.host, "docker-compose -f /bin/docker-compose.yml ps -q", output=True),
+            mock.call(self.host, 'docker ps -a --filter "id=de604d0d" --filter "status=running" --filter "health=healthy" -q', output=True)
+        ])
+
+    @mock.patch("osbenchmark.time.sleep")
+    def test_container_not_started(self, sleep):
+        # [Start container (from docker-compose up), Docker container id (from docker-compose ps),
+        # but NO Docker container id (from docker ps --filter...) twice
+        self.executor.execute.side_effect = [None, ["de604d0d"], [], []]
+
+        with self.assertRaisesRegex(LaunchError, "No healthy running container after 600 seconds!"):
+            self.launcher.start(self.host, [self.node_config])
+
+    @mock.patch("osbenchmark.telemetry.add_metadata_for_node")
+    def test_stops_container_successfully_with_metrics_store(self, add_metadata_for_node):
+        metrics_store = Mock()
+
+        nodes = [cluster.Node(0, "/bin", "127.0.0.1", "testnode", telemetry.Telemetry())]
+        self.launcher.stop(self.host, nodes, metrics_store=metrics_store)
+
+        add_metadata_for_node.assert_called_once_with(metrics_store, "testnode", "127.0.0.1")
+        self.executor.execute.assert_called_once_with(self.host, "docker-compose -f /bin/docker-compose.yml down")
+
+    @mock.patch("osbenchmark.telemetry.add_metadata_for_node")
+    def test_stops_container_when_no_metrics_store_is_provided(self, add_metadata_for_node):
+        metrics_store = None
+
+        nodes = [cluster.Node(0, "/bin", "127.0.0.1", "testnode", telemetry.Telemetry())]
+        self.launcher.stop(self.host, nodes, metrics_store=metrics_store)
+
+        self.assertEqual(0, add_metadata_for_node.call_count)
+        self.executor.execute.assert_called_once_with(self.host, "docker-compose -f /bin/docker-compose.yml down")
+
+
+class IterationBasedStopWatch:
+    __test__ = False
+
+    def __init__(self, max_iterations):
+        self.iterations = 0
+        self.max_iterations = max_iterations
+
+    def start(self):
+        self.iterations = 0
+
+    def split_time(self):
+        if self.iterations < self.max_iterations:
+            self.iterations += 1
+            return 0
+        else:
+            return sys.maxsize
+
+
+class TestClock:
+    __test__ = False
+
+    def __init__(self, stop_watch):
+        self._stop_watch = stop_watch
+
+    def stop_watch(self):
+        return self._stop_watch
+
+
+def get_metrics_store(cfg):
+    ms = InMemoryMetricsStore(cfg)
+    ms.open(test_ex_id=str(uuid.uuid4()),
+            test_ex_timestamp=datetime.now(),
+            workload_name="test",
+            test_procedure_name="test",
+            provision_config_instance_name="test")
+    return ms


### PR DESCRIPTION
### Description
This PR is part of the larger changes for #134 

Please see #113 for a class diagram of how this PR fits into the larger builder system. The plan for migrating the existing components is to duplicate the logic initially, then remove the initial logic and wire the new subcomponents into the builder system once everything is ready.

This PR adds 2 new implementations of the Launcher interface. The first is a NoOpLauncher, which performs no action when  its methods are invoked. The second is a DockerLauncher, which is a migration of the [existing class here](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/builder/launcher.py#L37-L105). The logic is a copy/paste with the following modifications:
* Update the public methods to include a `host` parameter
* Add `shell_executor` to the constructor for executing shell commands
* Replace instances of using `process.xyz` with `shell_executor.execute`

Additionally, the unit tests for the original DockerLauncher were copy pasted and reformatted to conform to the new DockerLauncher. For further testing, I wired the new DockerLauncher into the Builder and ran the `test_docker_distribution` test which passed.
 
### Check List
- [ ] New functionality includes testing
  - [ ] All unit and integration tests pass
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).