### PR TITLE
Update client.py to handle SSL issue preventing connection to secure clusters (#252)

### DIFF
--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -223,7 +223,9 @@ class OsClientFactory:
                 has_hostname = True
 
         if has_ip and has_hostname:
-            logger.warning("Although certificate verification is enabled, peer hostnames will not be matched since the host list is a mix of names and IP addresses")
+            logger.warning("Although certificate verification is enabled, "
+                "peer hostnames will not be matched since the host list is a mix "
+                "of names and IP addresses")
             return False
 
         return has_hostname

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -220,7 +220,8 @@ class OsClientFactory:
                 has_hostname = True
 
         if has_ip and has_hostname:
-            raise exceptions.SystemSetupError("Could not verify certs since both IP addresses and hostnames were provided. Please ensure one or the other is used.")
+            raise exceptions.SystemSetupError("Could not verify certs since both IP addresses \
+                 and hostnames were provided. Please ensure one or the other is used.")
 
         return has_hostname
 

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -220,8 +220,7 @@ class OsClientFactory:
                 has_hostname = True
 
         if has_ip and has_hostname:
-            raise exceptions.SystemSetupError("Could not verify certs since both IP addresses \
-                 and hostnames were provided. Please ensure one or the other is used.")
+            raise exceptions.SystemSetupError("Can't verify certs since both IP addresses and hostnames were found.")
 
         return has_hostname
 

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -223,9 +223,9 @@ class OsClientFactory:
                 has_hostname = True
 
         if has_ip and has_hostname:
-            logger.warning("Although certificate verification is enabled, "
+            console.warn("Although certificate verification is enabled, "
                 "peer hostnames will not be matched since the host list is a mix "
-                "of names and IP addresses")
+                "of names and IP addresses", logger=logger)
             return False
 
         return has_hostname

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -314,6 +314,19 @@ class OsClientFactoryTests(TestCase):
         assert f.ssl_context.check_hostname is True
         assert f.ssl_context.verify_mode == ssl.CERT_REQUIRED
 
+    def test_check_hostname_set_to_false_when_ssl_encounters_both_ips_and_hostnames(self):
+        hosts = [{"host": "localhost", "port": 9200}, {"host": "127.0.0.1", "port": 9200}]
+        client_options = {
+            "use_ssl": True,
+            "verify_certs": True,
+            "http_auth": ("user", "password"),
+        }
+
+        f = client.OsClientFactory(hosts, client_options)
+        assert f.hosts == hosts
+        assert f.ssl_context.check_hostname is False
+        assert f.ssl_context.verify_mode == ssl.CERT_REQUIRED
+
 class RequestContextManagerTests(TestCase):
     @pytest.mark.skip(reason="latency is system-dependent")
     @run_async

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -298,7 +298,7 @@ class OsClientFactoryTests(TestCase):
 
         with pytest.raises(
             exceptions.SystemSetupError,
-            match="Could not verify certs since both IP addresses and hostnames were provided. Please ensure one or the other is used.",
+            match="Can't verify certs since both IP addresses and hostnames were found.",
         ):
             client.OsClientFactory(hosts, client_options)
 


### PR DESCRIPTION
### Description
Users have discovered that when invoked with `use_ssl:true` in the `client-options` parameter, OpenSearch-Benchmark runs into SSL issues for Python 3.10+. There's a misunderstanding in the code that `ssl.Purpose.CLIENT_AUTH` connects to client sockets when in reality it is `ssl.Purpose.SERVER_AUTH` that connects to client sockets (with or without certs).

As of Python 3.10, there are warnings and errors in place to prevent this from happening.  See #252 for information on what the issue looks like. 

This PR introduces a few small changes that prevents the SSL issue from coming up again in Python 3.10+. Added a few more unittests. 

### Issues Resolved
#252 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
- Manually tested across Python 3.10 and 3.11 and Python 3.8 and 3.9 for backwards compatibility 
- Added a couple more unittests
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
