### PR TITLE
Create DockerInstaller

### DIFF
--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -7,92 +7,113 @@ from jinja2 import select_autoescape
 
 from osbenchmark import paths
 from osbenchmark.builder.installers.installer import Installer
-from osbenchmark.builder.provisioner import NodeConfiguration
-from osbenchmark.utils import convert, io
+from osbenchmark.builder.models.node import Node
+from osbenchmark.utils import io, console
 
 
 class DockerInstaller(Installer):
-    def __init__(self, pci, executor, node_name, ip, http_port, node_root_dir):
+    def __init__(self, provision_config_instance, executor):
         super().__init__(executor)
         self.logger = logging.getLogger(__name__)
-        self.pci = pci
-
-        #What to do about node info?
-        self.node_name = node_name
-        self.node_ip = ip
-        self.http_port = http_port
-        self.node_root_dir = node_root_dir
-        self.node_log_dir = os.path.join(node_root_dir, "logs", "server")
-        self.heap_dump_dir = os.path.join(node_root_dir, "heapdump")
-        self.binary_path = os.path.join(node_root_dir, "install")
-        # use a random subdirectory to isolate multiple runs because an external (non-root) user cannot clean it up.
-        self.data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
-
-        # How to handle this for remote machines??
-        self.node_root_dir = node_root_dir
-        self.node_log_dir = os.path.join(node_root_dir, "logs", "server")
-        self.heap_dump_dir = os.path.join(node_root_dir, "heapdump")
-        self.binary_path = os.path.join(node_root_dir, "install")
-        # use a random subdirectory to isolate multiple runs because an external (non-root) user cannot clean it up.
-        self.data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
+        self.provision_config_instance = provision_config_instance
 
     def install(self, host, binaries):
-        self._prepare(host)
+        return self._prepare(host)
 
     def _prepare(self, host):
-        # we need to allow other users to write to these directories due to Docker.
-        #
-        # Although os.mkdir passes 0o777 by default, mkdir(2) uses `mode & ~umask & 0777` to determine the final flags and
-        # hence we need to modify the process' umask here. For details see https://linux.die.net/man/2/mkdir.
-        previous_umask = os.umask(0)
-        try:
-            # How to handle directory creation on remote machines?
-            io.ensure_dir(self.binary_path)
-            io.ensure_dir(self.node_log_dir)
-            io.ensure_dir(self.heap_dump_dir)
-            io.ensure_dir(self.data_paths[0])
-        finally:
-            os.umask(previous_umask)
+        node = self._create_node()
+        self._prepare_node(host, node)
 
-        mounts = {}
+        return node
 
-        for provision_config_instance_config_path in self.pci.config_paths:
-            for root, _, files in os.walk(provision_config_instance_config_path):
-                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=select_autoescape(['html', 'xml']))
+    def _create_node(self):
+        node_name = str(uuid.uuid4())
+        node_port = int(self.provision_config_instance.variables["node"]["port"])
+        node_root_dir = os.path.join(self.provision_config_instance.variables["test_execution_root"], node_name)
+        node_data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
+        node_binary_path = os.path.join(node_root_dir, "install")
 
-                relative_root = root[len(provision_config_instance_config_path) + 1:]
-                absolute_target_root = os.path.join(self.binary_path, relative_root)
-                io.ensure_dir(absolute_target_root)
+        return Node(name=node_name,
+                    port=node_port,
+                    pid=None,
+                    root_dir=node_root_dir,
+                    binary_path=node_binary_path,
+                    data_paths=node_data_paths,
+                    telemetry=None)
 
-                for name in files:
-                    source_file = os.path.join(root, name)
-                    target_file = os.path.join(absolute_target_root, name)
-                    mounts[target_file] = os.path.join("/usr/share/opensearch", relative_root, name)
-                    if io.is_plain_text(source_file):
-                        config_vars = self._config_vars(host.nodes[0].name, host.nodes[0].port)
+    def _prepare_node(self, host, node):
+        node_log_dir = os.path.join(node.root_dir, "logs", "server")
+        node_heap_dump_dir = os.path.join(node.root_dir, "heapdump")
 
-                        self.logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
-                        with open(target_file, mode="a", encoding="utf-8") as f:
-                            f.write(self._render_template(env, config_vars, source_file))
-                    else:
-                        self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
-                        self.executor.copy(source_file, target_file)
+        directories_to_create = [node.binary_path, node_log_dir, node_heap_dump_dir, node.data_paths[0]]
+        for directory_to_create in directories_to_create:
+            self._create_directory(host, directory_to_create)
 
-        docker_cfg = self._render_template_from_docker_file(self._docker_vars(mounts, host.nodes[0].port))
-        self.logger.info("Starting Docker container with configuration:\n%s", docker_cfg)
+        mounts = self._prepare_mounts(host, node)
+        docker_cfg = self._render_template_from_docker_file(self._get_docker_vars(node, node_log_dir,
+                                                                                  node_heap_dump_dir, mounts))
+        self.logger.info("Installing Docker container with configuration:\n%s", docker_cfg)
 
-        with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
+        docker_compose_file = os.path.join(node.binary_path, "docker-compose.yml")
+        with open(docker_compose_file, mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)
+        self.executor.execute(host, "cp {0} {0}".format(docker_compose_file))
 
-        # Loop over nodes/host? Docker can only have 1 node per host due to single node discovery?
-        return NodeConfiguration("docker", self.pci.variables["system"]["runtime"]["jdk"],
-                                 convert.to_bool(self.pci.variables["system"]["runtime"]["jdk"]["bundled"]), host.ip,
-                                 host.nodes[0].name, self.node_root_dir, self.binary_path, self.data_paths)
+    def _create_directory(self, host, directory):
+        self.executor.execute(host, "mkdir -m 0777 -p " + directory)
 
-    def _config_vars(self, node_name, port):
+    def _prepare_mounts(self, host, node):
+        mounts = {}
+        for provision_config_instance_config_path in self.provision_config_instance.config_paths:
+            mounts.update(self._prepare_mounts_from_config_path(host, node, provision_config_instance_config_path))
+
+        return mounts
+
+    def _prepare_mounts_from_config_path(self, host, node, config_path):
+        config_path_mounts = {}
+        for root, _, files in os.walk(config_path):
+            config_path_mounts.update(self._prepare_mounts_from_config_path_root(host, node, config_path, root, files))
+
+        return config_path_mounts
+
+    def _prepare_mounts_from_config_path_root(self, host, node, config_path, root, files):
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(root),
+                                 autoescape=select_autoescape(['html', 'xml']))
+
+        relative_root = root[len(config_path) + 1:]
+        absolute_target_root = os.path.join(node.binary_path, relative_root)
+
+        # Create directory locally and on the host
+        io.ensure_dir(absolute_target_root)
+        self._create_directory(host, absolute_target_root)
+
+        config_path_file_mounts = {}
+        for file_name in files:
+            config_path_file_mounts[file_name] = self._prepare_mount(host, node, root, env, relative_root, absolute_target_root, file_name)
+
+        return config_path_file_mounts
+
+    def _prepare_mount(self, host, node, root, env, relative_root, absolute_target_root, file_name):
+        source_file = os.path.join(root, file_name)
+        target_file = os.path.join(absolute_target_root, file_name)
+        if io.is_plain_text(source_file):
+            config_vars = self._get_config_vars(node)
+
+            self.logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
+            with open(target_file, mode="a", encoding="utf-8") as f:
+                f.write(self._render_template(env, config_vars, source_file))
+
+            self.executor.execute(host, "cp {0} {0}".format(target_file))
+        else:
+            self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
+            self.executor.execute(host, "cp {} {}".format(source_file, target_file))
+
+        return os.path.join("/usr/share/opensearch", relative_root, file_name)
+
+    def _get_config_vars(self, node):
         provisioner_defaults = {
-            "cluster_name": "benchmark-provisioned-cluster",
-            "node_name": node_name,
+            "cluster_name": self.provision_config_instance.variables["cluster_name"],
+            "node_name": node.name,
             # we bind-mount the directories below on the host to these ones.
             "install_root_path": "/usr/share/opensearch",
             "data_paths": ["/usr/share/opensearch/data"],
@@ -101,39 +122,51 @@ class DockerInstaller(Installer):
             # Docker container needs to expose service on external interfaces
             "network_host": "0.0.0.0",
             "discovery_type": "single-node",
-            "http_port": str(port),
-            "transport_port": str(port + 100),
+            "http_port": str(node.port),
+            "transport_port": str(node.port + 100),
             "cluster_settings": {}
         }
 
         config_vars = {}
-        config_vars.update(self.pci.variables)
+        config_vars.update(self.provision_config_instance.variables["origin"]["docker"])
         config_vars.update(provisioner_defaults)
 
         return config_vars
 
-    def _docker_vars(self, port, mounts):
-        v = {
-            "os_version": self.pci.variables["origin"]["distribution"]["version"],
-            "docker_image": self.pci.variables["origin"]["docker"]["image"],
-            "http_port": port,
-            "os_data_dir": self.data_paths[0],
-            "os_log_dir": self.node_log_dir,
-            "os_heap_dump_dir": self.heap_dump_dir,
+    def _get_docker_vars(self, node, log_dir, heap_dump_dir, mounts):
+        docker_vars = {
+            "os_version": self.provision_config_instance.variables["origin"]["distribution"]["version"],
+            "docker_image": self.provision_config_instance.variables["origin"]["docker"]["docker_image"],
+            "http_port": node.port,
+            "os_data_dir": node.data_paths[0],
+            "os_log_dir": log_dir,
+            "os_heap_dump_dir": heap_dump_dir,
             "mounts": mounts
         }
-        self._add_if_defined_for_provision_config_instance(v, "mem_limit")
-        self._add_if_defined_for_provision_config_instance(v, "cpu_count")
-        return v
+        self._add_if_defined_for_provision_config_instance(docker_vars, "docker_mem_limit")
+        self._add_if_defined_for_provision_config_instance(docker_vars, "docker_cpu_count")
+        return docker_vars
 
     def _add_if_defined_for_provision_config_instance(self, variables, key):
-        if key in self.pci.variables["origin"]["docker"]:
-            variables[key] = self.pci.variables["origin"]["docker"][key]
+        if key in self.provision_config_instance.variables["origin"]["docker"]:
+            variables[key] = self.provision_config_instance.variables["origin"]["docker"][key]
 
     def _render_template_from_docker_file(self, variables):
         compose_file = os.path.join(paths.benchmark_root(), "resources", "docker-compose.yml.j2")
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(io.dirname(compose_file)), autoescape=select_autoescape(['html', 'xml']))
         return self._render_template(env, variables, compose_file)
 
-    def cleanup(self, host, node_configurations):
-        pass
+    def cleanup(self, host):
+        if self.provision_config_instance.variables["preserve_install"]:
+            console.info("Preserving benchmark candidate installation.", logger=self.logger)
+            return
+
+        self.logger.info("Wiping benchmark candidate installation at [%s].", host.node.binary_path)
+
+        for data_path in host.node.data_paths:
+            self._delete_path(host, data_path)
+
+        self._delete_path(host, host.node.binary_path)
+
+    def _delete_path(self, host, path):
+        self.executor.execute(host, "rm -rf " + path)

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -164,6 +164,3 @@ class DockerInstaller(Installer):
             self._delete_path(host, data_path)
 
         self._delete_path(host, host.node.binary_path)
-
-    def _delete_path(self, host, path):
-        self.executor.execute(host, "rm -r " + path)

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -18,9 +18,6 @@ class DockerInstaller(Installer):
         self.provision_config_instance = provision_config_instance
 
     def install(self, host, binaries):
-        return self._prepare(host)
-
-    def _prepare(self, host):
         node = self._create_node()
         self._prepare_node(host, node)
 

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -6,11 +6,11 @@ import jinja2
 from jinja2 import select_autoescape
 
 from osbenchmark.builder.installers.installer import Installer
-from osbenchmark.exceptions import InvalidSyntax, SystemSetupError
 
 
 class DockerInstaller(Installer):
-    def __init__(self, pci, node_name, ip, http_port, node_root_dir, distribution_version, benchmark_root):
+    def __init__(self, pci, executor, node_name, ip, http_port, node_root_dir, distribution_version, benchmark_root, ):
+        super().__init__(executor)
         self.logger = logging.getLogger(__name__)
         self.pci = pci
 
@@ -47,13 +47,17 @@ class DockerInstaller(Installer):
         self.config_vars.update(self.provision_config_instance.variables)
         self.config_vars.update(provisioner_defaults)
 
-    def prepare(self, binary):
+    def install(self, host, binaries):
+        self._prepare(host)
+
+    def _prepare(self, host):
         # we need to allow other users to write to these directories due to Docker.
         #
         # Although os.mkdir passes 0o777 by default, mkdir(2) uses `mode & ~umask & 0777` to determine the final flags and
         # hence we need to modify the process' umask here. For details see https://linux.die.net/man/2/mkdir.
         previous_umask = os.umask(0)
         try:
+            # How to handle directory creation on remote machines?
             io.ensure_dir(self.binary_path)
             io.ensure_dir(self.node_log_dir)
             io.ensure_dir(self.heap_dump_dir)
@@ -63,7 +67,7 @@ class DockerInstaller(Installer):
 
         mounts = {}
 
-        for provision_config_instance_config_path in self.provision_config_instance.config_paths:
+        for provision_config_instance_config_path in self.pci.config_paths:
             for root, _, files in os.walk(provision_config_instance_config_path):
                 env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=select_autoescape(['html', 'xml']))
 
@@ -75,63 +79,72 @@ class DockerInstaller(Installer):
                     source_file = os.path.join(root, name)
                     target_file = os.path.join(absolute_target_root, name)
                     mounts[target_file] = os.path.join("/usr/share/opensearch", relative_root, name)
-                    if plain_text(source_file):
+                    if io.is_plain_text(source_file):
+                        config_vars = self._config_vars(host.nodes[0].name, host.nodes[0].port)
+
                         self.logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
                         with open(target_file, mode="a", encoding="utf-8") as f:
-                            f.write(_render_template(env, self.config_vars, source_file))
+                            f.write(self._render_template(env, config_vars, source_file))
                     else:
                         self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
-                        shutil.copy(source_file, target_file)
+                        self.executor.copy(source_file, target_file)
 
-        docker_cfg = self._render_template_from_file(self.docker_vars(mounts))
+        docker_cfg = self._render_template_from_docker_file(self._docker_vars(mounts, host.nodes[0].port))
         self.logger.info("Starting Docker container with configuration:\n%s", docker_cfg)
 
         with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)
 
-        return NodeConfiguration("docker", self.provision_config_instance.mandatory_var("runtime.jdk"),
-                                 convert.to_bool(self.provision_config_instance.mandatory_var("runtime.jdk.bundled")), self.node_ip,
-                                 self.node_name, self.node_root_dir, self.binary_path, self.data_paths)
+        # Loop over nodes/host? Docker can only have 1 node per host due to single node discovery?
+        return NodeConfiguration("docker", self.pci.variables["system"]["runtime"]["jdk"],
+                                 convert.to_bool(self.pci.variables["system"]["runtime"]["jdk"]["bundled"]), host.ip,
+                                 host.nodes[0].name, self.node_root_dir, self.binary_path, self.data_paths)
 
-    def docker_vars(self, mounts):
+    def _config_vars(self, node_name, port):
+        provisioner_defaults = {
+            "cluster_name": "benchmark-provisioned-cluster",
+            "node_name": node_name,
+            # we bind-mount the directories below on the host to these ones.
+            "install_root_path": "/usr/share/opensearch",
+            "data_paths": ["/usr/share/opensearch/data"],
+            "log_path": "/var/log/opensearch",
+            "heap_dump_path": "/usr/share/opensearch/heapdump",
+            # Docker container needs to expose service on external interfaces
+            "network_host": "0.0.0.0",
+            "discovery_type": "single-node",
+            "http_port": str(port),
+            "transport_port": str(port + 100),
+            "cluster_settings": {}
+        }
+
+        config_vars = {}
+        config_vars.update(self.pci.variables)
+        config_vars.update(provisioner_defaults)
+
+        return config_vars
+
+    def _docker_vars(self, port, mounts):
         v = {
-            "os_version": self.distribution_version,
-            "docker_image": self.provision_config_instance.mandatory_var("docker_image"),
-            "http_port": self.http_port,
+            "os_version": self.pci.variables["origin"]["distribution"]["version"],
+            "docker_image": self.pci.variables["origin"]["docker"]["image"],
+            "http_port": port,
             "os_data_dir": self.data_paths[0],
             "os_log_dir": self.node_log_dir,
             "os_heap_dump_dir": self.heap_dump_dir,
             "mounts": mounts
         }
-        self._add_if_defined_for_provision_config_instance(v, "docker_mem_limit")
-        self._add_if_defined_for_provision_config_instance(v, "docker_cpu_count")
+        self._add_if_defined_for_provision_config_instance(v, "mem_limit")
+        self._add_if_defined_for_provision_config_instance(v, "cpu_count")
         return v
 
     def _add_if_defined_for_provision_config_instance(self, variables, key):
-        if key in self.pci.variables:
-            variables[key] = self.pci.variables[key]
+        if key in self.pci.variables["origin"]["docker"]:
+            variables[key] = self.pci.variables["origin"]["docker"][key]
 
-    def _render_template(self, loader, template_name, variables):
-        try:
-            env = jinja2.Environment(loader=loader, autoescape=select_autoescape(['html', 'xml']))
-            for k, v in variables.items():
-                env.globals[k] = v
-            template = env.get_template(template_name)
-
-            return template.render()
-        except jinja2.exceptions.TemplateSyntaxError as e:
-            raise InvalidSyntax("%s in %s" % (str(e), template_name))
-        except BaseException as e:
-            raise SystemSetupError("%s in %s" % (str(e), template_name))
-
-    def _render_template_from_file(self, variables):
+    def _render_template_from_docker_file(self, variables):
         compose_file = os.path.join(self.benchmark_root, "resources", "docker-compose.yml.j2")
-        return self._render_template(loader=jinja2.FileSystemLoader(io.dirname(compose_file)),
-                                     template_name=io.basename(compose_file),
-                                     variables=variables)
-
-    def install(self, host, binaries):
-        pass
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(io.dirname(compose_file)), autoescape=select_autoescape(['html', 'xml']))
+        return self._render_template(env, variables, compose_file)
 
     def cleanup(self, host, node_configurations):
         pass

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -57,6 +57,8 @@ class DockerInstaller(Installer):
         self.executor.execute(host, "cp {0} {0}".format(docker_compose_file))
 
     def _create_directory(self, host, directory):
+        # Create directory locally and on the host
+        io.ensure_dir(directory)
         self.executor.execute(host, "mkdir -m 0777 -p " + directory)
 
     def _prepare_mounts(self, host, node):
@@ -80,8 +82,6 @@ class DockerInstaller(Installer):
         relative_root = root[len(config_path) + 1:]
         absolute_target_root = os.path.join(node.binary_path, relative_root)
 
-        # Create directory locally and on the host
-        io.ensure_dir(absolute_target_root)
         self._create_directory(host, absolute_target_root)
 
         config_path_file_mounts = {}
@@ -166,4 +166,4 @@ class DockerInstaller(Installer):
         self._delete_path(host, host.node.binary_path)
 
     def _delete_path(self, host, path):
-        self.executor.execute(host, "rm -rf " + path)
+        self.executor.execute(host, "rm -r " + path)

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -1,0 +1,137 @@
+import logging
+import os
+import uuid
+
+import jinja2
+from jinja2 import select_autoescape
+
+from osbenchmark.builder.installers.installer import Installer
+from osbenchmark.exceptions import InvalidSyntax, SystemSetupError
+
+
+class DockerInstaller(Installer):
+    def __init__(self, pci, node_name, ip, http_port, node_root_dir, distribution_version, benchmark_root):
+        self.logger = logging.getLogger(__name__)
+        self.pci = pci
+
+        self.node_name = node_name
+        self.node_ip = ip
+        self.http_port = http_port
+        self.node_root_dir = node_root_dir
+        self.node_log_dir = os.path.join(node_root_dir, "logs", "server")
+        self.heap_dump_dir = os.path.join(node_root_dir, "heapdump")
+        self.distribution_version = distribution_version
+        self.benchmark_root = benchmark_root
+        self.binary_path = os.path.join(node_root_dir, "install")
+        # use a random subdirectory to isolate multiple runs because an external (non-root) user cannot clean it up.
+        self.data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
+
+
+        provisioner_defaults = {
+            "cluster_name": "benchmark-provisioned-cluster",
+            "node_name": self.node_name,
+            # we bind-mount the directories below on the host to these ones.
+            "install_root_path": "/usr/share/opensearch",
+            "data_paths": ["/usr/share/opensearch/data"],
+            "log_path": "/var/log/opensearch",
+            "heap_dump_path": "/usr/share/opensearch/heapdump",
+            # Docker container needs to expose service on external interfaces
+            "network_host": "0.0.0.0",
+            "discovery_type": "single-node",
+            "http_port": str(self.http_port),
+            "transport_port": str(self.http_port + 100),
+            "cluster_settings": {}
+        }
+
+        self.config_vars = {}
+        self.config_vars.update(self.provision_config_instance.variables)
+        self.config_vars.update(provisioner_defaults)
+
+    def prepare(self, binary):
+        # we need to allow other users to write to these directories due to Docker.
+        #
+        # Although os.mkdir passes 0o777 by default, mkdir(2) uses `mode & ~umask & 0777` to determine the final flags and
+        # hence we need to modify the process' umask here. For details see https://linux.die.net/man/2/mkdir.
+        previous_umask = os.umask(0)
+        try:
+            io.ensure_dir(self.binary_path)
+            io.ensure_dir(self.node_log_dir)
+            io.ensure_dir(self.heap_dump_dir)
+            io.ensure_dir(self.data_paths[0])
+        finally:
+            os.umask(previous_umask)
+
+        mounts = {}
+
+        for provision_config_instance_config_path in self.provision_config_instance.config_paths:
+            for root, _, files in os.walk(provision_config_instance_config_path):
+                env = jinja2.Environment(loader=jinja2.FileSystemLoader(root), autoescape=select_autoescape(['html', 'xml']))
+
+                relative_root = root[len(provision_config_instance_config_path) + 1:]
+                absolute_target_root = os.path.join(self.binary_path, relative_root)
+                io.ensure_dir(absolute_target_root)
+
+                for name in files:
+                    source_file = os.path.join(root, name)
+                    target_file = os.path.join(absolute_target_root, name)
+                    mounts[target_file] = os.path.join("/usr/share/opensearch", relative_root, name)
+                    if plain_text(source_file):
+                        self.logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
+                        with open(target_file, mode="a", encoding="utf-8") as f:
+                            f.write(_render_template(env, self.config_vars, source_file))
+                    else:
+                        self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
+                        shutil.copy(source_file, target_file)
+
+        docker_cfg = self._render_template_from_file(self.docker_vars(mounts))
+        self.logger.info("Starting Docker container with configuration:\n%s", docker_cfg)
+
+        with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
+            f.write(docker_cfg)
+
+        return NodeConfiguration("docker", self.provision_config_instance.mandatory_var("runtime.jdk"),
+                                 convert.to_bool(self.provision_config_instance.mandatory_var("runtime.jdk.bundled")), self.node_ip,
+                                 self.node_name, self.node_root_dir, self.binary_path, self.data_paths)
+
+    def docker_vars(self, mounts):
+        v = {
+            "os_version": self.distribution_version,
+            "docker_image": self.provision_config_instance.mandatory_var("docker_image"),
+            "http_port": self.http_port,
+            "os_data_dir": self.data_paths[0],
+            "os_log_dir": self.node_log_dir,
+            "os_heap_dump_dir": self.heap_dump_dir,
+            "mounts": mounts
+        }
+        self._add_if_defined_for_provision_config_instance(v, "docker_mem_limit")
+        self._add_if_defined_for_provision_config_instance(v, "docker_cpu_count")
+        return v
+
+    def _add_if_defined_for_provision_config_instance(self, variables, key):
+        if key in self.pci.variables:
+            variables[key] = self.pci.variables[key]
+
+    def _render_template(self, loader, template_name, variables):
+        try:
+            env = jinja2.Environment(loader=loader, autoescape=select_autoescape(['html', 'xml']))
+            for k, v in variables.items():
+                env.globals[k] = v
+            template = env.get_template(template_name)
+
+            return template.render()
+        except jinja2.exceptions.TemplateSyntaxError as e:
+            raise InvalidSyntax("%s in %s" % (str(e), template_name))
+        except BaseException as e:
+            raise SystemSetupError("%s in %s" % (str(e), template_name))
+
+    def _render_template_from_file(self, variables):
+        compose_file = os.path.join(self.benchmark_root, "resources", "docker-compose.yml.j2")
+        return self._render_template(loader=jinja2.FileSystemLoader(io.dirname(compose_file)),
+                                     template_name=io.basename(compose_file),
+                                     variables=variables)
+
+    def install(self, host, binaries):
+        pass
+
+    def cleanup(self, host, node_configurations):
+        pass

--- a/osbenchmark/builder/installers/installer.py
+++ b/osbenchmark/builder/installers/installer.py
@@ -23,12 +23,11 @@ class Installer:
         """
         raise NotImplementedError
 
-    def cleanup(self, host, node_configurations):
+    def cleanup(self, host):
         """
         Removes the data that was downloaded, installed, and created on a given host during the test execution
 
         ;param host: A Host object defining the host on which to remove the data
-        ;param node_configurations: A list of NodeConfiguration objects detailing the installation data of the nodes on the host
         ;return None
         """
         raise NotImplementedError

--- a/osbenchmark/builder/installers/installer.py
+++ b/osbenchmark/builder/installers/installer.py
@@ -41,3 +41,10 @@ class Installer:
             raise InvalidSyntax("%s in %s" % (str(e), file_name))
         except BaseException as e:
             raise SystemSetupError("%s in %s" % (str(e), file_name))
+
+    def _delete_path(self, host, path):
+        path_block_list = ["", "*", "/", None]
+        if path in path_block_list:
+            return
+
+        self.executor.execute(host, "rm -r " + path)

--- a/osbenchmark/builder/installers/installer.py
+++ b/osbenchmark/builder/installers/installer.py
@@ -1,8 +1,15 @@
-"""
-Installers are invoked to prepare the OpenSearch and Plugin data that exists on a host so that an OpenSearch cluster
-can be started.
-"""
+import jinja2
+
+from osbenchmark.exceptions import InvalidSyntax, SystemSetupError
+from osbenchmark.utils import io
+
+
 class Installer:
+    """
+    Installers are invoked to prepare the OpenSearch and Plugin data that exists on a host so that an OpenSearch cluster
+    can be started.
+    """
+
     def __init__(self, executor):
         self.executor = executor
 
@@ -25,3 +32,13 @@ class Installer:
         ;return None
         """
         raise NotImplementedError
+
+    def _render_template(self, env, variables, file_name):
+        try:
+            template = env.get_template(io.basename(file_name))
+            # force a new line at the end. Jinja seems to remove it.
+            return template.render(variables) + "\n"
+        except jinja2.exceptions.TemplateSyntaxError as e:
+            raise InvalidSyntax("%s in %s" % (str(e), file_name))
+        except BaseException as e:
+            raise SystemSetupError("%s in %s" % (str(e), file_name))

--- a/osbenchmark/builder/installers/installer.py
+++ b/osbenchmark/builder/installers/installer.py
@@ -19,7 +19,7 @@ class Installer:
 
         ;param host: A Host object defining the host on which to install the data
         ;param binaries: A map of components to install to their paths on the host
-        ;return node_configurations: A list of NodeConfiguration objects detailing the installation data of the nodes on the host
+        ;return node: A Node object detailing the installation data of the node on the host
         """
         raise NotImplementedError
 

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -400,7 +400,7 @@ def splitext(file_name):
         return os.path.splitext(file_name)
 
 
-def plain_text(file):
+def is_plain_text(file):
     _, ext = splitext(file)
     return ext in [".ini", ".txt", ".json", ".yml", ".yaml", ".options", ".properties"]
 

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -399,6 +399,7 @@ def splitext(file_name):
     else:
         return os.path.splitext(file_name)
 
+
 def plain_text(file):
     _, ext = splitext(file)
     return ext in [".ini", ".txt", ".json", ".yml", ".yaml", ".options", ".properties"]

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -399,6 +399,10 @@ def splitext(file_name):
     else:
         return os.path.splitext(file_name)
 
+def plain_text(file):
+    _, ext = splitext(file)
+    return ext in [".ini", ".txt", ".json", ".yml", ".yaml", ".options", ".properties"]
+
 
 def has_extension(file_name, extension):
     """

--- a/tests/builder/installers/docker_installer_test.py
+++ b/tests/builder/installers/docker_installer_test.py
@@ -1,0 +1,191 @@
+# pylint: disable=protected-access
+
+import os
+import tempfile
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from osbenchmark.builder.installers.docker_installer import DockerInstaller
+from osbenchmark.builder.provision_config import ProvisionConfigInstance
+
+
+class DockerProvisionerTests(TestCase):
+    def setUp(self):
+        self.host = None
+        self.binaries = None
+        self.node_name = "9dbc682e-d32a-4669-8fbe-56fb77120dd4"
+        self.cluster_name = "my-cluster"
+        self.port = "39200"
+        self.test_execution_root = tempfile.gettempdir()
+        self.node_root_dir = os.path.join(self.test_execution_root, self.node_name)
+        self.node_data_dir = os.path.join(self.node_root_dir, "data", self.node_name)
+        self.node_log_dir = os.path.join(self.node_root_dir, "logs", "server")
+        self.node_heap_dump_dir = os.path.join(self.node_root_dir, "heapdump")
+
+        self.executor = Mock()
+        self.provision_config_instance = ProvisionConfigInstance(
+            names="fake",
+            root_path=None,
+            config_paths="/tmp",
+            variables={
+                "cluster_name": self.cluster_name,
+                "test_execution_root": self.test_execution_root,
+                "node": {
+                    "port": self.port
+                },
+                "origin": {
+                    "distribution": {
+                        "version": "1.1.0"
+                    },
+                    "docker": {
+                        "docker_image": "opensearchproject/opensearch"
+                    }
+                }
+            }
+        )
+
+        self.installer = DockerInstaller(self.provision_config_instance, self.executor)
+
+    maxDiff = None
+    @mock.patch("uuid.uuid4")
+    @mock.patch("osbenchmark.paths.benchmark_root")
+    def test_provisioning_with_defaults(self, benchmark_root, uuid4):
+        uuid4.return_value = self.node_name
+        benchmark_root.return_value = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                                                    os.pardir, os.pardir, os.pardir, "osbenchmark"))
+
+        node = self.installer._create_node()
+
+        self.assertDictEqual({
+            "cluster_name": self.cluster_name,
+            "node_name": self.node_name,
+            "install_root_path": "/usr/share/opensearch",
+            "data_paths": ["/usr/share/opensearch/data"],
+            "log_path": "/var/log/opensearch",
+            "heap_dump_path": "/usr/share/opensearch/heapdump",
+            "discovery_type": "single-node",
+            "network_host": "0.0.0.0",
+            "http_port": self.port,
+            "transport_port": str(int(self.port) + 100),
+            "cluster_settings": {
+            },
+            "docker_image": "opensearchproject/opensearch"
+        }, self.installer._get_config_vars(node))
+
+        docker_vars = self.installer._get_docker_vars(node, self.node_log_dir, self.node_heap_dump_dir, mounts={})
+        self.assertDictEqual({
+            "os_data_dir": self.node_data_dir,
+            "os_log_dir": self.node_log_dir,
+            "os_heap_dump_dir": self.node_heap_dump_dir,
+            "os_version": "1.1.0",
+            "docker_image": "opensearchproject/opensearch",
+            "http_port": 39200,
+            "mounts": {}
+        }, docker_vars)
+
+        docker_cfg = self.installer._render_template_from_docker_file(docker_vars)
+
+        self.assertEqual(
+"""version: '3'
+services:
+  opensearch-node1:
+    image: opensearchproject/opensearch:1.1.0
+    container_name: opensearch-node1
+    labels:
+      io.benchmark.description: "opensearch-benchmark"
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - discovery.seed_hosts=opensearch-node1
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - %s:/usr/share/opensearch/data
+      - %s:/var/log/opensearch
+      - %s:/usr/share/opensearch/heapdump
+    ports:
+      - 39200:39200
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:39200 -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
+
+volumes:
+  opensearch-data1:
+networks:
+  opensearch-net:
+""" % (self.node_data_dir, self.node_log_dir, self.node_heap_dump_dir), docker_cfg)
+
+    @mock.patch("uuid.uuid4")
+    @mock.patch("osbenchmark.paths.benchmark_root")
+    def test_provisioning_with_variables(self, benchmark_root, uuid4):
+        uuid4.return_value = self.node_name
+        benchmark_root.return_value = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                                                    os.pardir, os.pardir, os.pardir, "osbenchmark"))
+
+        self.provision_config_instance.variables["origin"]["docker"]["docker_mem_limit"] = "256m"
+        self.provision_config_instance.variables["origin"]["docker"]["docker_cpu_count"] = 2
+
+        node = self.installer._create_node()
+
+        docker_vars = self.installer._get_docker_vars(node, self.node_log_dir, self.node_heap_dump_dir, mounts={})
+        docker_cfg = self.installer._render_template_from_docker_file(docker_vars)
+
+        self.assertEqual(
+"""version: '3'
+services:
+  opensearch-node1:
+    image: opensearchproject/opensearch:1.1.0
+    container_name: opensearch-node1
+    labels:
+      io.benchmark.description: "opensearch-benchmark"
+    cpu_count: 2
+    mem_limit: 256m
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - discovery.seed_hosts=opensearch-node1
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - %s:/usr/share/opensearch/data
+      - %s:/var/log/opensearch
+      - %s:/usr/share/opensearch/heapdump
+    ports:
+      - 39200:39200
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:39200 -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
+
+volumes:
+  opensearch-data1:
+networks:
+  opensearch-net:
+""" % (self.node_data_dir, self.node_log_dir, self.node_heap_dump_dir), docker_cfg)


### PR DESCRIPTION
### Description
Migrates the DockerProvisioner to a DockerInstaller that conforms to the Installer interface. As with the other migrations, the key changes are copying and refactoring the unit tests, substituting shell calls with executor.execute, swap out references to the `cfg` object with references to the `provision_config_instance`, and code cleanup/refactoring.

Aside from the above, one key decision this CR makes is to drop support for multiple nodes per host when building a cluster. This decision may be revisited in the future.
 
#134  
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).