### PR TITLE
Migrate java_resolver file to JavaHomeResolver class with executor

### DIFF
--- a/osbenchmark/builder/utils/java_home_resolver.py
+++ b/osbenchmark/builder/utils/java_home_resolver.py
@@ -1,0 +1,59 @@
+import logging
+
+from osbenchmark.builder.utils.jdk_resolver import JdkResolver
+from osbenchmark.exceptions import SystemSetupError
+
+
+class JavaHomeResolver:
+    def __init__(self, executor):
+        self.logger = logging.getLogger(__name__)
+        self.executor = executor
+        self.jdk_resolver = JdkResolver(executor)
+
+    def resolve_java_home(self, host, provision_config_instance_runtime_jdks, specified_runtime_jdk=None,
+                          provides_bundled_jdk=False):
+        try:
+            allowed_runtime_jdks = [int(v) for v in provision_config_instance_runtime_jdks.split(",")]
+        except ValueError:
+            raise SystemSetupError("ProvisionConfigInstance variable key \"runtime.jdk\" is invalid: \"{}\" (must be int)"
+                                   .format(provision_config_instance_runtime_jdks))
+
+        runtime_jdk_versions = self._determine_runtime_jdks(specified_runtime_jdk, allowed_runtime_jdks)
+
+        if runtime_jdk_versions[0] == "bundled":
+            return self._handle_bundled_jdk(host, allowed_runtime_jdks, provides_bundled_jdk)
+        else:
+            self.logger.info("Allowed JDK versions are %s.", runtime_jdk_versions)
+            return self._detect_jdk(host, runtime_jdk_versions)
+
+    def _determine_runtime_jdks(self, specified_runtime_jdk, allowed_runtime_jdks):
+        if specified_runtime_jdk:
+            return [specified_runtime_jdk]
+        else:
+            return allowed_runtime_jdks
+
+    def _handle_bundled_jdk(self, host, allowed_runtime_jdks, provides_bundled_jdk):
+        if not provides_bundled_jdk:
+            raise SystemSetupError(
+                "This OpenSearch version does not contain a bundled JDK. Please specify a different runtime JDK.")
+
+        self.logger.info("Using JDK bundled with OpenSearch.")
+        os_check = self.executor.execute(host, "uname", output=True)[0]
+        if os_check == "Windows":
+            raise SystemSetupError("OpenSearch doesn't provide release artifacts for Windows currently.")
+        if os_check == "Darwin":
+            # OpenSearch does not provide a Darwin version of OpenSearch or a MacOS JDK version
+            self.logger.info("Using JDK set from JAVA_HOME because OS is MacOS (Darwin).")
+            self.logger.info(
+                "NOTICE: OpenSearch doesn't provide jdk bundled release artifacts for MacOS (Darwin) currently. "
+                "Please set JAVA_HOME to JDK 11 or JDK 8 and set the runtime.jdk.bundled to true in the specified "
+                "provision config instance file")
+            return self._detect_jdk(host, allowed_runtime_jdks)
+
+        # assume that the bundled JDK is the highest available; the path is irrelevant
+        return allowed_runtime_jdks[0], None
+
+    def _detect_jdk(self, host, jdks):
+        major, java_home = self.jdk_resolver.resolve_jdk_path(host, jdks)
+        self.logger.info("Detected JDK with major version [%s] in [%s].", major, java_home)
+        return major, java_home

--- a/tests/builder/utils/java_home_resolver_test.py
+++ b/tests/builder/utils/java_home_resolver_test.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from osbenchmark.builder.utils.java_home_resolver import JavaHomeResolver
+from osbenchmark.exceptions import SystemSetupError
+
+
+class JavaHomeResolverTests(TestCase):
+    def setUp(self):
+        self.host = None
+        self.executor = Mock()
+        self.java_home_resolver = JavaHomeResolver(self.executor)
+        self.java_home_resolver.jdk_resolver = Mock()
+
+    def test_resolves_java_home_for_default_runtime_jdk(self):
+        self.executor.execute.return_value = ["Darwin"]
+        self.java_home_resolver.jdk_resolver.resolve_jdk_path.return_value = (12, "/opt/jdk12")
+        major, java_home = self.java_home_resolver.resolve_java_home(self.host, "12,11,10,9,8", specified_runtime_jdk=None,
+                                                                     provides_bundled_jdk=True)
+
+        self.assertEqual(major, 12)
+        self.assertEqual(java_home, "/opt/jdk12")
+
+    def test_resolves_java_home_for_specific_runtime_jdk(self):
+        self.executor.execute.return_value = ["Darwin"]
+        self.java_home_resolver.jdk_resolver.resolve_jdk_path.return_value = (8, "/opt/jdk8")
+        major, java_home = self.java_home_resolver.resolve_java_home(self.host, "12,11,10,9,8", specified_runtime_jdk=8,
+                                                                     provides_bundled_jdk=True)
+
+        self.assertEqual(major, 8)
+        self.assertEqual(java_home, "/opt/jdk8")
+        self.java_home_resolver.jdk_resolver.resolve_jdk_path.assert_called_with(None, [8])
+
+    def test_resolves_java_home_for_bundled_jdk_on_linux(self):
+        self.executor.execute.return_value = ["Linux"]
+        major, java_home = self.java_home_resolver.resolve_java_home(self.host, "12,11,10,9,8", specified_runtime_jdk="bundled",
+                                                                     provides_bundled_jdk=True)
+
+        self.assertEqual(major, 12)
+        self.assertEqual(java_home, None)
+
+    def test_resolves_java_home_for_bundled_jdk_windows(self):
+        self.executor.execute.return_value = ["Windows"]
+        with self.assertRaises(SystemSetupError) as ctx:
+            self.java_home_resolver.resolve_java_home(self.host, "12,11,10,9", specified_runtime_jdk="bundled", provides_bundled_jdk=True)
+        self.assertEqual("OpenSearch doesn't provide release artifacts for Windows currently.", ctx.exception.args[0])
+
+    def test_disallowed_bundled_jdk(self):
+        with self.assertRaises(SystemSetupError) as ctx:
+            self.java_home_resolver.resolve_java_home(self.host, "12,11,10,9,8", specified_runtime_jdk="bundled")
+        self.assertEqual(
+            "This OpenSearch version does not contain a bundled JDK. Please specify a different runtime JDK.", ctx.exception.args[0])


### PR DESCRIPTION
### Description
Migrates the [java_resolver](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/builder/java_resolver.py) functionality to a `JavaHomeResolver` class that utilizes an executor. This allows the builder subcomponents to use the `JavaHomeResolver` regardless of the cluster infrastructure provider.

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#134 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).