### PR TITLE
Add condition to check for distribution version when publishing warn statement

### DIFF
--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -129,7 +129,7 @@ class OsClientFactory:
             masked_client_options["basic_auth_password"] = "*****"
         if "http_auth" in masked_client_options:
             masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
-        self.logger.info("Creating ES client connected to %s with options [%s]", hosts, masked_client_options)
+        self.logger.info("Creating OpenSearch client connected to %s with options [%s]", hosts, masked_client_options)
 
         # we're using an SSL context now and it is not allowed to have use_ssl present in client options anymore
         if self.client_options.pop("use_ssl", False):

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -614,6 +614,7 @@ class NodeStats(TelemetryDevice):
     warning = """You have enabled the node-stats telemetry device with OpenSearch < 1.1.0. Requests to the
           _nodes/stats OpenSearch endpoint trigger additional refreshes and WILL SKEW results.
     """
+    opensearch_distribution = "opensearch"
 
     def __init__(self, telemetry_params, clients, metrics_store):
         super().__init__()
@@ -625,10 +626,11 @@ class NodeStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         default_client = self.clients["default"]
+        distribution_name = default_client.info()["version"]["distribution"]
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]
 
-        if major < 7 or (major == 7 and minor < 2):
+        if distribution_name != NodeStats.opensearch_distribution and (major < 7 or (major == 7 and minor < 2)):
             console.warn(NodeStats.warning, logger=self.logger)
 
         for cluster_name in self.specified_cluster_names:

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1410,7 +1410,7 @@ class NodeStatsTests(TestCase):
     @mock.patch("osbenchmark.telemetry.NodeStatsRecorder", mock.Mock())
     @mock.patch("osbenchmark.telemetry.SamplerThread", mock.Mock())
     def test_prints_warning_using_node_stats(self):
-        clients = {"default": Client(info={"version": {"number": "7.1.0"}})}
+        clients = {"default": Client(info={"version": {"distribution": "elasticsearch", "number": "7.1.0"}})}
         cfg = create_config()
         metrics_store = metrics.OsMetricsStore(cfg)
         telemetry_params = {
@@ -1428,7 +1428,7 @@ class NodeStatsTests(TestCase):
     @mock.patch("osbenchmark.telemetry.NodeStatsRecorder", mock.Mock())
     @mock.patch("osbenchmark.telemetry.SamplerThread", mock.Mock())
     def test_no_warning_using_node_stats_after_version(self):
-        clients = {"default": Client(info={"version": {"number": "7.2.0"}})}
+        clients = {"default": Client(info={"version": {"distribution": "elasticsearch", "number": "7.2.0"}})}
         cfg = create_config()
         metrics_store = metrics.OsMetricsStore(cfg)
         telemetry_params = {


### PR DESCRIPTION
### Description
Users who are using OpenSearch versions greater than or less than 1.1.0 are still seeing the warn statement, which is misleading. This statement was originally intended for users running telemetry on ES versions 7.2.0 or less. This quick PR adds a condition to check if the distribution name is `opensearch` or `elasticsearch` in case OSB still wants to test ES versions <=7.10 (or prior to OpenSearch 1.0). 

Also, revised a logging statement from `ES` to `OpenSearch` when referring to the client. 

### Issues Resolved
#243 

### Testing
- [x] New functionality includes testing

Tested OSB with and without changes in a fresh Ubuntu environment. Confirmed that the warn statement appears on the console and logs only when distribution name is `elasticsearch` and version is 7.2.0 or less.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
