### PR TITLE
Rename pci to provision_config_instance

### DIFF
--- a/osbenchmark/builder/launchers/docker_launcher.py
+++ b/osbenchmark/builder/launchers/docker_launcher.py
@@ -12,7 +12,7 @@ class DockerLauncher(Launcher):
     CONTAINER_WAIT_TIMEOUT_SECONDS = 10 * 60
     CONTAINER_WAIT_INTERVAL_SECONDS = 0.5
 
-    def __init__(self, pci, shell_executor, metrics_store, clock=time.Clock):
+    def __init__(self, provision_config_instance, shell_executor, metrics_store, clock=time.Clock):
         super().__init__(shell_executor)
         self.logger = logging.getLogger(__name__)
         self.metrics_store = metrics_store

--- a/osbenchmark/builder/launchers/local_process_launcher.py
+++ b/osbenchmark/builder/launchers/local_process_launcher.py
@@ -16,10 +16,10 @@ class LocalProcessLauncher(Launcher):
     PROCESS_WAIT_TIMEOUT_SECONDS = 90
     PROCESS_WAIT_INTERVAL_SECONDS = 0.5
 
-    def __init__(self, pci, shell_executor, metrics_store, clock=time.Clock):
+    def __init__(self, provision_config_instance, shell_executor, metrics_store, clock=time.Clock):
         super().__init__(shell_executor)
         self.logger = logging.getLogger(__name__)
-        self.pci = pci
+        self.provision_config_instance = provision_config_instance
         self.metrics_store = metrics_store
         self.waiter = PeriodicWaiter(LocalProcessLauncher.PROCESS_WAIT_INTERVAL_SECONDS,
                                      LocalProcessLauncher.PROCESS_WAIT_TIMEOUT_SECONDS, clock=clock)
@@ -34,7 +34,7 @@ class LocalProcessLauncher(Launcher):
         binary_path = node_configuration.binary_path
 
         java_major_version, java_home = java_resolver.java_home(node_configuration.provision_config_instance_runtime_jdks,
-                                                                self.pci.variables["system"]["runtime"]["jdk"],
+                                                                self.provision_config_instance.variables["system"]["runtime"]["jdk"],
                                                                 node_configuration.provision_config_instance_provides_bundled_jdk)
         self.logger.info("Java major version: %s", java_major_version)
         self.logger.info("Java home: %s", java_home)
@@ -57,8 +57,8 @@ class LocalProcessLauncher(Launcher):
         data_paths = node_configuration.data_paths
         node_telemetry_dir = os.path.join(node_configuration.node_root_path, "telemetry")
 
-        enabled_devices = self.pci.variables["telemetry"]["devices"]
-        telemetry_params = self.pci.variables["telemetry"]["params"]
+        enabled_devices = self.provision_config_instance.variables["telemetry"]["devices"]
+        telemetry_params = self.provision_config_instance.variables["telemetry"]["params"]
 
         node_telemetry = [
             telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
@@ -73,7 +73,8 @@ class LocalProcessLauncher(Launcher):
         return telemetry.Telemetry(enabled_devices, devices=node_telemetry)
 
     def _prepare_env(self, node_name, java_home, telemetry):
-        env = {k: v for k, v in os.environ.items() if k in opts.csv_to_list(self.pci.variables["system"]["env"]["passenv"])}
+        env = {k: v for k, v in os.environ.items() if k in
+               opts.csv_to_list(self.provision_config_instance.variables["system"]["env"]["passenv"])}
         if java_home:
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
             # This property is the higher priority starting in ES 7.12.0, and is the only supported java home in >=8.0

--- a/tests/builder/launchers/local_process_launcher_test.py
+++ b/tests/builder/launchers/local_process_launcher_test.py
@@ -32,9 +32,10 @@ class LocalProcessLauncherTests(TestCase):
                 "params": None
             }
         }
-        self.pci = ProvisionConfigInstance("fake_pci", "/path/to/root", ["/path/to/config"], variables=self.variables)
+        self.provision_config_instance = ProvisionConfigInstance("fake_provision_config_instance", "/path/to/root",
+                                                                 ["/path/to/config"], variables=self.variables)
 
-        self.launcher = LocalProcessLauncher(self.pci, self.shell_executor, self.metrics_store)
+        self.launcher = LocalProcessLauncher(self.provision_config_instance, self.shell_executor, self.metrics_store)
         self.launcher.waiter = Mock()
         self.host = None
         self.path = "fake"
@@ -111,7 +112,7 @@ class LocalProcessLauncherTests(TestCase):
         self.assertIsNone(env.get("JAVA_HOME"))
 
     def test_pass_env_vars(self):
-        self.pci.variables["system"]["env"]["passenv"] = "JAVA_HOME,FOO1"
+        self.provision_config_instance.variables["system"]["env"]["passenv"] = "JAVA_HOME,FOO1"
 
         os.environ["JAVA_HOME"] = "/path/to/java"
         os.environ["FOO1"] = "BAR1"
@@ -126,7 +127,7 @@ class LocalProcessLauncherTests(TestCase):
         self.assertEqual(env["OPENSEARCH_JAVA_OPTS"], "-XX:+ExitOnOutOfMemoryError")
 
     def test_pass_java_opts(self):
-        self.pci.variables["system"]["env"]["passenv"] = "OPENSEARCH_JAVA_OPTS"
+        self.provision_config_instance.variables["system"]["env"]["passenv"] = "OPENSEARCH_JAVA_OPTS"
 
         os.environ["OPENSEARCH_JAVA_OPTS"] = "-XX:-someJunk"
 


### PR DESCRIPTION
### Description
Renames all variables `pci` to `provision_config_instance` for clarity.
 
Signed-off-by: Chase Engelbrecht <engechas@amazon.com>

### Check List
- [ ] New functionality includes testing
  - [ ] All unit and integration tests pass
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).