### PR TITLE
Refactor to use f-strings instead of .format() in Builder system

### DIFF
--- a/osbenchmark/builder/downloaders/opensearch_distribution_downloader.py
+++ b/osbenchmark/builder/downloaders/opensearch_distribution_downloader.py
@@ -47,7 +47,7 @@ class OpenSearchDistributionDownloader(Downloader):
 
     def _is_binary_present(self, host, distribution_path):
         try:
-            self.executor.execute(host, "test -f {}".format(distribution_path))
+            self.executor.execute(host, f"test -f {distribution_path}")
             return True
         except ExecutorError:
             return False
@@ -57,7 +57,7 @@ class OpenSearchDistributionDownloader(Downloader):
         self.logger.info("Starting download of OpenSearch [%s]", opensearch_version)
 
         try:
-            self.executor.execute(host, "curl -o {} {}".format(distribution_path, download_url))
+            self.executor.execute(host, f"curl -o {distribution_path} {download_url}")
         except ExecutorError as e:
             self.logger.exception("Exception downloading OpenSearch distribution for version [%s] from [%s].",
                                   opensearch_version, download_url)

--- a/osbenchmark/builder/downloaders/repositories/opensearch_distribution_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/opensearch_distribution_repository_provider.py
@@ -17,9 +17,9 @@ class OpenSearchDistributionRepositoryProvider:
 
         self.logger.info("runtime_jdk_bundled? [%s]", is_runtime_jdk_bundled)
         if is_runtime_jdk_bundled:
-            url_key = "distribution.jdk.bundled.{}_url".format(distribution_repository)
+            url_key = f"distribution.jdk.bundled.{distribution_repository}_url"
         else:
-            url_key = "distribution.jdk.unbundled.{}_url".format(distribution_repository)
+            url_key = f"distribution.jdk.unbundled.{distribution_repository}_url"
 
         self.logger.info("key: [%s]", url_key)
         return self.repository_url_provider.render_url_for_key(host, self.provision_config_instance.variables, url_key)

--- a/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
@@ -9,5 +9,5 @@ class PluginDistributionRepositoryProvider:
     def get_download_url(self, host):
         distribution_repository = self.plugin.variables["distribution"]["repository"]
 
-        default_key = "plugin.{}.{}.url".format(self.plugin.name, distribution_repository)
+        default_key = f"plugin.{self.plugin.name}.{distribution_repository}.url"
         return self.repository_url_provider.render_url_for_key(host, self.plugin.variables, default_key, mandatory=False)

--- a/osbenchmark/builder/downloaders/repositories/repository_url_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/repository_url_provider.py
@@ -19,7 +19,7 @@ class RepositoryUrlProvider:
             url_template = self._get_value_from_dot_notation_key(config_variables, key)
         except TypeError:
             if mandatory:
-                raise SystemSetupError("Config key [{}] is not defined.".format(key))
+                raise SystemSetupError(f"Config key [{key}] is not defined.")
             else:
                 return None
         return self.template_renderer.render_template_string(url_template, self._get_url_template_variables(host, config_variables))

--- a/osbenchmark/builder/executors/exception_handling_shell_executor.py
+++ b/osbenchmark/builder/executors/exception_handling_shell_executor.py
@@ -10,4 +10,4 @@ class ExceptionHandlingShellExecutor(ShellExecutor):
         try:
             return self.executor.execute(host, command, kwargs)
         except Exception as e:
-            raise ExecutorError("Command \"{}\" on host \"{}\" failed to execute".format(command, host), e)
+            raise ExecutorError(f"Command \"{command}\" on host \"{host}\" failed to execute", e)

--- a/osbenchmark/builder/executors/local_shell_executor.py
+++ b/osbenchmark/builder/executors/local_shell_executor.py
@@ -12,4 +12,4 @@ class LocalShellExecutor(ShellExecutor):
             return process.run_subprocess_with_output(command)
         else:
             if process.run_subprocess_with_logging(command, stdout=stdout, stderr=stderr, env=env, detach=detach):
-                raise ExecutorError("Command: \"{}\" returned a non-zero exit code".format(command))
+                raise ExecutorError(f"Command: \"{command}\" returned a non-zero exit code")

--- a/osbenchmark/builder/installers/bare_installer.py
+++ b/osbenchmark/builder/installers/bare_installer.py
@@ -67,7 +67,7 @@ class BareInstaller(Installer):
     def _get_node(self, preparer_to_node):
         nodes_list = list(filter(lambda node: node is not None, preparer_to_node.values()))
 
-        assert len(nodes_list) == 1, "Exactly one node must be provisioned per host, but found nodes: {}".format(nodes_list)
+        assert len(nodes_list) == 1, f"Exactly one node must be provisioned per host, but found nodes: {nodes_list}"
 
         return nodes_list[0]
 

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -59,7 +59,7 @@ class DockerInstaller(Installer):
         docker_compose_file = os.path.join(node.binary_path, "docker-compose.yml")
         with open(docker_compose_file, mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)
-        self.executor.execute(host, "cp {0} {0}".format(docker_compose_file))
+        self.executor.execute(host, f"cp {docker_compose_file} {docker_compose_file}")
 
     def _prepare_mounts(self, host, node):
         config_vars = self._get_config_vars(node)

--- a/osbenchmark/builder/installers/preparers/opensearch_preparer.py
+++ b/osbenchmark/builder/installers/preparers/opensearch_preparer.py
@@ -60,7 +60,7 @@ class OpenSearchPreparer(Preparer):
 
     def _extract_opensearch(self, host, node, binary):
         self.logger.info("Unzipping %s to %s", binary, node.binary_path)
-        self.executor.execute(host, "tar -xzvf {} --directory {}".format(binary, node.binary_path))
+        self.executor.execute(host, f"tar -xzvf {binary} --directory {node.binary_path}")
 
     def _update_node_binary_path(self, node):
         node.binary_path = os.path.join(node.binary_path, "opensearch*")

--- a/osbenchmark/builder/launchers/docker_launcher.py
+++ b/osbenchmark/builder/launchers/docker_launcher.py
@@ -46,7 +46,7 @@ class DockerLauncher(Launcher):
     def _docker_compose(self, compose_config, cmd):
         docker_compose_file = self._get_docker_compose_file(compose_config)
 
-        return "docker-compose -f {} {}".format(docker_compose_file, cmd)
+        return f"docker-compose -f {docker_compose_file} {cmd}"
 
     def _get_docker_compose_file(self, compose_config):
         return os.path.join(compose_config, "docker-compose.yml")
@@ -59,7 +59,7 @@ class DockerLauncher(Launcher):
         self.waiter.wait(self._is_container_healthy, host, container_id)
 
     def _is_container_healthy(self, host, container_id):
-        cmd = 'docker ps -a --filter "id={}" --filter "status=running" --filter "health=healthy" -q'.format(container_id)
+        cmd = f'docker ps -a --filter "id={container_id}" --filter "status=running" --filter "health=healthy" -q'
         containers = self.shell_executor.execute(host, cmd, output=True)
         return len(containers) > 0
 

--- a/osbenchmark/builder/launchers/exception_handling_launcher.py
+++ b/osbenchmark/builder/launchers/exception_handling_launcher.py
@@ -11,10 +11,10 @@ class ExceptionHandlingLauncher(Launcher):
         try:
             return self.launcher.start(host, node_configurations)
         except Exception as e:
-            raise LaunchError("Starting node(s) on host \"{}\" failed".format(host), e)
+            raise LaunchError(f"Starting node(s) on host \"{host}\" failed", e)
 
     def stop(self, host, nodes):
         try:
             return self.launcher.stop(host, nodes)
         except Exception as e:
-            raise LaunchError("Stopping node(s) on host \"{}\" failed".format(host), e)
+            raise LaunchError(f"Stopping node(s) on host \"{host}\" failed", e)

--- a/osbenchmark/builder/utils/config_applier.py
+++ b/osbenchmark/builder/utils/config_applier.py
@@ -36,9 +36,9 @@ class ConfigApplier:
                     with open(target_file, mode="a", encoding="utf-8") as f:
                         f.write(self.template_renderer.render_template_file(root, config_vars, source_file))
 
-                    self.executor.execute(host, "cp {0} {0}".format(target_file))
+                    self.executor.execute(host, f"cp {target_file} {target_file}")
                 else:
                     self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
-                    self.executor.execute(host, "cp {} {}".format(source_file, target_file))
+                    self.executor.execute(host, f"cp {source_file} {target_file}")
 
         return mounts

--- a/osbenchmark/builder/utils/java_home_resolver.py
+++ b/osbenchmark/builder/utils/java_home_resolver.py
@@ -17,8 +17,7 @@ class JavaHomeResolver:
         try:
             allowed_runtime_jdks = [int(v) for v in runtime_jdks.split(",")]
         except ValueError:
-            raise SystemSetupError("ProvisionConfigInstance variable key \"runtime.jdk\" is invalid: \"{}\" (must be int)"
-                                   .format(runtime_jdks))
+            raise SystemSetupError(f"ProvisionConfigInstance variable key \"runtime.jdk\" is invalid: \"{runtime_jdks}\" (must be int)")
 
         if is_runtime_jdk_bundled:
             return self._handle_bundled_jdk(host, allowed_runtime_jdks)

--- a/tests/builder/launchers/local_process_launcher_test.py
+++ b/tests/builder/launchers/local_process_launcher_test.py
@@ -54,7 +54,7 @@ class LocalProcessLauncherTests(TestCase):
                                                   provision_config_instance_runtime_jdks="12,11",
                                                   provision_config_instance_provides_bundled_jdk=True,
                                                   ip="127.0.0.1",
-                                                  node_name="testnode-{}".format(node),
+                                                  node_name=f"testnode-{node}",
                                                   node_root_path="/tmp",
                                                   binary_path="/tmp",
                                                   data_paths="/tmp"))

--- a/tests/builder/utils/path_manager_test.py
+++ b/tests/builder/utils/path_manager_test.py
@@ -21,7 +21,7 @@ class PathManagerTest(TestCase):
             mock.call(self.path)
         ])
         self.executor.execute.assert_has_calls([
-            mock.call(self.host, "mkdir -m 0777 -p {}".format(self.path))
+            mock.call(self.host, f"mkdir -m 0777 -p {self.path}")
         ])
 
     @mock.patch('osbenchmark.utils.io.ensure_dir')
@@ -30,14 +30,14 @@ class PathManagerTest(TestCase):
 
         ensure_dir.assert_has_calls([])
         self.executor.execute.assert_has_calls([
-            mock.call(self.host, "mkdir -m 0777 -p {}".format(self.path))
+            mock.call(self.host, f"mkdir -m 0777 -p {self.path}")
         ])
 
     def test_delete_valid_path(self):
         self.path_manager.delete_path(self.host, self.path)
 
         self.executor.execute.assert_has_calls([
-            mock.call(self.host, "rm -r {}".format(self.path))
+            mock.call(self.host, f"rm -r {self.path}")
         ])
 
     def test_delete_invalid_path(self):


### PR DESCRIPTION
### Description
Follow up from #175 to prefer f-strings over .format()

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).