### PR TITLE
Add fix for git.py to index from the right and reformat branches (#245)

### DIFF
--- a/osbenchmark/utils/git.py
+++ b/osbenchmark/utils/git.py
@@ -121,7 +121,7 @@ def branches(src_dir, remote=True):
     if remote:
         # alternatively: git for-each-ref refs/remotes/ --format='%(refname:short)'
         return _cleanup_remote_branch_names(process.run_subprocess_with_output(
-                "git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src)))
+                "git -C {src} for-each-ref refs/remotes/ --format='%(refname)'".format(src=clean_src)))
     else:
         return _cleanup_local_branch_names(
                 process.run_subprocess_with_output(
@@ -134,7 +134,7 @@ def tags(src_dir):
 
 
 def _cleanup_remote_branch_names(branch_names):
-    return [(b[b.index("/") + 1:]).strip() for b in branch_names if not b.endswith("/HEAD")]
+    return [(b[b.rindex("/") + 1:]).strip() for b in branch_names if not b.endswith("/HEAD")]
 
 
 def _cleanup_local_branch_names(branch_names):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -179,7 +179,7 @@ class GitTests(TestCase):
                                        "  origin/5.0.0-alpha1",
                                        "  origin/5"]
         self.assertEqual(["main", "5.0.0-alpha1", "5"], git.branches("/src", remote=True))
-        run_subprocess.assert_called_with("git -C /src for-each-ref refs/remotes/ --format='%(refname:short)'")
+        run_subprocess.assert_called_with("git -C /src for-each-ref refs/remotes/ --format='%(refname)'")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")


### PR DESCRIPTION
### Description
Integration tests and users using latest versions of `git (2.40.0)` experienced issues when using the `list` subcommand or OSB commands that relied on `workloads` repository. See #245 for more details. When invoking such commands, there would either be connection refused issues or `ValueError: substring not found` would appear. 

This PR applies the fix suggested in the issue #245. See the issue for more details. 

### Issues Resolved
#245

### Testing
- [x] New functionality includes testing 

[Describe how this change was tested]
- Tested it in an ubuntu environment (see https://github.com/opensearch-project/opensearch-benchmark/issues/245#issuecomment-1488907699)
- Tested in Integration Testing Environment in Github Actions
- Ran integration tests to confirm that fix resolved all failing integration tests. 
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
