### PR TITLE
Update Dockerfile and Docker README

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,3 +67,5 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark"
 
 VOLUME ["/opensearch-benchmark/.benchmark"]
+
+ENTRYPOINT [ "opensearch-benchmark", "--help" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,8 +5,9 @@ This Docker image allows users to spin up a Docker container preloaded with esse
 # Running the OpenSearch Benchmark Image
 **Prerequisite:** Ensure that Docker is installed. If not, refer to [this guide to download Docker Desktop](https://docs.docker.com/get-docker/) or [this guide to download Docker Engine](https://docs.docker.com/engine/install/).
 1. Run the command `docker pull opensearchproject/opensearch-benchmark`. Docker will pull in the image on your host
-2. To run the image and start a Docker container, run the command `docker run --entrypoint bash opensearchproject/opensearch-benchmark:latest -c "opensearch-benchmark -h"`. This will print the help screen and terminate the container. If you'd like to run it against a target OpenSearch cluster, replace `opensearch-benchmark -h` with the appropriate OSB command and arguments.
-    - A simpler alternative would be to run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`, which would place you into a shell to interact with the container. Now, you can invoke `opensearch-benchmark` with any desired subcommands or options. When you are finished, invoke exit command to terminate the container.
+2. To run the image and start a Docker container, run the command `docker run --entrypoint bash opensearchproject/opensearch-benchmark:latest -c "opensearch-benchmark -h"`. This will print the help screen and terminate the container. If you'd like to run the image with a different OSB command, replace `opensearch-benchmark -h` with your preferred OSB command and arguments.
+    - A simpler alternative would be to run `docker run opensearchproject/opensearch-benchmark opensearch-benchmark -h`.
+    - To run in interactive mode, run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`. This would place you into a shell to interact with the container where you can invoke `opensearch-benchmark` with any desired subcommands or options. When you are finished, invoke exit command to terminate the container.
 
 
 # Building a Copy of OpenSearch Benchmark Image

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,10 +4,19 @@ This Docker image allows users to spin up a Docker container preloaded with esse
 
 # Running the OpenSearch Benchmark Image
 **Prerequisite:** Ensure that Docker is installed. If not, refer to [this guide to download Docker Desktop](https://docs.docker.com/get-docker/) or [this guide to download Docker Engine](https://docs.docker.com/engine/install/).
-1. Run the command `docker pull opensearchproject/opensearch-benchmark`. Docker will pull in the image on your host
-2. To run the image and start a Docker container, run the command `docker run --entrypoint bash opensearchproject/opensearch-benchmark:latest -c "opensearch-benchmark -h"`. This will print the help screen and terminate the container. If you'd like to run the image with a different OSB command, replace `opensearch-benchmark -h` with your preferred OSB command and arguments.
-    - A simpler alternative would be to run `docker run opensearchproject/opensearch-benchmark opensearch-benchmark -h`.
-    - To run in interactive mode, run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`. This would place you into a shell to interact with the container where you can invoke `opensearch-benchmark` with any desired subcommands or options. When you are finished, invoke exit command to terminate the container.
+
+To run the image in a Docker container, invoke one of the following command lines:
+```
+docker run --entrypoint bash opensearchproject/opensearch-benchmark:latest -c "opensearch-benchmark [ARGS]"
+OR
+docker run opensearchproject/opensearch-benchmark opensearch-benchmark [ARGS]
+```
+
+For instance, using `-h` for the arguments will print the OSB help information. Once the OSB process completes, the Docker container is automatically terminated.
+
+To run in interactive mode, run docker run `-it opensearchproject/opensearch-benchmark /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
+
+
 
 
 # Building a Copy of OpenSearch Benchmark Image

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,9 @@ This Docker image allows users to spin up a Docker container preloaded with esse
 # Running the OpenSearch Benchmark Image
 **Prerequisite:** Ensure that Docker is installed. If not, refer to [this guide to download Docker Desktop](https://docs.docker.com/get-docker/) or [this guide to download Docker Engine](https://docs.docker.com/engine/install/).
 1. Run the command `docker pull opensearchproject/opensearch-benchmark`. Docker will pull in the image on your host
-2. To run the image and start a Docker container, run the command `docker run opensearchproject/opensearch-benchmark`
+2. To run the image and start a Docker container, run the command `docker run --entrypoint bash opensearchproject/opensearch-benchmark:latest -c "opensearch-benchmark -h"`. This will print the help screen and terminate the container. If you'd like to run it against a target OpenSearch cluster, replace `opensearch-benchmark -h` with the appropriate OSB command and arguments.
+    - A simpler alternative would be to run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`, which would place you into a shell to interact with the container. Now, you can invoke `opensearch-benchmark` with any desired subcommands or options. When you are finished, invoke exit command to terminate the container.
+
 
 # Building a Copy of OpenSearch Benchmark Image
 1. Git clone OpenSearch Benchmark Github repository

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,9 +16,6 @@ For instance, using `-h` for the arguments will print the OSB help information. 
 
 To run in interactive mode, run docker run `-it opensearchproject/opensearch-benchmark /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
 
-
-
-
 # Building a Copy of OpenSearch Benchmark Image
 1. Git clone OpenSearch Benchmark Github repository
 2. Make changes locally

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -614,7 +614,7 @@ class NodeStats(TelemetryDevice):
     warning = """You have enabled the node-stats telemetry device with OpenSearch < 1.1.0. Requests to the
           _nodes/stats OpenSearch endpoint trigger additional refreshes and WILL SKEW results.
     """
-    opensearch_distribution = "opensearch"
+    opensearch_distribution_name = "opensearch"
 
     def __init__(self, telemetry_params, clients, metrics_store):
         super().__init__()
@@ -630,7 +630,7 @@ class NodeStats(TelemetryDevice):
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]
 
-        if distribution_name != NodeStats.opensearch_distribution and (major < 7 or (major == 7 and minor < 2)):
+        if distribution_name != NodeStats.opensearch_distribution_name and (major < 7 or (major == 7 and minor < 2)):
             console.warn(NodeStats.warning, logger=self.logger)
 
         for cluster_name in self.specified_cluster_names:


### PR DESCRIPTION
### Description
Users on Dockerhub were having trouble running the command `docker run opensearchproject/opensearch-benchmark` in the README and Dockerhub repo's description. The commands exits with an exit status code of 0 because it doesn't run any entrypoint commands. This PR does the following:
- Adds entrypoint commands to Dockerfile
- Adds more information to the README to illuminate how to use the Docker image. 
- Adds the command that's been updated in the [Dockerhub repository](https://hub.docker.com/r/opensearchproject/opensearch-benchmark) so that there's consistency between the README and the Dockerhub repository overview tab.

### Issues Resolved

### Testing
- [x] New functionality includes testing

Built image locally after updating Dockerfile and tested it with the following commands with Docker CLI. Tested on Docker Desktop to confirm consistency:
- `docker run --entrypoint bash <IMAGE> -c "opensearch-benchmark -h"` --> overwrites entrypoint commands to use opensearch-benchmark help command
- `docker run <IMAGE> opensearch-benchmark -h` --> runs it in simpler method
- `docker run -it <IMAGE> /bin/sh` --> runs in interactive mode in terminal
- Ran with Docker Desktop to run the image 
- Monitored container status on Docker desktop



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
