### PR TITLE
Refactors for using BinaryKey enum, factory pattern, and creating ArtifactVariablesProvider helper class

### DIFF
--- a/osbenchmark/builder/downloaders/opensearch_distribution_downloader.py
+++ b/osbenchmark/builder/downloaders/opensearch_distribution_downloader.py
@@ -2,25 +2,21 @@ import logging
 import os.path
 
 from osbenchmark.builder.downloaders.downloader import Downloader
-from osbenchmark.builder.downloaders.repositories.opensearch_distribution_repository_provider import \
-    OpenSearchDistributionRepositoryProvider
-from osbenchmark.builder.utils.path_manager import PathManager
+from osbenchmark.builder.utils.binary_keys import BinaryKeys
 from osbenchmark.exceptions import ExecutorError
 
 
 class OpenSearchDistributionDownloader(Downloader):
-    BINARY_KEY = "opensearch"
-
-    def __init__(self, provision_config_instance, executor):
+    def __init__(self, provision_config_instance, executor, path_manager, distribution_repository_provider):
         super().__init__(executor)
         self.logger = logging.getLogger(__name__)
         self.provision_config_instance = provision_config_instance
-        self.path_manager = PathManager(executor)
-        self.distribution_repository_provider = OpenSearchDistributionRepositoryProvider(provision_config_instance, executor)
+        self.path_manager = path_manager
+        self.distribution_repository_provider = distribution_repository_provider
 
     def download(self, host):
         binary_path = self._fetch_binary(host)
-        return {OpenSearchDistributionDownloader.BINARY_KEY: binary_path}
+        return {BinaryKeys.OPENSEARCH: binary_path}
 
     def _fetch_binary(self, host):
         download_url = self.distribution_repository_provider.get_download_url(host)

--- a/osbenchmark/builder/downloaders/plugin_distribution_downloader.py
+++ b/osbenchmark/builder/downloaders/plugin_distribution_downloader.py
@@ -1,13 +1,11 @@
 from osbenchmark.builder.downloaders.downloader import Downloader
-from osbenchmark.builder.downloaders.repositories.plugin_distribution_repository_provider import \
-    PluginDistributionRepositoryProvider
 
 
 class PluginDistributionDownloader(Downloader):
-    def __init__(self, plugin, executor):
+    def __init__(self, plugin, executor, distribution_repository_provider):
         super().__init__(executor)
         self.plugin = plugin
-        self.distribution_repository_provider = PluginDistributionRepositoryProvider(plugin, executor)
+        self.distribution_repository_provider = distribution_repository_provider
 
     def download(self, host):
         plugin_url = self.distribution_repository_provider.get_download_url(host)

--- a/osbenchmark/builder/downloaders/repositories/opensearch_distribution_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/opensearch_distribution_repository_provider.py
@@ -1,15 +1,13 @@
 import logging
 
-from osbenchmark.builder.downloaders.repositories.repository_url_provider import RepositoryUrlProvider
 from osbenchmark.utils import convert
 
 
 class OpenSearchDistributionRepositoryProvider:
-    def __init__(self, provision_config_instance, executor):
+    def __init__(self, provision_config_instance, repository_url_provider):
         self.logger = logging.getLogger(__name__)
         self.provision_config_instance = provision_config_instance
-        self.executor = executor
-        self.repository_url_provider = RepositoryUrlProvider(executor)
+        self.repository_url_provider = repository_url_provider
 
     def get_download_url(self, host):
         is_runtime_jdk_bundled = self.provision_config_instance.variables["system"]["runtime"]["jdk"]["bundled"]

--- a/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/plugin_distribution_repository_provider.py
@@ -1,10 +1,7 @@
-from osbenchmark.builder.downloaders.repositories.repository_url_provider import RepositoryUrlProvider
-
-
 class PluginDistributionRepositoryProvider:
-    def __init__(self, plugin, executor):
+    def __init__(self, plugin, repository_url_provider):
         self.plugin = plugin
-        self.repository_url_provider = RepositoryUrlProvider(executor)
+        self.repository_url_provider = repository_url_provider
 
     def get_download_url(self, host):
         distribution_repository = self.plugin.variables["distribution"]["repository"]

--- a/osbenchmark/builder/downloaders/repositories/repository_url_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/repository_url_provider.py
@@ -1,18 +1,12 @@
 from functools import reduce
 
-from osbenchmark.builder.utils.template_renderer import TemplateRenderer
 from osbenchmark.exceptions import SystemSetupError
-
-ARCH_MAPPINGS = {
-    "x86_64": "x64",
-    "aarch64": "arm64"
-}
 
 
 class RepositoryUrlProvider:
-    def __init__(self, executor):
-        self.executor = executor
-        self.template_renderer = TemplateRenderer()
+    def __init__(self, template_renderer, artifact_variables_provider):
+        self.template_renderer = template_renderer
+        self.artifact_variables_provider = artifact_variables_provider
 
     def render_url_for_key(self, host, config_variables, key, mandatory=True):
         try:
@@ -22,22 +16,10 @@ class RepositoryUrlProvider:
                 raise SystemSetupError(f"Config key [{key}] is not defined.")
             else:
                 return None
-        return self.template_renderer.render_template_string(url_template, self._get_url_template_variables(host, config_variables))
+
+        artifact_version = config_variables["distribution"]["version"]
+        artifact_variables = self.artifact_variables_provider.get_artifact_variables(host, artifact_version)
+        return self.template_renderer.render_template_string(url_template, artifact_variables)
 
     def _get_value_from_dot_notation_key(self, dict_object, key):
         return reduce(dict.get, key.split("."), dict_object)
-
-    def _get_url_template_variables(self, host, config_variables):
-        return {
-            "VERSION": config_variables["distribution"]["version"],
-            "OSNAME": self._get_os_name(host),
-            "ARCH": self._get_arch(host)
-        }
-
-    def _get_os_name(self, host):
-        os_name = self.executor.execute(host, "uname", output=True)[0]
-        return os_name.lower()
-
-    def _get_arch(self, host):
-        arch = self.executor.execute(host, "uname -m", output=True)[0]
-        return ARCH_MAPPINGS[arch.lower()]

--- a/osbenchmark/builder/installers/preparers/opensearch_preparer.py
+++ b/osbenchmark/builder/installers/preparers/opensearch_preparer.py
@@ -4,13 +4,12 @@ import uuid
 
 from osbenchmark.builder.installers.preparers.preparer import Preparer
 from osbenchmark.builder.models.node import Node
+from osbenchmark.builder.utils.binary_keys import BinaryKeys
 from osbenchmark.builder.utils.host_cleaner import HostCleaner
 from osbenchmark.builder.utils.path_manager import PathManager
 
 
 class OpenSearchPreparer(Preparer):
-    OPENSEARCH_BINARY_KEY = "opensearch"
-
     def __init__(self, provision_config_instance, executor, hook_handler_class):
         super().__init__(executor)
         self.logger = logging.getLogger(__name__)
@@ -23,7 +22,7 @@ class OpenSearchPreparer(Preparer):
 
     def prepare(self, host, binaries):
         node = self._create_node()
-        self._prepare_node(host, node, binaries[OpenSearchPreparer.OPENSEARCH_BINARY_KEY])
+        self._prepare_node(host, node, binaries[BinaryKeys.OPENSEARCH])
 
         return node
 

--- a/osbenchmark/builder/models/architecture_types.py
+++ b/osbenchmark/builder/models/architecture_types.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class ArchitectureTypes(Enum):
+    """
+    Represents a machine's architecture type
+
+    :param hardware_name: The value returned by the machine when querying the architecture. Obtained via `uname -m` for unix machines
+    ;param opensearch_name: The value used by opensearch artifacts to represent the architecture
+    """
+
+    def __init__(self, hardware_name, opensearch_name):
+        self.hardware_name = hardware_name
+        self.opensearch_name = opensearch_name
+
+    ARM = "aarch64", "arm64"
+    x86 = "x86_64", "x64"
+
+    @staticmethod
+    def get_from_hardware_name(hardware_name):
+        for arch_type in ArchitectureTypes:
+            if arch_type.hardware_name == hardware_name:
+                return arch_type
+
+        raise ValueError

--- a/osbenchmark/builder/utils/artifact_variables_provider.py
+++ b/osbenchmark/builder/utils/artifact_variables_provider.py
@@ -1,0 +1,24 @@
+ARCH_MAPPINGS = {
+    "x86_64": "x64",
+    "aarch64": "arm64"
+}
+
+
+class ArtifactVariablesProvider:
+    def __init__(self, executor):
+        self.executor = executor
+
+    def get_artifact_variables(self, host, opensearch_version=None):
+        return {
+            "VERSION": opensearch_version,
+            "OSNAME": self._get_os_name(host),
+            "ARCH": self._get_arch(host)
+        }
+
+    def _get_os_name(self, host):
+        os_name = self.executor.execute(host, "uname", output=True)[0]
+        return os_name.lower()
+
+    def _get_arch(self, host):
+        arch = self.executor.execute(host, "uname -m", output=True)[0]
+        return ARCH_MAPPINGS[arch.lower()]

--- a/osbenchmark/builder/utils/artifact_variables_provider.py
+++ b/osbenchmark/builder/utils/artifact_variables_provider.py
@@ -1,7 +1,4 @@
-ARCH_MAPPINGS = {
-    "x86_64": "x64",
-    "aarch64": "arm64"
-}
+from osbenchmark.builder.models.architecture_types import ArchitectureTypes
 
 
 class ArtifactVariablesProvider:
@@ -21,4 +18,4 @@ class ArtifactVariablesProvider:
 
     def _get_arch(self, host):
         arch = self.executor.execute(host, "uname -m", output=True)[0]
-        return ARCH_MAPPINGS[arch.lower()]
+        return ArchitectureTypes.get_from_hardware_name(arch.lower()).opensearch_name

--- a/osbenchmark/builder/utils/binary_keys.py
+++ b/osbenchmark/builder/utils/binary_keys.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class BinaryKeys(str, Enum):
+    OPENSEARCH = "opensearch"

--- a/tests/builder/downloaders/opensearch_distribution_downloader_test.py
+++ b/tests/builder/downloaders/opensearch_distribution_downloader_test.py
@@ -22,9 +22,11 @@ class OpenSearchDistributionDownloaderTest(TestCase):
             }
         })
 
-        self.os_distro_downloader = OpenSearchDistributionDownloader(self.provision_config_instance, self.executor)
-        self.os_distro_downloader.path_manager = Mock()
-        self.os_distro_downloader.distribution_repository_provider = Mock()
+        self.path_manager = Mock()
+        self.distribution_repository_provider = Mock()
+        self.os_distro_downloader = OpenSearchDistributionDownloader(self.provision_config_instance, self.executor, self.path_manager,
+                                                                     self.distribution_repository_provider)
+
 
         self.os_distro_downloader.distribution_repository_provider.get_download_url.return_value = "https://fake/download.tar.gz"
         self.os_distro_downloader.distribution_repository_provider.get_file_name_from_download_url.return_value = "my-distro"

--- a/tests/builder/downloaders/plugin_distribution_downloader_test.py
+++ b/tests/builder/downloaders/plugin_distribution_downloader_test.py
@@ -12,8 +12,8 @@ class PluginDistributionDownloaderTest(TestCase):
         self.executor = Mock()
         self.plugin = PluginDescriptor(name="my plugin")
 
-        self.plugin_distro_downloader = PluginDistributionDownloader(self.plugin, self.executor)
-        self.plugin_distro_downloader.distribution_repository_provider = Mock()
+        self.distribution_repository_provider = Mock()
+        self.plugin_distro_downloader = PluginDistributionDownloader(self.plugin, self.executor, self.distribution_repository_provider)
 
     def test_plugin_url_exists(self):
         self.plugin_distro_downloader.distribution_repository_provider.get_download_url.return_value = "https://fake"

--- a/tests/builder/downloaders/repositories/opensearch_distribution_repository_provider_test.py
+++ b/tests/builder/downloaders/repositories/opensearch_distribution_repository_provider_test.py
@@ -8,8 +8,6 @@ from osbenchmark.builder.provision_config import ProvisionConfigInstance
 
 class OpenSearchDistributionRepositoryProviderTest(TestCase):
     def setUp(self):
-        self.executor = Mock()
-
         self.host = None
         self.provision_config_instance = ProvisionConfigInstance(names=None, config_paths=None, root_path=None, variables={
             "system": {
@@ -26,8 +24,10 @@ class OpenSearchDistributionRepositoryProviderTest(TestCase):
                 }
             }
         })
-        self.os_distro_repo_provider = OpenSearchDistributionRepositoryProvider(self.provision_config_instance, self.executor)
-        self.os_distro_repo_provider.repository_url_provider = Mock()
+        self.repository_url_provider = Mock()
+        self.os_distro_repo_provider = OpenSearchDistributionRepositoryProvider(self.provision_config_instance,
+                                                                                self.repository_url_provider)
+
 
     def test_get_url_bundled_jdk(self):
         self.os_distro_repo_provider.get_download_url(self.host)

--- a/tests/builder/downloaders/repositories/plugin_distribution_repository_provider_test.py
+++ b/tests/builder/downloaders/repositories/plugin_distribution_repository_provider_test.py
@@ -8,12 +8,11 @@ from osbenchmark.builder.provision_config import PluginDescriptor
 
 class PluginDistributionRepositoryProviderTest(TestCase):
     def setUp(self):
-        self.executor = Mock()
-
         self.host = None
         self.plugin = PluginDescriptor(name="my-plugin", variables={"distribution": {"repository": "release"}})
-        self.plugin_distro_repo_provider = PluginDistributionRepositoryProvider(self.plugin, self.executor)
-        self.plugin_distro_repo_provider.repository_url_provider = Mock()
+        self.repository_url_provider = Mock()
+        self.plugin_distro_repo_provider = PluginDistributionRepositoryProvider(self.plugin, self.repository_url_provider)
+
 
     def test_get_plugin_url(self):
         self.plugin_distro_repo_provider.get_download_url(self.host)

--- a/tests/builder/installers/preparers/opensearch_preparer_test.py
+++ b/tests/builder/installers/preparers/opensearch_preparer_test.py
@@ -6,6 +6,7 @@ from osbenchmark.builder.installers.preparers.opensearch_preparer import OpenSea
 from osbenchmark.builder.models.host import Host
 from osbenchmark.builder.models.node import Node
 from osbenchmark.builder.provision_config import ProvisionConfigInstance
+from osbenchmark.builder.utils.binary_keys import BinaryKeys
 
 
 class OpenSearchPreparerTests(TestCase):
@@ -15,7 +16,7 @@ class OpenSearchPreparerTests(TestCase):
                          name=self.node_id, pid=None, telemetry=None, port=9200, root_dir=None,
                          log_path="/fake/logpath", heap_dump_path="/fake/heap")
         self.host = Host(name="fake", address="10.17.22.23", metadata={}, node=None)
-        self.binaries = {OpenSearchPreparer.OPENSEARCH_BINARY_KEY: "/data/builds/distributions"}
+        self.binaries = {BinaryKeys.OPENSEARCH: "/data/builds/distributions"}
         self.all_node_ips = ["10.17.22.22", "10.17.22.23"]
 
         self.test_execution_root = "fake_root"

--- a/tests/builder/utils/artifact_variables_provider_test.py
+++ b/tests/builder/utils/artifact_variables_provider_test.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from osbenchmark.builder.utils.artifact_variables_provider import ArtifactVariablesProvider
+
+
+class ArtifactVariablesProviderTest(TestCase):
+    def setUp(self):
+        self.host = None
+
+        self.executor = Mock()
+        self.artifact_variables_provider = ArtifactVariablesProvider(self.executor)
+
+    def test_x86(self):
+        self.executor.execute.side_effect = [["Linux"], ["x86_64"]]
+        variables = self.artifact_variables_provider.get_artifact_variables(self.host)
+
+        self.assertEqual(variables, {
+            "VERSION": None,
+            "OSNAME": "linux",
+            "ARCH": "x64"
+        })
+
+    def test_arm(self):
+        self.executor.execute.side_effect = [["Linux"], ["aarch64"]]
+        variables = self.artifact_variables_provider.get_artifact_variables(self.host)
+
+        self.assertEqual(variables, {
+            "VERSION": None,
+            "OSNAME": "linux",
+            "ARCH": "arm64"
+        })
+
+    def test_version_supplied(self):
+        self.executor.execute.side_effect = [["Linux"], ["aarch64"]]
+        variables = self.artifact_variables_provider.get_artifact_variables(self.host, "1.23")
+
+        self.assertEqual(variables, {
+            "VERSION": "1.23",
+            "OSNAME": "linux",
+            "ARCH": "arm64"
+        })


### PR DESCRIPTION
### Description
This PR creates the `ArtifactVariablesProvider` helper class which populates a dict with variables for version, arch, and osname. As part of breaking the logic for `ArtifactVariablesProvider` out of `RepositoryUrlProvider`, some minor refactoring was required. I took it a bit further and did the following:
* Remove instances of initialization in constructors for the distribution downloader classes, instead will use factory pattern
* Create new enum BinaryKeys to store the keys for the binaries map, replaced hard coded "opensearch" with reference to the appropriate binary key
 
 
### Check List
- [x] New functionality includes testing
  - [x] All unit and integration tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).