### PR TITLE
Implement ExternalPluginSourceDownloader, refactor repo url lookup in PluginDistributionRepositoryProvider

### DIFF
--- a/osbenchmark/builder/downloaders/external_plugin_source_downloader.py
+++ b/osbenchmark/builder/downloaders/external_plugin_source_downloader.py
@@ -1,0 +1,30 @@
+from osbenchmark.builder.downloaders.downloader import Downloader
+
+
+class ExternalPluginSourceDownloader(Downloader):
+    def __init__(self, plugin_config_instance, executor, source_repository_provider, binary_builder, plugin_source_directory):
+        super().__init__(executor)
+        self.plugin_config_instance = plugin_config_instance
+        self.source_repository_provider = source_repository_provider
+        self.binary_builder = binary_builder
+        self.plugin_source_directory = plugin_source_directory
+
+    def download(self, host):
+        self._fetch(host)
+        self._prepare(host)
+
+        return {self.plugin_config_instance.name: self._get_zip_path()}
+
+    def _fetch(self, host):
+        plugin_remote_url = self.plugin_config_instance.variables["source"]["remote"]["repo"]["url"]
+        plugin_revision = self.plugin_config_instance.variables["source"]["revision"]
+        self.source_repository_provider.fetch_repository(host, plugin_remote_url, plugin_revision, self.plugin_source_directory)
+
+    def _prepare(self, host):
+        if self.binary_builder:
+            build_command = self.plugin_config_instance.variables["source"]["build"]["command"]
+            self.binary_builder.build(host, [build_command], override_source_directory=self.plugin_source_directory)
+
+    def _get_zip_path(self):
+        artifact_path = self.plugin_config_instance.variables["source"]["build"]["artifact"]["subdir"]
+        return f"file://{self.plugin_source_directory}/{artifact_path}/*.zip"

--- a/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
@@ -9,5 +9,5 @@ class PluginDistributionRepositoryProvider:
     def get_download_url(self, host):
         distribution_repository = self.plugin.variables["distribution"]["repository"]
 
-        default_key = f"plugin.{self.plugin.name}.{distribution_repository}.url"
+        default_key = f"distribution.{distribution_repository}.remote.repo.url"
         return self.repository_url_provider.render_url_for_key(host, self.plugin.variables, default_key, mandatory=False)

--- a/tests/builder/downloaders/external_plugin_source_downloader_test.py
+++ b/tests/builder/downloaders/external_plugin_source_downloader_test.py
@@ -1,0 +1,54 @@
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from osbenchmark.builder.downloaders.external_plugin_source_downloader import ExternalPluginSourceDownloader
+from osbenchmark.builder.provision_config import PluginDescriptor
+
+
+class ExternalPluginSourceDownloaderTest(TestCase):
+    def setUp(self):
+        self.executor = Mock()
+        self.source_repo_provider = Mock()
+        self.binary_builder = Mock()
+
+        self.host = None
+        self.plugin_config_instance = PluginDescriptor(name="my-plugin", variables={
+            "source": {
+                "remote": {
+                    "repo": {
+                        "url": "https//fake.url.com"
+                    }
+                },
+                "revision": "current",
+                "build": {
+                    "command": "gradle build",
+                    "artifact": {
+                        "subdir": "plugin/subdir"
+                    }
+                },
+            }
+        })
+        self.plugin_src_dir = "/fake/dir/for/plugin"
+
+        self.external_plugin_source_downloader = ExternalPluginSourceDownloader(self.plugin_config_instance, self.executor,
+                                                                                self.source_repo_provider, self.binary_builder,
+                                                                                self.plugin_src_dir)
+
+    def test_download_with_build(self):
+        plugin_binary = self.external_plugin_source_downloader.download(self.host)
+        self.assertEqual(plugin_binary, {"my-plugin": "file:///fake/dir/for/plugin/plugin/subdir/*.zip"})
+        self.source_repo_provider.fetch_repository.assert_has_calls([
+            mock.call(self.host, "https//fake.url.com", "current", self.plugin_src_dir)
+        ])
+        self.binary_builder.build.assert_has_calls([
+            mock.call(self.host, ["gradle build"], override_source_directory=self.plugin_src_dir)
+        ])
+
+    def test_download_without_build(self):
+        self.binary_builder = None
+
+        plugin_binary = self.external_plugin_source_downloader.download(self.host)
+        self.assertEqual(plugin_binary, {"my-plugin": "file:///fake/dir/for/plugin/plugin/subdir/*.zip"})
+        self.source_repo_provider.fetch_repository.assert_has_calls([
+            mock.call(self.host, "https//fake.url.com", "current", self.plugin_src_dir)
+        ])

--- a/tests/builder/downloaders/repositories/plugin_distribution_repository_provider_test.py
+++ b/tests/builder/downloaders/repositories/plugin_distribution_repository_provider_test.py
@@ -18,5 +18,5 @@ class PluginDistributionRepositoryProviderTest(TestCase):
     def test_get_plugin_url(self):
         self.plugin_distro_repo_provider.get_download_url(self.host)
         self.plugin_distro_repo_provider.repository_url_provider.render_url_for_key.assert_has_calls([
-            mock.call(None, {"distribution": {"repository": "release"}}, "plugin.my-plugin.release.url", mandatory=False)
+            mock.call(None, {"distribution": {"repository": "release"}}, "distribution.release.remote.repo.url", mandatory=False)
         ])


### PR DESCRIPTION
### Description
Implements the ExternalPluginSourceDownloader. There is also a slight refactor to the url lookup in PluginDistributionRepositoryProvider from the config as I start thinking ahead to the PluginConfigInstance model structure.

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved
#134 
 
### Check List
- [ ] New functionality includes testing
  - [ ] All unit and integration tests pass
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).