### PR TITLE
Update MAINTAINERS.md and create CODEOWNERS to meet format for opensearch-project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ianhoang @gkamat

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,8 +7,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer        | GitHub ID                                             | Affiliation |
 | ----------------- | ----------------------------------------------------- | ----------- |
 | Ian Hoang         | [ianhoang](https://github.com/ianhoang)               | Amazon      |
-| Achit Ojha        | [achitojha](https://github.com/achitojha)             | Amazon      |
-| Travis Benedict   | [travisbenedict](https://github.com/travisbenedict)   | Amazon      |
-| Chase Engelbrecht | [engechas](https://github.com/engechas)               | Amazon      |
 | Govind Kamat      | [gkamat](https://github.com/gkamat)                   | Amazon      |
-| Phill Treddenick  | [treddeni-amazon](https://github.com/treddeni-amazon) | Amazon      |


### PR DESCRIPTION


### Description
Updated MAINTAINERS.md to reflect the active maintainers. Also created a CODEOWNERS in `.github` directory and added active maintainers there as suggested in the issue.

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/217

### Testing
- [ ] New functionality includes testing

This doesn't affect testing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
