### PR TITLE
Display help text when no arguments passed

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -102,6 +102,10 @@ def create_arg_parser():
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     subparsers = parser.add_subparsers(
         title="subcommands",
         dest="subcommand",


### PR DESCRIPTION
### Description
Currently OSB prints out an error when users invoke `opensearch-benchmark` only. This PR enables OSB to display the help message when no arguments are passed. 
Before suggested change:
```
$ opensearch-benchmark
Traceback (most recent call last):
  File "/home/ec2-user/.local/bin/opensearch-benchmark", line 8, in <module>
    sys.exit(main())
  File "/home/ec2-user/.local/lib/python3.9/site-packages/osbenchmark/benchmark.py", line 949, in main
    console.init(quiet=args.quiet)
AttributeError: 'Namespace' object has no attribute 'quiet'
```
After suggested change:
```
hoangia@3c22fbd0d988 opensearch-benchmark % opensearch-benchmark
usage: opensearch-benchmark [-h] [--version]

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

 A benchmarking tool for OpenSearch

options:
  -h, --help  show this help message and exit
  --version   show program's version number and exit

Find out more about Benchmark at https://opensearch.org/docs
```

### Issues Resolved
#237 

### Testing
- [x] New functionality includes testing

- Ran Unittests 
- Ran opensearch-benchmark test in test-mode
- Ran basic test execution with OpenSearch 1.0.0 distribution

Basic test execution with OpenSearch 1.0.0 distribution 
```
hoangia@3c22fbd0d988 opensearch-benchmark % opensearch-benchmark execute_test --distribution-version=1.0.0 --workload=geonames --test-mode


   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Preparing for test execution ...
[INFO] Downloading OpenSearch 1.0.0 (411.1 MB total size)                           [100%]
[INFO] Downloading workload data (20.5 kB total size)                             [100.0%]
[INFO] Decompressing workload data from [/Users/hoangia/.benchmark/benchmarks/data/geonames/documents-2-1k.json.bz2] to [/Users/hoangia/.benchmark/benchmarks/data/geonames/documents-2-1k.json] ... [OK]
[INFO] Preparing file offset table for [/Users/hoangia/.benchmark/benchmarks/data/geonames/documents-2-1k.json] ... [OK]
[INFO] Executing test with workload [geonames], test_procedure [append-no-conflicts] and provision_config_instance ['defaults'] with version [1.0.0].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index-append                                                           [100% done]
Running refresh-after-index                                                    [100% done]
Running force-merge                                                            [100% done]
Running refresh-after-force-merge                                              [100% done]
Running wait-until-merges-finish                                               [100% done]
Running index-stats                                                            [100% done]
Running node-stats                                                             [100% done]
Running default                                                                [100% done]
Running term                                                                   [100% done]
Running phrase                                                                 [100% done]
Running country_agg_uncached                                                   [100% done]
Running country_agg_cached                                                     [100% done]
Running scroll                                                                 [100% done]
Running expression                                                             [100% done]
Running painless_static                                                        [100% done]
Running painless_dynamic                                                       [100% done]
Running decay_geo_gauss_function_score                                         [100% done]
Running decay_geo_gauss_script_score                                           [100% done]
Running field_value_function_score                                             [100% done]
Running field_value_script_score                                               [100% done]
Running large_terms                                                            [100% done]
Running large_filtered_terms                                                   [100% done]
Running large_prohibited_terms                                                 [100% done]
Running desc_sort_population                                                   [100% done]
Running asc_sort_population                                                    [100% done]
Running asc_sort_with_after_population                                         [100% done]
Running desc_sort_geonameid                                                    [100% done]
Running desc_sort_with_after_geonameid                                         [100% done]
Running asc_sort_geonameid                                                     [100% done]
Running asc_sort_with_after_geonameid                                          [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                           Task |       Value |    Unit |
|---------------------------------------------------------------:|-------------------------------:|------------:|--------:|
|                     Cumulative indexing time of primary shards |                                |      0.0532 |     min |
|             Min cumulative indexing time across primary shards |                                |  0.00548333 |     min |
|          Median cumulative indexing time across primary shards |                                |  0.00656667 |     min |
|             Max cumulative indexing time across primary shards |                                |   0.0264333 |     min |
|            Cumulative indexing throttle time of primary shards |                                |           0 |     min |
|    Min cumulative indexing throttle time across primary shards |                                |           0 |     min |
| Median cumulative indexing throttle time across primary shards |                                |           0 |     min |
|    Max cumulative indexing throttle time across primary shards |                                |           0 |     min |
|                        Cumulative merge time of primary shards |                                |           0 |     min |
|                       Cumulative merge count of primary shards |                                |           0 |         |
|                Min cumulative merge time across primary shards |                                |           0 |     min |
|             Median cumulative merge time across primary shards |                                |           0 |     min |
|                Max cumulative merge time across primary shards |                                |           0 |     min |
|               Cumulative merge throttle time of primary shards |                                |           0 |     min |
|       Min cumulative merge throttle time across primary shards |                                |           0 |     min |
|    Median cumulative merge throttle time across primary shards |                                |           0 |     min |
|       Max cumulative merge throttle time across primary shards |                                |           0 |     min |
|                      Cumulative refresh time of primary shards |                                |   0.0221667 |     min |
|                     Cumulative refresh count of primary shards |                                |          30 |         |
|              Min cumulative refresh time across primary shards |                                |     0.00285 |     min |
|           Median cumulative refresh time across primary shards |                                |      0.0034 |     min |
|              Max cumulative refresh time across primary shards |                                |     0.00895 |     min |
|                        Cumulative flush time of primary shards |                                |           0 |     min |
|                       Cumulative flush count of primary shards |                                |           0 |         |
|                Min cumulative flush time across primary shards |                                |           0 |     min |
|             Median cumulative flush time across primary shards |                                |           0 |     min |
|                Max cumulative flush time across primary shards |                                |           0 |     min |
|                                        Total Young Gen GC time |                                |       0.018 |       s |
|                                       Total Young Gen GC count |                                |           2 |         |
|                                          Total Old Gen GC time |                                |           0 |       s |
|                                         Total Old Gen GC count |                                |           0 |         |
|                                                     Store size |                                | 0.000557473 |      GB |
|                                                  Translog size |                                | 2.56114e-07 |      GB |
|                                         Heap used for segments |                                |    0.158394 |      MB |
|                                       Heap used for doc values |                                |   0.0175705 |      MB |
|                                            Heap used for terms |                                |    0.113525 |      MB |
|                                            Heap used for norms |                                |   0.0151978 |      MB |
|                                           Heap used for points |                                |           0 |      MB |
|                                    Heap used for stored fields |                                |   0.0121002 |      MB |
|                                                  Segment count |                                |          26 |         |
|                                                 Min Throughput |                   index-append |      1686.2 |  docs/s |
|                                                Mean Throughput |                   index-append |      1686.2 |  docs/s |
|                                              Median Throughput |                   index-append |      1686.2 |  docs/s |
|                                                 Max Throughput |                   index-append |      1686.2 |  docs/s |
|                                        50th percentile latency |                   index-append |     533.637 |      ms |
|                                       100th percentile latency |                   index-append |     804.877 |      ms |
|                                   50th percentile service time |                   index-append |     533.637 |      ms |
|                                  100th percentile service time |                   index-append |     804.877 |      ms |
|                                                     error rate |                   index-append |           0 |       % |
|                                                 Min Throughput |       wait-until-merges-finish |       39.07 |   ops/s |
|                                                Mean Throughput |       wait-until-merges-finish |       39.07 |   ops/s |
|                                              Median Throughput |       wait-until-merges-finish |       39.07 |   ops/s |
|                                                 Max Throughput |       wait-until-merges-finish |       39.07 |   ops/s |
|                                       100th percentile latency |       wait-until-merges-finish |     25.0307 |      ms |
|                                  100th percentile service time |       wait-until-merges-finish |     25.0307 |      ms |
|                                                     error rate |       wait-until-merges-finish |           0 |       % |
|                                                 Min Throughput |                    index-stats |       88.42 |   ops/s |
|                                                Mean Throughput |                    index-stats |       88.42 |   ops/s |
|                                              Median Throughput |                    index-stats |       88.42 |   ops/s |
|                                                 Max Throughput |                    index-stats |       88.42 |   ops/s |
|                                       100th percentile latency |                    index-stats |     19.2001 |      ms |
|                                  100th percentile service time |                    index-stats |     7.49804 |      ms |
|                                                     error rate |                    index-stats |           0 |       % |
|                                                 Min Throughput |                     node-stats |       85.32 |   ops/s |
|                                                Mean Throughput |                     node-stats |       85.32 |   ops/s |
|                                              Median Throughput |                     node-stats |       85.32 |   ops/s |
|                                                 Max Throughput |                     node-stats |       85.32 |   ops/s |
|                                       100th percentile latency |                     node-stats |     18.7108 |      ms |
|                                  100th percentile service time |                     node-stats |     6.64253 |      ms |
|                                                     error rate |                     node-stats |           0 |       % |
|                                                 Min Throughput |                        default |       12.49 |   ops/s |
|                                                Mean Throughput |                        default |       12.49 |   ops/s |
|                                              Median Throughput |                        default |       12.49 |   ops/s |
|                                                 Max Throughput |                        default |       12.49 |   ops/s |
|                                       100th percentile latency |                        default |     90.5016 |      ms |
|                                  100th percentile service time |                        default |     10.1879 |      ms |
|                                                     error rate |                        default |           0 |       % |
|                                                 Min Throughput |                           term |        78.3 |   ops/s |
|                                                Mean Throughput |                           term |        78.3 |   ops/s |
|                                              Median Throughput |                           term |        78.3 |   ops/s |
|                                                 Max Throughput |                           term |        78.3 |   ops/s |
|                                       100th percentile latency |                           term |     17.4888 |      ms |
|                                  100th percentile service time |                           term |      4.5026 |      ms |
|                                                     error rate |                           term |           0 |       % |
|                                                 Min Throughput |                         phrase |       44.39 |   ops/s |
|                                                Mean Throughput |                         phrase |       44.39 |   ops/s |
|                                              Median Throughput |                         phrase |       44.39 |   ops/s |
|                                                 Max Throughput |                         phrase |       44.39 |   ops/s |
|                                       100th percentile latency |                         phrase |     28.5227 |      ms |
|                                  100th percentile service time |                         phrase |     5.77905 |      ms |
|                                                     error rate |                         phrase |           0 |       % |
|                                                 Min Throughput |           country_agg_uncached |       15.02 |   ops/s |
|                                                Mean Throughput |           country_agg_uncached |       15.02 |   ops/s |
|                                              Median Throughput |           country_agg_uncached |       15.02 |   ops/s |
|                                                 Max Throughput |           country_agg_uncached |       15.02 |   ops/s |
|                                       100th percentile latency |           country_agg_uncached |     72.6533 |      ms |
|                                  100th percentile service time |           country_agg_uncached |     5.87177 |      ms |
|                                                     error rate |           country_agg_uncached |           0 |       % |
|                                                 Min Throughput |             country_agg_cached |       67.73 |   ops/s |
|                                                Mean Throughput |             country_agg_cached |       67.73 |   ops/s |
|                                              Median Throughput |             country_agg_cached |       67.73 |   ops/s |
|                                                 Max Throughput |             country_agg_cached |       67.73 |   ops/s |
|                                       100th percentile latency |             country_agg_cached |     34.9918 |      ms |
|                                  100th percentile service time |             country_agg_cached |     19.9631 |      ms |
|                                                     error rate |             country_agg_cached |           0 |       % |
|                                                 Min Throughput |                         scroll |       32.15 | pages/s |
|                                                Mean Throughput |                         scroll |       32.15 | pages/s |
|                                              Median Throughput |                         scroll |       32.15 | pages/s |
|                                                 Max Throughput |                         scroll |       32.15 | pages/s |
|                                       100th percentile latency |                         scroll |     89.1093 |      ms |
|                                  100th percentile service time |                         scroll |     26.4634 |      ms |
|                                                     error rate |                         scroll |           0 |       % |
|                                                 Min Throughput |                     expression |        7.48 |   ops/s |
|                                                Mean Throughput |                     expression |        7.48 |   ops/s |
|                                              Median Throughput |                     expression |        7.48 |   ops/s |
|                                                 Max Throughput |                     expression |        7.48 |   ops/s |
|                                       100th percentile latency |                     expression |     138.751 |      ms |
|                                  100th percentile service time |                     expression |     4.92239 |      ms |
|                                                     error rate |                     expression |           0 |       % |
|                                                 Min Throughput |                painless_static |        5.37 |   ops/s |
|                                                Mean Throughput |                painless_static |        5.37 |   ops/s |
|                                              Median Throughput |                painless_static |        5.37 |   ops/s |
|                                                 Max Throughput |                painless_static |        5.37 |   ops/s |
|                                       100th percentile latency |                painless_static |      190.91 |      ms |
|                                  100th percentile service time |                painless_static |     4.67129 |      ms |
|                                                     error rate |                painless_static |           0 |       % |
|                                                 Min Throughput |               painless_dynamic |       21.01 |   ops/s |
|                                                Mean Throughput |               painless_dynamic |       21.01 |   ops/s |
|                                              Median Throughput |               painless_dynamic |       21.01 |   ops/s |
|                                                 Max Throughput |               painless_dynamic |       21.01 |   ops/s |
|                                       100th percentile latency |               painless_dynamic |     54.0805 |      ms |
|                                  100th percentile service time |               painless_dynamic |      6.2575 |      ms |
|                                                     error rate |               painless_dynamic |           0 |       % |
|                                                 Min Throughput | decay_geo_gauss_function_score |       76.51 |   ops/s |
|                                                Mean Throughput | decay_geo_gauss_function_score |       76.51 |   ops/s |
|                                              Median Throughput | decay_geo_gauss_function_score |       76.51 |   ops/s |
|                                                 Max Throughput | decay_geo_gauss_function_score |       76.51 |   ops/s |
|                                       100th percentile latency | decay_geo_gauss_function_score |     21.0489 |      ms |
|                                  100th percentile service time | decay_geo_gauss_function_score |      7.7264 |      ms |
|                                                     error rate | decay_geo_gauss_function_score |           0 |       % |
|                                                 Min Throughput |   decay_geo_gauss_script_score |       32.62 |   ops/s |
|                                                Mean Throughput |   decay_geo_gauss_script_score |       32.62 |   ops/s |
|                                              Median Throughput |   decay_geo_gauss_script_score |       32.62 |   ops/s |
|                                                 Max Throughput |   decay_geo_gauss_script_score |       32.62 |   ops/s |
|                                       100th percentile latency |   decay_geo_gauss_script_score |     35.6504 |      ms |
|                                  100th percentile service time |   decay_geo_gauss_script_score |     4.73009 |      ms |
|                                                     error rate |   decay_geo_gauss_script_score |           0 |       % |
|                                                 Min Throughput |     field_value_function_score |       62.33 |   ops/s |
|                                                Mean Throughput |     field_value_function_score |       62.33 |   ops/s |
|                                              Median Throughput |     field_value_function_score |       62.33 |   ops/s |
|                                                 Max Throughput |     field_value_function_score |       62.33 |   ops/s |
|                                       100th percentile latency |     field_value_function_score |     22.9279 |      ms |
|                                  100th percentile service time |     field_value_function_score |     6.56206 |      ms |
|                                                     error rate |     field_value_function_score |           0 |       % |
|                                                 Min Throughput |       field_value_script_score |       37.61 |   ops/s |
|                                                Mean Throughput |       field_value_script_score |       37.61 |   ops/s |
|                                              Median Throughput |       field_value_script_score |       37.61 |   ops/s |
|                                                 Max Throughput |       field_value_script_score |       37.61 |   ops/s |
|                                       100th percentile latency |       field_value_script_score |     31.9671 |      ms |
|                                  100th percentile service time |       field_value_script_score |     5.13632 |      ms |
|                                                     error rate |       field_value_script_score |           0 |       % |
|                                                 Min Throughput |                    large_terms |        1.04 |   ops/s |
|                                                Mean Throughput |                    large_terms |        1.04 |   ops/s |
|                                              Median Throughput |                    large_terms |        1.04 |   ops/s |
|                                                 Max Throughput |                    large_terms |        1.04 |   ops/s |
|                                       100th percentile latency |                    large_terms |     1236.03 |      ms |
|                                  100th percentile service time |                    large_terms |     263.588 |      ms |
|                                                     error rate |                    large_terms |           0 |       % |
|                                                 Min Throughput |           large_filtered_terms |        3.35 |   ops/s |
|                                                Mean Throughput |           large_filtered_terms |        3.35 |   ops/s |
|                                              Median Throughput |           large_filtered_terms |        3.35 |   ops/s |
|                                                 Max Throughput |           large_filtered_terms |        3.35 |   ops/s |
|                                       100th percentile latency |           large_filtered_terms |     443.827 |      ms |
|                                  100th percentile service time |           large_filtered_terms |     138.291 |      ms |
|                                                     error rate |           large_filtered_terms |           0 |       % |
|                                                 Min Throughput |         large_prohibited_terms |        6.17 |   ops/s |
|                                                Mean Throughput |         large_prohibited_terms |        6.17 |   ops/s |
|                                              Median Throughput |         large_prohibited_terms |        6.17 |   ops/s |
|                                                 Max Throughput |         large_prohibited_terms |        6.17 |   ops/s |
|                                       100th percentile latency |         large_prohibited_terms |      319.06 |      ms |
|                                  100th percentile service time |         large_prohibited_terms |     150.256 |      ms |
|                                                     error rate |         large_prohibited_terms |           0 |       % |
|                                                 Min Throughput |           desc_sort_population |       52.21 |   ops/s |
|                                                Mean Throughput |           desc_sort_population |       52.21 |   ops/s |
|                                              Median Throughput |           desc_sort_population |       52.21 |   ops/s |
|                                                 Max Throughput |           desc_sort_population |       52.21 |   ops/s |
|                                       100th percentile latency |           desc_sort_population |     24.3588 |      ms |
|                                  100th percentile service time |           desc_sort_population |     4.85923 |      ms |
|                                                     error rate |           desc_sort_population |           0 |       % |
|                                                 Min Throughput |            asc_sort_population |       99.75 |   ops/s |
|                                                Mean Throughput |            asc_sort_population |       99.75 |   ops/s |
|                                              Median Throughput |            asc_sort_population |       99.75 |   ops/s |
|                                                 Max Throughput |            asc_sort_population |       99.75 |   ops/s |
|                                       100th percentile latency |            asc_sort_population |     16.7499 |      ms |
|                                  100th percentile service time |            asc_sort_population |      6.4968 |      ms |
|                                                     error rate |            asc_sort_population |           0 |       % |
|                                                 Min Throughput | asc_sort_with_after_population |      113.48 |   ops/s |
|                                                Mean Throughput | asc_sort_with_after_population |      113.48 |   ops/s |
|                                              Median Throughput | asc_sort_with_after_population |      113.48 |   ops/s |
|                                                 Max Throughput | asc_sort_with_after_population |      113.48 |   ops/s |
|                                       100th percentile latency | asc_sort_with_after_population |     14.3933 |      ms |
|                                  100th percentile service time | asc_sort_with_after_population |     5.38322 |      ms |
|                                                     error rate | asc_sort_with_after_population |           0 |       % |
|                                                 Min Throughput |            desc_sort_geonameid |       90.68 |   ops/s |
|                                                Mean Throughput |            desc_sort_geonameid |       90.68 |   ops/s |
|                                              Median Throughput |            desc_sort_geonameid |       90.68 |   ops/s |
|                                                 Max Throughput |            desc_sort_geonameid |       90.68 |   ops/s |
|                                       100th percentile latency |            desc_sort_geonameid |     17.3694 |      ms |
|                                  100th percentile service time |            desc_sort_geonameid |     6.12722 |      ms |
|                                                     error rate |            desc_sort_geonameid |           0 |       % |
|                                                 Min Throughput | desc_sort_with_after_geonameid |      104.23 |   ops/s |
|                                                Mean Throughput | desc_sort_with_after_geonameid |      104.23 |   ops/s |
|                                              Median Throughput | desc_sort_with_after_geonameid |      104.23 |   ops/s |
|                                                 Max Throughput | desc_sort_with_after_geonameid |      104.23 |   ops/s |
|                                       100th percentile latency | desc_sort_with_after_geonameid |     16.1783 |      ms |
|                                  100th percentile service time | desc_sort_with_after_geonameid |      6.3748 |      ms |
|                                                     error rate | desc_sort_with_after_geonameid |           0 |       % |
|                                                 Min Throughput |             asc_sort_geonameid |       99.99 |   ops/s |
|                                                Mean Throughput |             asc_sort_geonameid |       99.99 |   ops/s |
|                                              Median Throughput |             asc_sort_geonameid |       99.99 |   ops/s |
|                                                 Max Throughput |             asc_sort_geonameid |       99.99 |   ops/s |
|                                       100th percentile latency |             asc_sort_geonameid |     17.1668 |      ms |
|                                  100th percentile service time |             asc_sort_geonameid |     6.87625 |      ms |
|                                                     error rate |             asc_sort_geonameid |           0 |       % |
|                                                 Min Throughput |  asc_sort_with_after_geonameid |      112.66 |   ops/s |
|                                                Mean Throughput |  asc_sort_with_after_geonameid |      112.66 |   ops/s |
|                                              Median Throughput |  asc_sort_with_after_geonameid |      112.66 |   ops/s |
|                                                 Max Throughput |  asc_sort_with_after_geonameid |      112.66 |   ops/s |
|                                       100th percentile latency |  asc_sort_with_after_geonameid |      14.399 |      ms |
|                                  100th percentile service time |  asc_sort_with_after_geonameid |     5.30651 |      ms |
|                                                     error rate |  asc_sort_with_after_geonameid |           0 |       % |


--------------------------------
[INFO] SUCCESS (took 58 seconds)
--------------------------------
```
Ran test execution with test-mode on external cluster
```
hoangia@3c22fbd0d988 opensearch-benchmark % opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="<target-host-endpoint>." --client-options="basic_auth_user:'<username>',basic_auth_password:'<password>'" --include-tasks="create-index,index-append" --test-mode

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Executing test with workload [geonames], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [1.1.0].

[WARNING] merges_total_time is 94 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 55 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 209 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 16 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running create-index                                                           [100% done]
Running index-append                                                           [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |         Task |       Value |   Unit |
|---------------------------------------------------------------:|-------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |              |  0.00263333 |    min |
|             Min cumulative indexing time across primary shards |              |           0 |    min |
|          Median cumulative indexing time across primary shards |              |     0.00025 |    min |
|             Max cumulative indexing time across primary shards |              | 0.000916667 |    min |
|            Cumulative indexing throttle time of primary shards |              |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |              |           0 |    min |
| Median cumulative indexing throttle time across primary shards |              |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |              |           0 |    min |
|                        Cumulative merge time of primary shards |              |  0.00156667 |    min |
|                       Cumulative merge count of primary shards |              |           1 |        |
|                Min cumulative merge time across primary shards |              |           0 |    min |
|             Median cumulative merge time across primary shards |              |           0 |    min |
|                Max cumulative merge time across primary shards |              |  0.00156667 |    min |
|               Cumulative merge throttle time of primary shards |              |           0 |    min |
|       Min cumulative merge throttle time across primary shards |              |           0 |    min |
|    Median cumulative merge throttle time across primary shards |              |           0 |    min |
|       Max cumulative merge throttle time across primary shards |              |           0 |    min |
|                      Cumulative refresh time of primary shards |              |  0.00348333 |    min |
|                     Cumulative refresh count of primary shards |              |         152 |        |
|              Min cumulative refresh time across primary shards |              |           0 |    min |
|           Median cumulative refresh time across primary shards |              |           0 |    min |
|              Max cumulative refresh time across primary shards |              |  0.00348333 |    min |
|                        Cumulative flush time of primary shards |              | 0.000266667 |    min |
|                       Cumulative flush count of primary shards |              |           3 |        |
|                Min cumulative flush time across primary shards |              |           0 |    min |
|             Median cumulative flush time across primary shards |              |           0 |    min |
|                Max cumulative flush time across primary shards |              | 0.000266667 |    min |
|                                        Total Young Gen GC time |              |           0 |      s |
|                                       Total Young Gen GC count |              |           0 |        |
|                                          Total Old Gen GC time |              |           0 |      s |
|                                         Total Old Gen GC count |              |           0 |        |
|                                                     Store size |              | 0.000185816 |     GB |
|                                                  Translog size |              | 0.000323541 |     GB |
|                                         Heap used for segments |              |  0.00626755 |     MB |
|                                       Heap used for doc values |              | 0.000431061 |     MB |
|                                            Heap used for terms |              |   0.0038147 |     MB |
|                                            Heap used for norms |              | 0.000610352 |     MB |
|                                           Heap used for points |              |           0 |     MB |
|                                    Heap used for stored fields |              |  0.00141144 |     MB |
|                                                  Segment count |              |           3 |        |
|                                                 Min Throughput | index-append |     2654.46 | docs/s |
|                                                Mean Throughput | index-append |     2654.46 | docs/s |
|                                              Median Throughput | index-append |     2654.46 | docs/s |
|                                                 Max Throughput | index-append |     2654.46 | docs/s |
|                                        50th percentile latency | index-append |     281.447 |     ms |
|                                       100th percentile latency | index-append |     300.606 |     ms |
|                                   50th percentile service time | index-append |     281.447 |     ms |
|                                  100th percentile service time | index-append |     300.606 |     ms |
|                                                     error rate | index-append |           0 |      % |


--------------------------------
[INFO] SUCCESS (took 11 seconds)
--------------------------------
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
