### PR TITLE
Update entrypoint in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,4 +68,4 @@ LABEL org.label-schema.schema-version="1.0" \
 
 VOLUME ["/opensearch-benchmark/.benchmark"]
 
-ENTRYPOINT [ "opensearch-benchmark", "--help" ]
+ENTRYPOINT [ "opensearch-benchmark" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,14 +7,15 @@ This Docker image allows users to spin up a Docker container preloaded with esse
 
 To run the image in a Docker container, invoke the following command:
 ```
-docker run opensearchproject/opensearch-benchmark [ARGS]
+docker run opensearchproject/opensearch-benchmark [OSB ARGS]
 ```
 
 For instance, using `-h` for the arguments will print the OSB help information. Once the OSB process completes, the Docker container is automatically terminated.
 
-To run in interactive mode, run docker run `-it opensearchproject/opensearch-benchmark /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
+To run in interactive mode, run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
 
-**Minor Bug in OSB v0.2.0:** For OSB version 0.2.0 on Dockerhub and Pypi, running opensearch-benchmark without any subcommands will result in a failure. See the following for examples:
+### Minor Bug found in OSB 0.2.0 on Dockerhub and Pypi
+For OSB version 0.2.0 on Dockerhub and Pypi, running opensearch-benchmark without any arguments will result in a failure. See the following for examples:
 
 Ran opensearch-benchmark docker image with tag 0.2.0 without any args
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ This Docker image allows users to spin up a Docker container preloaded with esse
 
 To run the image in a Docker container, invoke the following command:
 ```
-docker run opensearchproject/opensearch-benchmark opensearch-benchmark [ARGS]
+docker run opensearchproject/opensearch-benchmark [ARGS]
 ```
 
 For instance, using `-h` for the arguments will print the OSB help information. Once the OSB process completes, the Docker container is automatically terminated.

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ docker run opensearchproject/opensearch-benchmark [OSB ARGS]
 
 For instance, using `-h` for the arguments will print the OSB help information. Once the OSB process completes, the Docker container is automatically terminated.
 
-To run in interactive mode, run `docker run -it opensearchproject/opensearch-benchmark /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
+To run in interactive mode, run `docker run --entrypoint bash -it opensearchproject/opensearch-benchmark -c /bin/sh`. This will place you into a shell to interact with the container where you can invoke opensearch-benchmark with any desired subcommands or options. When you are finished, exit from the shell to terminate the container.
 
 ### Minor Bug found in OSB 0.2.0 on Dockerhub and Pypi
 For OSB version 0.2.0 on Dockerhub and Pypi, running opensearch-benchmark without any arguments will result in a failure. See the following for examples:


### PR DESCRIPTION
### Description
This PR quickly updates the entrypoint in the Dockerfile by removing the `--help` flag to avoid conflicts. This is because when users append arguments -- such as `list workloads` -- to the sample command `docker run opensearchproject/opensearch-benchmark` found in the Docker README, it is the equivalent of running `opensearch-benchmark --help list workloads`. This is why it still presents the help screen instead of listing workloads.
```
docker run opensearchproject/opensearch-benchmark list workloads
usage: opensearch-benchmark [-h] [--version]
                            {execute_test,list,info,create-workload,generate,compare,download,install,start,stop}
                            ...

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

 A benchmarking tool for OpenSearch

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

subcommands:
  {execute_test,list,info,create-workload,generate,compare,download,install,start,stop}
    execute_test        Run a benchmark
    list                List configuration options
    info                Show info about a workload
    create-workload     Create a Benchmark workload from existing data
    generate            Generate artifacts
    compare             Compare two test_executions
    download            Downloads an artifact
    install             Installs an OpenSearch node locally
    start               Starts an OpenSearch node locally
    stop                Stops an OpenSearch node locally

Find out more about Benchmark at https://opensearch.org/docs
hoangia@3c22fbd0d988 Instance Keys %
```

Removing the `--help` flag prevents this. Also, users do not need to specify opensearch-benchmark again when adding args.


### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [x] New functionality includes testing

Built docker image locally and ran test commands with it. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
