### PR TITLE
Including setup.py change that was skipped in change 00eaa79.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ setup(name="opensearch-benchmark",
               "opensearch-benchmarkd=osbenchmark.benchmarkd:main"
           ],
       },
+      scripts=['scripts/expand-data-corpus.py'],
       classifiers=[
           "Topic :: System :: Benchmark",
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### Description
Updating change to setup.py, that was dropped in change 00eaa79 (feature to increase the size of the data corpus for the http_logs)

### Issues Resolved

https://github.com/opensearch-project/opensearch-benchmark/issues/254



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
