### PR TITLE
Change bulk operation for metrics and index templates to support Open…

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -27,7 +27,6 @@ import glob
 import json
 import logging
 import math
-import opensearchpy.helpers
 import os
 import pickle
 import random
@@ -37,7 +36,7 @@ import time
 import zlib
 from enum import Enum, IntEnum
 from http.client import responses
-
+import opensearchpy.helpers
 import tabulate
 
 from osbenchmark import client, time, exceptions, config, version, paths

--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -9,90 +9,88 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "@timestamp": {
+        "type": "date",
+        "format": "epoch_millis"
       },
-      "properties": {
-        "@timestamp": {
-          "type": "date",
-          "format": "epoch_millis"
-        },
-        "relative-time-ms": {
-          "type": "float"
-        },
-        "test-execution-id": {
-          "type": "keyword"
-        },
-        "test-execution-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "relative-time-ms": {
+        "type": "float"
+      },
+      "test-execution-id": {
+        "type": "keyword"
+      },
+      "test-execution-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "workload": {
-          "type": "keyword"
-        },
-        "test_procedure": {
-          "type": "keyword"
-        },
-        "provision-config-instance": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "value": {
-          "type": "float"
-        },
-        "min": {
-          "type": "float"
-        },
-        "max": {
-          "type": "float"
-        },
-        "mean": {
-          "type": "float"
-        },
-        "median": {
-          "type": "float"
-        },
-        "unit": {
-          "type": "keyword"
-        },
-        "sample-type": {
-          "type": "keyword"
-        },
-        "task": {
-          "type": "keyword"
-        },
-        "operation": {
-          "type": "keyword"
-        },
-        "operation-type": {
-          "type": "keyword"
-        },
-        "job": {
-          "type": "keyword"
         }
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "workload": {
+        "type": "keyword"
+      },
+      "test_procedure": {
+        "type": "keyword"
+      },
+      "provision-config-instance": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "float"
+      },
+      "min": {
+        "type": "float"
+      },
+      "max": {
+        "type": "float"
+      },
+      "mean": {
+        "type": "float"
+      },
+      "median": {
+        "type": "float"
+      },
+      "unit": {
+        "type": "keyword"
+      },
+      "sample-type": {
+        "type": "keyword"
+      },
+      "task": {
+        "type": "keyword"
+      },
+      "operation": {
+        "type": "keyword"
+      },
+      "operation-type": {
+        "type": "keyword"
+      },
+      "job": {
+        "type": "keyword"
       }
     }
   }

--- a/osbenchmark/resources/results-template.json
+++ b/osbenchmark/resources/results-template.json
@@ -9,101 +9,99 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "test-execution-id": {
+        "type": "keyword"
       },
-      "properties": {
-        "test-execution-id": {
-          "type": "keyword"
-        },
-        "test-execution-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "test-execution-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "active": {
-          "type": "boolean"
-        },
-        "benchmark-version": {
-          "type": "keyword"
-        },
-        "benchmark-revision": {
-          "type": "keyword"
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "workload": {
-          "type": "keyword"
-        },
-        "test_procedure": {
-          "type": "keyword"
-        },
-        "provision-config-instance": {
-          "type": "keyword"
-        },
-        "node-count": {
-          "type": "short"
-        },
-        "plugins": {
-          "type": "keyword"
-        },
-        "distribution-flavor": {
-          "type": "keyword"
-        },
-        "distribution-version": {
-          "type": "keyword"
-        },
-        "distribution-major-version": {
-          "type": "short"
-        },
-        "task": {
-          "type": "keyword"
-        },
-        "operation": {
-          "type": "keyword"
-        },
-        "job": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "value": {
-          "type": "object",
-          "properties": {
-            "single": {
-              "type": "double"
-            },
-            "min": {
-              "type": "double"
-            },
-            "mean": {
-              "type": "double"
-            },
-            "median": {
-              "type": "double"
-            },
-            "max": {
-              "type": "double"
-            }
+        }
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "benchmark-version": {
+        "type": "keyword"
+      },
+      "benchmark-revision": {
+        "type": "keyword"
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "workload": {
+        "type": "keyword"
+      },
+      "test_procedure": {
+        "type": "keyword"
+      },
+      "provision-config-instance": {
+        "type": "keyword"
+      },
+      "node-count": {
+        "type": "short"
+      },
+      "plugins": {
+        "type": "keyword"
+      },
+      "distribution-flavor": {
+        "type": "keyword"
+      },
+      "distribution-version": {
+        "type": "keyword"
+      },
+      "distribution-major-version": {
+        "type": "short"
+      },
+      "task": {
+        "type": "keyword"
+      },
+      "operation": {
+        "type": "keyword"
+      },
+      "job": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "object",
+        "properties": {
+          "single": {
+            "type": "double"
+          },
+          "min": {
+            "type": "double"
+          },
+          "mean": {
+            "type": "double"
+          },
+          "median": {
+            "type": "double"
+          },
+          "max": {
+            "type": "double"
           }
         }
       }

--- a/osbenchmark/resources/test-executions-template.json
+++ b/osbenchmark/resources/test-executions-template.json
@@ -9,67 +9,65 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "test-execution-id": {
+        "type": "keyword"
       },
-      "properties": {
-        "test-execution-id": {
-          "type": "keyword"
-        },
-        "test-execution-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "test-execution-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "benchmark-version": {
-          "type": "keyword"
-        },
-        "benchmark-revision": {
-          "type": "keyword"
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "pipeline": {
-          "type": "keyword"
-        },
-        "workload": {
-          "type": "keyword"
-        },
-        "test_procedure": {
-          "type": "keyword"
-        },
-        "provision-config-instance": {
-          "type": "keyword"
-        },
-        "node-count": {
-          "type": "short"
-        },
-        "plugins": {
-          "type": "keyword"
-        },
-        "results": {
-          "properties": {
-            "op_metrics": {
-              "type": "nested"
-            }
+        }
+      },
+      "benchmark-version": {
+        "type": "keyword"
+      },
+      "benchmark-revision": {
+        "type": "keyword"
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "pipeline": {
+        "type": "keyword"
+      },
+      "workload": {
+        "type": "keyword"
+      },
+      "test_procedure": {
+        "type": "keyword"
+      },
+      "provision-config-instance": {
+        "type": "keyword"
+      },
+      "node-count": {
+        "type": "short"
+      },
+      "plugins": {
+        "type": "keyword"
+      },
+      "results": {
+        "properties": {
+          "op_metrics": {
+            "type": "nested"
           }
         }
       }


### PR DESCRIPTION
…Search 2.0 as a data store

Signed-off-by: travisbenedict <travisrb10@gmail.com>

### Description
Add support for OpenSearch 2.0 as a metrics data store by updating the MDS index templates, removing the `doc_type` argument from bulk requests and removing `include_type_name` from put template requests. 

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-benchmark/issues/150
 
### Check List
- [ ] New functionality includes testing
  - [ ] All unit and integration tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).