### PR TITLE
Create Cluster, Host, and Node models

### DIFF
--- a/osbenchmark/builder/models/cluster.py
+++ b/osbenchmark/builder/models/cluster.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import List
+
+from osbenchmark.builder.models.host import Host
+
+
+@dataclass
+class Cluster:
+    """A representation of the cluster used in the benchmark"""
+
+    name: str
+    hosts: List[Host]

--- a/osbenchmark/builder/models/host.py
+++ b/osbenchmark/builder/models/host.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from osbenchmark.builder.models.node import Node
+
+
+@dataclass
+class Host:
+    """A representation of a host within a cluster"""
+
+    name: str
+    ip: str
+    metadata: dict
+    node_count: int
+    node: Node

--- a/osbenchmark/builder/models/host.py
+++ b/osbenchmark/builder/models/host.py
@@ -8,7 +8,7 @@ class Host:
     """A representation of a host within a cluster"""
 
     name: str
-    ip: str
+    address: str
     metadata: dict
     node_count: int
     node: Node

--- a/osbenchmark/builder/models/node.py
+++ b/osbenchmark/builder/models/node.py
@@ -6,6 +6,8 @@ from osbenchmark.telemetry import Telemetry
 
 @dataclass
 class Node:
+    """A representation of a node within a host"""
+
     name: str
     port: int
     pid: int

--- a/osbenchmark/builder/models/node.py
+++ b/osbenchmark/builder/models/node.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import List
+
+from osbenchmark.telemetry import Telemetry
+
+
+@dataclass
+class Node:
+    name: str
+    port: int
+    pid: int
+    root_dir: str
+    binary_path: str
+    data_paths: List[str]
+    telemetry: Telemetry


### PR DESCRIPTION
### Description
Adds the models to represent a cluster constructed by the builder. The models will be populated as the builder system progresses through creating a cluster.

Cluster and Host are new models, Node is a combination of the existing [Node](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/builder/cluster.py#L26) and [NodeConfiguration](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/builder/provisioner.py#L66) models to serve as a singular representation of a node.
 
### Issues Resolved
#132 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).