### PR TITLE
Add Dockerfile Bug Fix and additional updates to Dockerfile / README.md

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.url="https://opensearch.org/" \
   org.label-schema.version=“0.2.0” \
   org.label-schema.license=“Apache-2.0” \
-  org.label-schema.description=“About OpenSearch Benchmark - a community driven, open source project to run performance tests for OpenSearch” \
+  org.label-schema.description=“A community driven, open source project to run performance tests for OpenSearch” \
   org.label-schema.build-date=“2023-03-23T20:00:00Z”
   org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="/opensearch-benchmark/venv/bin:$PATH"
 
 WORKDIR /opensearch-benchmark
 # Wipe away any lingering caches, copied over from the local machine
-RUN find /opensearch-benchmark -name "__pycache__" -exec rm -rf -- \{\} \; 2>/dev/null || true
-RUN find /opensearch-benchmark -name ".pyc" -exec rm -rf -- \{\} \; 2>/dev/null || true
+RUN find ./opensearch-benchmark -name '__pycache__' -o -name '*.pyc' | xargs rm -f
 RUN python3 -m pip install --upgrade pip setuptools wheel
 RUN python3 -m pip install /opensearch-benchmark
 
@@ -62,6 +61,6 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="OpenSearch-Project" \
   org.label-schema.name="opensearch-benchmark" \
   org.label-schema.url="https://opensearch.org/docs" \
-  org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark" \
+  org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark"
 
 VOLUME ["/opensearch-benchmark/.benchmark"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,8 +34,7 @@ RUN python3 -m pip install /opensearch-benchmark
 ################################################################################
 
 FROM python:3.11.2-slim
-ARG BENCHMARK_VERSION
-ARG BENCHMARK_LICENSE
+ARG VERSION
 ENV BENCHMARK_RUNNING_IN_DOCKER True
 
 RUN apt-get -y update && \
@@ -60,7 +59,11 @@ ENV PATH=/opensearch-benchmark/venv/bin:$PATH
 LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="OpenSearch-Project" \
   org.label-schema.name="opensearch-benchmark" \
-  org.label-schema.url="https://opensearch.org/docs" \
+  org.label-schema.url="https://opensearch.org/" \
+  org.label-schema.version=“0.2.0” \
+  org.label-schema.license=“Apache-2.0” \
+  org.label-schema.description=“About OpenSearch Benchmark - a community driven, open source project to run performance tests for OpenSearch” \
+  org.label-schema.build-date=“2023-03-23T20:00:00Z”
   org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark"
 
 VOLUME ["/opensearch-benchmark/.benchmark"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,10 +2,10 @@
 
 This Docker image allows users to spin up a Docker container preloaded with essential dependencies and get started with OpenSearch Benchmark faster.
 
-# Running OpenSearch Benchmark Image
-**Prerequisite:** Ensure that Docker is installed in the command line.
+# Running the OpenSearch Benchmark Image
+**Prerequisite:** Ensure that Docker is installed. If not, refer to [this guide to download Docker Desktop](https://docs.docker.com/get-docker/) or [this guide to download Docker Engine](https://docs.docker.com/engine/install/).
 1. Run the command `docker pull opensearchproject/opensearch-benchmark`. Docker will pull in the image on your host
-2. To run the image to start a container, run the command `docker run opensearchproject/opensearch-benchmark`
+2. To run the image and start a Docker container, run the command `docker run opensearchproject/opensearch-benchmark`
 
 # Building a Copy of OpenSearch Benchmark Image
 1. Git clone OpenSearch Benchmark Github repository


### PR DESCRIPTION
### Description
There was a bug introduced in the Dockerfile in the previous PR (#236). This was noticed after the previous PR was merged into main. Bug was discovered when I was making extra edits to Dockerfile. When I tried building the Dockerfile, I received the following error: 
```
failed to solve with frontend dockerfile.v0: failed to create LLB definition: Syntax error - can't find = in "VOLUME". Must be of the form: name=value
```

This PR fixes that bug and introduces a few more suggested edits to Dockerfile and README.md.

Changes:
- Remove extra `\` at the end of line 65 in Dockerfile
https://github.com/opensearch-project/opensearch-benchmark/blob/27cb82a40ecc6d04c125fbb155331722e18f8052/docker/Dockerfile#L65
- Simplify two `RUN` commands in Dockerfile with 
```
RUN find ./opensearch-benchmark -name '__pycache__' -o -name '*.pyc' | xargs rm -f
```
- Add .dockerignore
- Update README.md

### Issues Resolved
#221 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
- Applied change
- Successfully built Docker image and ran it to start a Docker container
- Verified OSB 0.2.0 and Python 3.11.2 was installed
- Ran OSB geonames workload with ingestion only
- Received successful test
```

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Downloading workload data (252.9 MB total size)                            [100.0%]
[INFO] Decompressing workload data from [/opensearch-benchmark/.benchmark/benchmarks/data/geonames/documents-2.json.bz2] to [/opensearch-benchmark/.benchmark/benchmarks/data/geonames/documents-2.json] (resulting size: [3.30] GB) ... [OK]
[INFO] Preparing file offset table for [/opensearch-benchmark/.benchmark/benchmarks/data/geonames/documents-2.json] ... [OK]
[INFO] Executing test with workload [geonames], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [1.1.0].

[WARNING] merges_total_time is 94 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 55 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 209 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 16 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running create-index                                                           [100% done]
Running index-append                                                           [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |         Task |     Value |   Unit |
|---------------------------------------------------------------:|-------------:|----------:|-------:|
|                     Cumulative indexing time of primary shards |              |   20.2959 |    min |
|             Min cumulative indexing time across primary shards |              |         0 |    min |
|          Median cumulative indexing time across primary shards |              |   3.74047 |    min |
|             Max cumulative indexing time across primary shards |              |   4.54037 |    min |
|            Cumulative indexing throttle time of primary shards |              |         0 |    min |
|    Min cumulative indexing throttle time across primary shards |              |         0 |    min |
| Median cumulative indexing throttle time across primary shards |              |         0 |    min |
|    Max cumulative indexing throttle time across primary shards |              |         0 |    min |
|                        Cumulative merge time of primary shards |              |   0.20395 |    min |
|                       Cumulative merge count of primary shards |              |         7 |        |
|                Min cumulative merge time across primary shards |              |         0 |    min |
|             Median cumulative merge time across primary shards |              | 0.0268167 |    min |
|                Max cumulative merge time across primary shards |              | 0.0554167 |    min |
|               Cumulative merge throttle time of primary shards |              |         0 |    min |
|       Min cumulative merge throttle time across primary shards |              |         0 |    min |
|    Median cumulative merge throttle time across primary shards |              |         0 |    min |
|       Max cumulative merge throttle time across primary shards |              |         0 |    min |
|                      Cumulative refresh time of primary shards |              |    1.6519 |    min |
|                     Cumulative refresh count of primary shards |              |       216 |        |
|              Min cumulative refresh time across primary shards |              |         0 |    min |
|           Median cumulative refresh time across primary shards |              |  0.282867 |    min |
|              Max cumulative refresh time across primary shards |              |  0.485967 |    min |
|                        Cumulative flush time of primary shards |              |  0.991233 |    min |
|                       Cumulative flush count of primary shards |              |         8 |        |
|                Min cumulative flush time across primary shards |              |         0 |    min |
|             Median cumulative flush time across primary shards |              |  0.107867 |    min |
|                Max cumulative flush time across primary shards |              |  0.463783 |    min |
|                                        Total Young Gen GC time |              |     5.233 |      s |
|                                       Total Young Gen GC count |              |       268 |        |
|                                          Total Old Gen GC time |              |         0 |      s |
|                                         Total Old Gen GC count |              |         0 |        |
|                                                     Store size |              |   2.10277 |     GB |
|                                                  Translog size |              |   1.51716 |     GB |
|                                         Heap used for segments |              |  0.491123 |     MB |
|                                       Heap used for doc values |              | 0.0254936 |     MB |
|                                            Heap used for terms |              |  0.379974 |     MB |
|                                            Heap used for norms |              | 0.0517578 |     MB |
|                                           Heap used for points |              |         0 |     MB |
|                                    Heap used for stored fields |              | 0.0338974 |     MB |
|                                                  Segment count |              |        69 |        |
|                                                 Min Throughput | index-append |   31439.9 | docs/s |
|                                                Mean Throughput | index-append |     32898 | docs/s |
|                                              Median Throughput | index-append |     32816 | docs/s |
|                                                 Max Throughput | index-append |   34825.3 | docs/s |
|                                        50th percentile latency | index-append |     977.5 |     ms |
|                                        90th percentile latency | index-append |    1781.7 |     ms |
|                                        99th percentile latency | index-append |   5256.87 |     ms |
|                                      99.9th percentile latency | index-append |   10780.5 |     ms |
|                                       100th percentile latency | index-append |   10937.8 |     ms |
|                                   50th percentile service time | index-append |     977.5 |     ms |
|                                   90th percentile service time | index-append |    1781.7 |     ms |
|                                   99th percentile service time | index-append |   5256.87 |     ms |
|                                 99.9th percentile service time | index-append |   10780.5 |     ms |
|                                  100th percentile service time | index-append |   10937.8 |     ms |
|                                                     error rate | index-append |      0.43 |      % |

[WARNING] Error rate is 0.43 for operation 'index-append'. Please check the logs.

---------------------------------
[INFO] SUCCESS (took 512 seconds)
---------------------------------
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
