### PR TITLE
Change process name finder to use opensearch-benchmark instead of osb…

### DIFF
--- a/osbenchmark/utils/process.py
+++ b/osbenchmark/utils/process.py
@@ -110,11 +110,10 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
 
 
 def is_benchmark_process(p):
-    return p.name() == "osbenchmark" or \
-           p.name() == "benchmark" or \
+    return p.name() == "opensearch-benchmark" or \
            (p.name().lower().startswith("python")
-            and any("osbenchmark" in e for e in p.cmdline())
-            and not any("osbenchmarkd" in e for e in p.cmdline()))
+            and any("opensearch-benchmark" in e for e in p.cmdline())
+            and not any("opensearch-benchmarkd" in e for e in p.cmdline()))
 
 
 def find_all_other_benchmark_processes():
@@ -127,7 +126,7 @@ def kill_all(predicate):
     def kill(p):
         logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s].", p.pid, p.cmdline())
         p.kill()
-        # wait until process has terminated, at most 3 seconds. Otherwise we might run into TestExecution conditions with actor system
+        # wait until process has terminated, at most 3 seconds. Otherwise we might run into race conditions with actor system
         # sockets that are still open.
         for _ in range(3):
             try:
@@ -135,7 +134,6 @@ def kill_all(predicate):
                 time.sleep(1)
             except psutil.NoSuchProcess:
                 break
-
     for_all_other_processes(predicate, kill)
 
 
@@ -151,11 +149,4 @@ def for_all_other_processes(predicate, action):
 
 
 def kill_running_benchmark_instances():
-    def benchmark_process(p):
-        return p.name() == "osbenchmark" or \
-               p.name() == "benchmark" or \
-               (p.name().lower().startswith("python")
-                and any("osbenchmark" in e for e in p.cmdline())
-                and not any("osbenchmarkd" in e for e in p.cmdline()))
-
-    kill_all(benchmark_process)
+    kill_all(is_benchmark_process)

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -69,15 +69,14 @@ class ProcessTests(TestCase):
                                                                    "org.elasticsearch.bootstrap.Elasticsearch"])
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
-        benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_r = ProcessTests.Process(106, "benchmark", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_e = ProcessTests.Process(107, "osbenchmark", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/osbenchmark"])
+        benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/opensearch-benchmark"])
         # fake own process by determining our pid
         own_benchmark_process = ProcessTests.Process(
             os.getpid(), "Python",
             ["/Python.app/Contents/MacOS/Python",
-            "~/.local/bin/osbenchmark"])
+            "~/.local/bin/opensearch-benchmark"])
         night_benchmark_process = ProcessTests.Process(110, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/night_benchmark"])
 
         process_iter.return_value = [
@@ -87,14 +86,13 @@ class ProcessTests(TestCase):
             random_python,
             other_process,
             benchmark_process_p,
-            benchmark_process_r,
             benchmark_process_e,
             benchmark_process_mac,
             own_benchmark_process,
             night_benchmark_process,
         ]
 
-        self.assertEqual([benchmark_process_p, benchmark_process_r, benchmark_process_e, benchmark_process_mac],
+        self.assertEqual([benchmark_process_p, benchmark_process_e, benchmark_process_mac],
                          process.find_all_other_benchmark_processes())
 
     @mock.patch("psutil.process_iter")
@@ -123,14 +121,13 @@ class ProcessTests(TestCase):
                                                                    "org.elasticsearch.bootstrap.Elasticsearch"])
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
-        benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_r = ProcessTests.Process(106, "benchmark", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_e = ProcessTests.Process(107, "osbenchmark", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
-        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/osbenchmark"])
+        benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/opensearch-benchmark"])
         # fake own process by determining our pid
         own_benchmark_process = ProcessTests.Process(
             os.getpid(), "Python",
-            ["/Python.app/Contents/MacOS/Python", "~/.local/bin/osbenchmark"])
+            ["/Python.app/Contents/MacOS/Python", "~/.local/bin/opensearch-benchmark"])
         night_benchmark_process = ProcessTests.Process(110, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/night_benchmark"])
 
         process_iter.return_value = [
@@ -140,7 +137,6 @@ class ProcessTests(TestCase):
             random_python,
             other_process,
             benchmark_process_p,
-            benchmark_process_r,
             benchmark_process_e,
             benchmark_process_mac,
             own_benchmark_process,
@@ -155,7 +151,6 @@ class ProcessTests(TestCase):
         self.assertFalse(random_python.killed)
         self.assertFalse(other_process.killed)
         self.assertTrue(benchmark_process_p.killed)
-        self.assertTrue(benchmark_process_r.killed)
         self.assertTrue(benchmark_process_e.killed)
         self.assertTrue(benchmark_process_mac.killed)
         self.assertFalse(own_benchmark_process.killed)

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -71,7 +71,8 @@ class ProcessTests(TestCase):
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
-        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python",
+                                                                     "~/.local/bin/opensearch-benchmark"])
         # fake own process by determining our pid
         own_benchmark_process = ProcessTests.Process(
             os.getpid(), "Python",
@@ -123,7 +124,8 @@ class ProcessTests(TestCase):
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
-        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python", "~/.local/bin/opensearch-benchmark"])
+        benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python",
+                                                                     "~/.local/bin/opensearch-benchmark"])
         # fake own process by determining our pid
         own_benchmark_process = ProcessTests.Process(
             os.getpid(), "Python",


### PR DESCRIPTION
…enchmark

Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
The `--kill-running-processes` flag wasn't working because of changes made as part of https://github.com/opensearch-project/opensearch-benchmark/issues/81 that changed the process name. This PR fixes the process finding logic to use the correct name 
 
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-benchmark/issues/96
 
### Check List
- [X] New functionality includes testing
  - [X] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).