### PR TITLE
Migrate Provision and Plugin config parser models to standalone classes in the models module

### DIFF
--- a/osbenchmark/builder/models/bootstrap_phase.py
+++ b/osbenchmark/builder/models/bootstrap_phase.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class BootstrapPhase(Enum):
+    """
+    An enum defining the valid phases of bootstrapping. A BootstrapPhase is used to define when a BootstrapHookHandler
+    is executed during cluster creation.
+    """
+    POST_INSTALL = 10
+
+    @classmethod
+    def valid(cls, name):
+        for n in BootstrapPhase.names():
+            if n == name:
+                return True
+        return False
+
+    @classmethod
+    def names(cls):
+        return [p.name for p in list(BootstrapPhase)]

--- a/osbenchmark/builder/models/plugin_config_instance.py
+++ b/osbenchmark/builder/models/plugin_config_instance.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class PluginConfigInstance:
+    # name of the initial Python file to load for plugins.
+    ENTRY_POINT = "plugin"
+
+    """
+    Creates new settings for a plugin attached to a benchmark candidate.
+
+    :param names: Descriptive name for this plugin_config_instance.
+    :param is_core_plugin: A boolean dictating if the plugin is a core plugin.
+    :param config_names: A list of config folder names where the raw config can be found. May be ``None``.
+    :param root_path: The root path from which bootstrap hooks should be loaded if any. May be ``None``.
+    :param config_paths: A non-empty list of paths where the raw config can be found.
+    :param variables: A dict containing variable definitions that need to be replaced.
+    """
+    name: str
+    is_core_plugin: bool = False
+    config_names: List[str] = None
+    root_path: str = None
+    config_paths: List[str] = field(default_factory=list)
+    variables: dict = field(default_factory=dict)
+
+    @staticmethod
+    def get_entry_point():
+        return PluginConfigInstance.ENTRY_POINT
+
+    def __str__(self):
+        return "Plugin descriptor for [%s]" % self.name
+
+    def __repr__(self):
+        r = []
+        for prop, value in vars(self).items():
+            r.append("%s = [%s]" % (prop, repr(value)))
+        return ", ".join(r)
+
+    def __hash__(self):
+        return hash(self.name) ^ hash(self.config_names) ^ hash(self.is_core_plugin)
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and \
+               (self.name, self.config_names, self.is_core_plugin) == (other.name, other.config_names, other.is_core_plugin)

--- a/osbenchmark/builder/models/provision_config_instance.py
+++ b/osbenchmark/builder/models/provision_config_instance.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from osbenchmark.builder.models.cluster_flavors import ClusterFlavor
+from osbenchmark.builder.models.cluster_infra_providers import ClusterInfraProvider
+
+
+@dataclass
+class ProvisionConfigInstance:
+    ENTRY_POINT = "config"
+
+    """
+    Creates new settings for a benchmark candidate.
+
+    :param names: Descriptive name(s) for this provision_config_instance.
+    :param root_path: The root path from which bootstrap hooks should be loaded if any. May be ``None``.
+    :param provider: The infrastructure provider for the cluster
+    :param flavor: The flavor of cluster to be provisioned
+    :param config_paths: A non-empty list of paths where the raw config can be found.
+    :param variables: A dict containing variable definitions that need to be replaced.
+    """
+    names: List[str]
+    root_path: str
+    provider: ClusterInfraProvider = ClusterInfraProvider.LOCAL
+    flavor: ClusterFlavor = ClusterFlavor.SELF_MANAGED
+    config_paths: List[str] = field(default_factory=list)
+    variables: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if isinstance(self.names, str):
+            self.names = [self.names]
+
+    @staticmethod
+    def get_entry_point():
+        return ProvisionConfigInstance.ENTRY_POINT
+
+    @property
+    def name(self):
+        return "+".join(self.names)
+
+    # Adapter method for BootstrapHookHandler
+    @property
+    def config(self):
+        return self.name
+
+    @property
+    def safe_name(self):
+        return "_".join(self.names)
+
+    def __str__(self):
+        return self.name

--- a/osbenchmark/builder/models/provision_config_instance_descriptor.py
+++ b/osbenchmark/builder/models/provision_config_instance_descriptor.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from osbenchmark.builder.models.cluster_flavors import ClusterFlavor
+from osbenchmark.builder.models.cluster_infra_providers import ClusterInfraProvider
+from osbenchmark.builder.models.provision_config_instance_types import ProvisionConfigInstanceType
+
+
+@dataclass
+class ProvisionConfigInstanceDescriptor:
+    """
+    A ProvisionConfigInstanceDescriptor represents a single source of provision config definition. These descriptors serve
+    as an intermediary store of the cluster to be provisioned. Descriptors are created from each config source and played
+    on top of one another to create the final ProvisionConfigInstance to be used by the Builder system.
+
+    :param name: Descriptive name for this provision config instance source.
+    :param description: A description for this provision config instance source.
+    :param type: The type of provision config instance source. Can be a standalone config instance or a mixin
+    :param root_paths: A list of root paths from which bootstrap hooks should be loaded if any. May be empty.
+    :param provider: The infrastructure provider for the cluster. May be ``None``.
+    :param flavor: The flavor of cluster to be provisioned. May be ``None``.
+    :param config_paths: A list of paths where the raw config can be found. May be empty.
+    :param variables: A dict containing variable definitions that need to be replaced.
+    """
+
+    name: str
+    description: str = ""
+    type: ProvisionConfigInstanceType = ProvisionConfigInstanceType.PROVISION_CONFIG_INSTANCE
+    root_paths: List[str] = field(default_factory=list)
+    provider: ClusterInfraProvider = None
+    flavor: ClusterFlavor = None
+    config_paths: List[str] = field(default_factory=list)
+    variables: dict = field(default_factory=dict)

--- a/osbenchmark/builder/models/provision_config_instance_types.py
+++ b/osbenchmark/builder/models/provision_config_instance_types.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ProvisionConfigInstanceType(str, Enum):
+    PROVISION_CONFIG_INSTANCE = "provision-config-instance"
+    MIXIN = "mixin"


### PR DESCRIPTION
### Description
Migrates the existing models used for parsing a Provision and PluginConfigInstance to standalone dataclasses classes. The original models can be found in this class: https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/builder/provision_config.py

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#132 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).