### PR TITLE
Replace execute_test with execute-test

### DIFF
--- a/PYTHON_SUPPORT_GUIDE.md
+++ b/PYTHON_SUPPORT_GUIDE.md
@@ -27,17 +27,17 @@ supported_python_versions = [(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)]
 
 **Basic OpenSearch Benchmark command with distribution version and test mode**
 ```
-opensearch-benchmark execute_test --distribution-version=1.0.0 --workload=geonames --test-mode
+opensearch-benchmark execute-test --distribution-version=1.0.0 --workload=geonames --test-mode
 ```
 
 **OpenSearch Benchmark command executing test on target-host in test mode**
 ```
-opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
+opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
 ```
 
 **OpenSearch-Benchmark command executing test on target-host without test mode**
 ```
-opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 To ensure that users are using the correct python versions, install the repository with `python3 -m pip install -e .` and run `which opensearch-benchmark` to get the path. Pre-append this path to each of the three commands above and re-run them in the command line.
@@ -46,12 +46,12 @@ Keep in mind the file path outputted differs for each operating system and might
 
 - For example: When running `which opensearch-benchmark` on an Ubuntu environment, the commad line outputs `/home/ubuntu/.pyenv/shims/opensearch-benchmark`. On closer inspection, the path points to a shell script. Thus, to invoke OpenSearch Benchmark, pre-=append the OpenSearch Benchmark command with `bash` and the path outputted earlier:
 ```
-bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 - Another example: When running `which opensearch-benchmark` on an Amazon Linux 2 environment, the command line outputs `~/.local/bin/opensearch-benchmark`. On closer inspection, the path points to a Python script. Thus, to invoke OpenSearch Benchmark, pre-append the OpenSearch Benchmark command with `python3` and the path outputted earlier:
 ```
-python3 ~/.local/bin/opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+python3 ~/.local/bin/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 ### Creating a Pull Request After Adding Changes and Testing Them Out

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run your first test execution
 
 Now we're ready to run our first test execution:
 
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --workload=geonames --test-mode
+    opensearch-benchmark execute-test --distribution-version=1.0.0 --workload=geonames --test-mode
 
 This will download OpenSearch 1.0.0 and run one of OpenSearch Benchmark's official workloads - the [geonames workload](<https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/geonames>) - against it.
 Note that this uses the `--test-mode` argument to only run a single instance of each operation in order to reduce the time needed for a test execution. This argument is used as a sanity check and should be removed in an actual benchmarking scenario.

--- a/docs/api/execute-test.md
+++ b/docs/api/execute-test.md
@@ -5,13 +5,13 @@ parent: Benchmark API
 nav_order: 10
 ---
 
-The `execute_test` command of OpenSearch Benchmark executes tests against your OpenSearch cluster.
+The `execute-test` command of OpenSearch Benchmark executes tests against your OpenSearch cluster.
 
 
-## Syntax 
+## Syntax
 
 ```bash
-opensearch-benchmark execute_test <arguments>
+opensearch-benchmark execute-test <arguments>
 ```
 
 
@@ -34,26 +34,26 @@ Argument | Description | Required
 *Example 1*
 
 ```
-opensearch-benchmark execute_test --workload eventdata --test-mode
+opensearch-benchmark execute-test --workload eventdata --test-mode
 ```
 
-Provision an OpenSearch node on the local machine based on the latest source code in Github and execute the `eventdata` workload in test mode. 
+Provision an OpenSearch node on the local machine based on the latest source code in Github and execute the `eventdata` workload in test mode.
 
 *Example 2*
 
 ```
-opensearch-benchmark execute_test --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
+opensearch-benchmark execute-test --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
 ```
 
-Execute the `http_logs` workload against an existing OpenSearch cluster but only use one client for indexing and only ingest 10% of the total data corpus. 
+Execute the `http_logs` workload against an existing OpenSearch cluster but only use one client for indexing and only ingest 10% of the total data corpus.
 
 *Example 3*
 
 ```
-opensearch-benchmark execute_test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
+opensearch-benchmark execute-test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
 ```
 
-Execute the `nyc_taxis` workload against an existing OpenSearch cluster with the security plugin enabled. 
+Execute the `nyc_taxis` workload against an existing OpenSearch cluster with the security plugin enabled.
 
 
 ### All Arguments

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -94,7 +94,7 @@ def execute_test(cfg, command_line):
     This method should be used for benchmark invocations of the test_execution command.
     It sets up some defaults for how the integration tests expect to run test_executions.
     """
-    return osbenchmark(cfg, f"execute_test {command_line} --kill-running-processes --on-error='abort'")
+    return osbenchmark(cfg, f"execute-test {command_line} --kill-running-processes --on-error='abort'")
 
 
 def shell_cmd(command_line):

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -859,7 +859,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             builder.stop(cfg)
         elif sub_command == "execute-test":
-            # As the execute_test command is doing more work than necessary at the moment, we duplicate several parameters
+            # As the execute-test command is doing more work than necessary at the moment, we duplicate several parameters
             # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
             # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute-test" only
             # to run the actual benchmark (i.e. generating load).

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -111,7 +111,7 @@ def create_arg_parser():
         dest="subcommand",
         help="")
 
-    test_execution_parser = subparsers.add_parser("execute_test", help="Run a benchmark")
+    test_execution_parser = subparsers.add_parser("execute-test", help="Run a benchmark")
     # change in favor of "list telemetry", "list workloads", "list pipelines"
     list_parser = subparsers.add_parser("list", help="List configuration options")
     list_parser.add_argument(
@@ -858,10 +858,10 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             builder.stop(cfg)
-        elif sub_command == "execute_test":
+        elif sub_command == "execute-test":
             # As the execute_test command is doing more work than necessary at the moment, we duplicate several parameters
             # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
-            # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute_test" only
+            # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute-test" only
             # to run the actual benchmark (i.e. generating load).
             if args.effective_start_date:
                 cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -31,7 +31,7 @@ done
 echo
 
 # Configure the seed nodes on follower cluster
-# TODO: Update the seed node to private IP. 
+# TODO: Update the seed node to private IP.
 echo "Configure remotes on follower"
 curl -o /dev/null -H 'Content-Type: application/json' -k -u admin:admin -X PUT https://localhost:9201/_cluster/settings -d @- <<-EOF
     {
@@ -147,4 +147,4 @@ EOF
 
 
 # Start OpenSearch Benchmark
-opensearch-benchmark execute_test --configuration-name=metricstore --workload=geonames --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --workload-params="number_of_replicas:1" --client-options=./ccr-client-options.json --kill-running-processes --telemetry="ccr-stats" --telemetry-params=./ccr-telemetry-param.json
+opensearch-benchmark execute-test --configuration-name=metricstore --workload=geonames --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --workload-params="number_of_replicas:1" --client-options=./ccr-client-options.json --kill-running-processes --telemetry="ccr-stats" --telemetry-params=./ccr-telemetry-param.json

--- a/scripts/expand-data-corpus.py
+++ b/scripts/expand-data-corpus.py
@@ -30,7 +30,7 @@ TLDR: to generate a 100 GB corpus and then run a test against it:
 
 $ expand-data-corpus.py --corpus-size 100 --output-file-suffix 100gb
 
-$ opensearch-benchmark execute_test --workload http_logs \\
+$ opensearch-benchmark execute-test --workload http_logs \\
     --workload_params=generated_corpus:t ...
 
 The script generates new documents by duplicating ones in the existing


### PR DESCRIPTION
### Description
As discussed in this issue #238, have opted to replace `execute_test` with `execute-test` to remain consistent. Ensured that methods in OSB called `execute_test()` remained unchanged.

### Issues Resolved
#238 

### Testing
- [x] New functionality includes testing

Confirmed old invocation format does not work anymore
```
hoangia@3c22fbd0d988 opensearch-benchmark % opensearch-benchmark execute_test --workload=geonames --pipeline=benchmark-only --target-host="https://search-hoangia-aos-testing-2-xpwa7ykgv7bbc7qqfuuzt2no7i.us-east-1.es.amazonaws.com" --client-options="basic_auth_user:'hoangia',basic_auth_password:'Hoangia@123'" --test-mode
usage: opensearch-benchmark [-h] [--version] {execute-test,list,info,create-workload,generate,compare,download,install,start,stop} ...
opensearch-benchmark: error: argument subcommand: invalid choice: 'execute_test' (choose from 'execute-test', 'list', 'info', 'create-workload', 'generate', 'compare', 'download', 'install', 'start', 'stop')
```
Successful test with new invocation format
```
$ opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="https://search-hoangia-aos-testing-2-xpwa7ykgv7bbc7qqfuuzt2no7i.us-east-1.es.amazonaws.com" --client-options="basic_auth_user:'hoangia',basic_auth_password:'Hoangia@123'" --test-mode

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Executing test with workload [geonames], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [1.1.0].

[WARNING] merges_total_time is 152490 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 1650652 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 61284 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 98794 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index-append                                                           [100% done]
Running refresh-after-index                                                    [100% done]
Running force-merge                                                            [100% done]
Running refresh-after-force-merge                                              [100% done]
Running wait-until-merges-finish                                               [100% done]
Running index-stats                                                            [100% done]
Running node-stats                                                             [100% done]
Running default                                                                [100% done]
Running term                                                                   [100% done]
Running phrase                                                                 [100% done]
Running country_agg_uncached                                                   [100% done]
Running country_agg_cached                                                     [100% done]
Running scroll                                                                 [100% done]
Running expression                                                             [100% done]
Running painless_static                                                        [100% done]
Running painless_dynamic                                                       [100% done]
Running decay_geo_gauss_function_score                                         [100% done]
Running decay_geo_gauss_script_score                                           [100% done]
Running field_value_function_score                                             [100% done]
Running field_value_script_score                                               [100% done]
Running large_terms                                                            [100% done]
Running large_filtered_terms                                                   [100% done]
Running large_prohibited_terms                                                 [100% done]
Running desc_sort_population                                                   [100% done]
Running asc_sort_population                                                    [100% done]
Running asc_sort_with_after_population                                         [100% done]
Running desc_sort_geonameid                                                    [100% done]
Running desc_sort_with_after_geonameid                                         [100% done]
Running asc_sort_geonameid                                                     [100% done]
Running asc_sort_with_after_geonameid                                          [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                           Task |       Value |    Unit |
|---------------------------------------------------------------:|-------------------------------:|------------:|--------:|
|                     Cumulative indexing time of primary shards |                                |     27.5108 |     min |
|             Min cumulative indexing time across primary shards |                                |           0 |     min |
|          Median cumulative indexing time across primary shards |                                | 0.000133333 |     min |
|             Max cumulative indexing time across primary shards |                                |     6.06973 |     min |
|            Cumulative indexing throttle time of primary shards |                                |           0 |     min |
|    Min cumulative indexing throttle time across primary shards |                                |           0 |     min |
| Median cumulative indexing throttle time across primary shards |                                |           0 |     min |
|    Max cumulative indexing throttle time across primary shards |                                |           0 |     min |
|                        Cumulative merge time of primary shards |                                |      2.5415 |     min |
|                       Cumulative merge count of primary shards |                                |          16 |         |
|                Min cumulative merge time across primary shards |                                |           0 |     min |
|             Median cumulative merge time across primary shards |                                |           0 |     min |
|                Max cumulative merge time across primary shards |                                |      0.5262 |     min |
|               Cumulative merge throttle time of primary shards |                                |           0 |     min |
|       Min cumulative merge throttle time across primary shards |                                |           0 |     min |
|    Median cumulative merge throttle time across primary shards |                                |           0 |     min |
|       Max cumulative merge throttle time across primary shards |                                |           0 |     min |
|                      Cumulative refresh time of primary shards |                                |     1.02148 |     min |
|                     Cumulative refresh count of primary shards |                                |         663 |         |
|              Min cumulative refresh time across primary shards |                                |           0 |     min |
|           Median cumulative refresh time across primary shards |                                |      0.0001 |     min |
|              Max cumulative refresh time across primary shards |                                |      0.2147 |     min |
|                        Cumulative flush time of primary shards |                                |     1.64657 |     min |
|                       Cumulative flush count of primary shards |                                |          46 |         |
|                Min cumulative flush time across primary shards |                                |           0 |     min |
|             Median cumulative flush time across primary shards |                                |           0 |     min |
|                Max cumulative flush time across primary shards |                                |    0.348717 |     min |
|                                        Total Young Gen GC time |                                |       0.018 |       s |
|                                       Total Young Gen GC count |                                |           1 |         |
|                                          Total Old Gen GC time |                                |           0 |       s |
|                                         Total Old Gen GC count |                                |           0 |         |
|                                                     Store size |                                |     2.67245 |      GB |
|                                                  Translog size |                                | 3.17581e-06 |      GB |
|                                         Heap used for segments |                                |    0.197437 |      MB |
|                                       Heap used for doc values |                                |   0.0301476 |      MB |
|                                            Heap used for terms |                                |    0.128082 |      MB |
|                                            Heap used for norms |                                |   0.0128174 |      MB |
|                                           Heap used for points |                                |           0 |      MB |
|                                    Heap used for stored fields |                                |   0.0263901 |      MB |
|                                                  Segment count |                                |          51 |         |
|                                                 Min Throughput |                   index-append |     2089.48 |  docs/s |
|                                                Mean Throughput |                   index-append |     2089.48 |  docs/s |
|                                              Median Throughput |                   index-append |     2089.48 |  docs/s |
|                                                 Max Throughput |                   index-append |     2089.48 |  docs/s |
|                                        50th percentile latency |                   index-append |     438.907 |      ms |
|                                       100th percentile latency |                   index-append |     454.561 |      ms |
|                                   50th percentile service time |                   index-append |     438.907 |      ms |
|                                  100th percentile service time |                   index-append |     454.561 |      ms |
|                                                     error rate |                   index-append |           0 |       % |
|                                                 Min Throughput |       wait-until-merges-finish |        3.38 |   ops/s |
|                                                Mean Throughput |       wait-until-merges-finish |        3.38 |   ops/s |
|                                              Median Throughput |       wait-until-merges-finish |        3.38 |   ops/s |
|                                                 Max Throughput |       wait-until-merges-finish |        3.38 |   ops/s |
|                                       100th percentile latency |       wait-until-merges-finish |     263.747 |      ms |
|                                  100th percentile service time |       wait-until-merges-finish |     263.747 |      ms |
|                                                     error rate |       wait-until-merges-finish |           0 |       % |
|                                                 Min Throughput |                    index-stats |        3.39 |   ops/s |
|                                                Mean Throughput |                    index-stats |        3.39 |   ops/s |
|                                              Median Throughput |                    index-stats |        3.39 |   ops/s |
|                                                 Max Throughput |                    index-stats |        3.39 |   ops/s |
|                                       100th percentile latency |                    index-stats |     372.122 |      ms |
|                                  100th percentile service time |                    index-stats |     71.5005 |      ms |
|                                                     error rate |                    index-stats |           0 |       % |
|                                                 Min Throughput |                     node-stats |        2.89 |   ops/s |
|                                                Mean Throughput |                     node-stats |        2.89 |   ops/s |
|                                              Median Throughput |                     node-stats |        2.89 |   ops/s |
|                                                 Max Throughput |                     node-stats |        2.89 |   ops/s |
|                                       100th percentile latency |                     node-stats |     463.244 |      ms |
|                                  100th percentile service time |                     node-stats |     99.2511 |      ms |
|                                                     error rate |                     node-stats |           0 |       % |
|                                                 Min Throughput |                        default |        3.15 |   ops/s |
|                                                Mean Throughput |                        default |        3.15 |   ops/s |
|                                              Median Throughput |                        default |        3.15 |   ops/s |
|                                                 Max Throughput |                        default |        3.15 |   ops/s |
|                                       100th percentile latency |                        default |      583.72 |      ms |
|                                  100th percentile service time |                        default |     265.723 |      ms |
|                                                     error rate |                        default |           0 |       % |
|                                                 Min Throughput |                           term |        2.82 |   ops/s |
|                                                Mean Throughput |                           term |        2.82 |   ops/s |
|                                              Median Throughput |                           term |        2.82 |   ops/s |
|                                                 Max Throughput |                           term |        2.82 |   ops/s |
|                                       100th percentile latency |                           term |     654.957 |      ms |
|                                  100th percentile service time |                           term |     300.101 |      ms |
|                                                     error rate |                           term |           0 |       % |
|                                                 Min Throughput |                         phrase |        3.31 |   ops/s |
|                                                Mean Throughput |                         phrase |        3.31 |   ops/s |
|                                              Median Throughput |                         phrase |        3.31 |   ops/s |
|                                                 Max Throughput |                         phrase |        3.31 |   ops/s |
|                                       100th percentile latency |                         phrase |     566.513 |      ms |
|                                  100th percentile service time |                         phrase |      263.73 |      ms |
|                                                     error rate |                         phrase |           0 |       % |
|                                                 Min Throughput |           country_agg_uncached |        3.21 |   ops/s |
|                                                Mean Throughput |           country_agg_uncached |        3.21 |   ops/s |
|                                              Median Throughput |           country_agg_uncached |        3.21 |   ops/s |
|                                                 Max Throughput |           country_agg_uncached |        3.21 |   ops/s |
|                                       100th percentile latency |           country_agg_uncached |     585.681 |      ms |
|                                  100th percentile service time |           country_agg_uncached |     273.747 |      ms |
|                                                     error rate |           country_agg_uncached |           0 |       % |
|                                                 Min Throughput |             country_agg_cached |        3.09 |   ops/s |
|                                                Mean Throughput |             country_agg_cached |        3.09 |   ops/s |
|                                              Median Throughput |             country_agg_cached |        3.09 |   ops/s |
|                                                 Max Throughput |             country_agg_cached |        3.09 |   ops/s |
|                                       100th percentile latency |             country_agg_cached |     596.243 |      ms |
|                                  100th percentile service time |             country_agg_cached |     272.092 |      ms |
|                                                     error rate |             country_agg_cached |           0 |       % |
|                                                 Min Throughput |                         scroll |        2.13 | pages/s |
|                                                Mean Throughput |                         scroll |        2.13 | pages/s |
|                                              Median Throughput |                         scroll |        2.13 | pages/s |
|                                                 Max Throughput |                         scroll |        2.13 | pages/s |
|                                       100th percentile latency |                         scroll |     1763.43 |      ms |
|                                  100th percentile service time |                         scroll |     825.152 |      ms |
|                                                     error rate |                         scroll |           0 |       % |
|                                                 Min Throughput |                     expression |        3.03 |   ops/s |
|                                                Mean Throughput |                     expression |        3.03 |   ops/s |
|                                              Median Throughput |                     expression |        3.03 |   ops/s |
|                                                 Max Throughput |                     expression |        3.03 |   ops/s |
|                                       100th percentile latency |                     expression |     599.247 |      ms |
|                                  100th percentile service time |                     expression |     268.697 |      ms |
|                                                     error rate |                     expression |           0 |       % |
|                                                 Min Throughput |                painless_static |        3.12 |   ops/s |
|                                                Mean Throughput |                painless_static |        3.12 |   ops/s |
|                                              Median Throughput |                painless_static |        3.12 |   ops/s |
|                                                 Max Throughput |                painless_static |        3.12 |   ops/s |
|                                       100th percentile latency |                painless_static |     590.138 |      ms |
|                                  100th percentile service time |                painless_static |     269.305 |      ms |
|                                                     error rate |                painless_static |           0 |       % |
|                                                 Min Throughput |               painless_dynamic |        3.26 |   ops/s |
|                                                Mean Throughput |               painless_dynamic |        3.26 |   ops/s |
|                                              Median Throughput |               painless_dynamic |        3.26 |   ops/s |
|                                                 Max Throughput |               painless_dynamic |        3.26 |   ops/s |
|                                       100th percentile latency |               painless_dynamic |      579.19 |      ms |
|                                  100th percentile service time |               painless_dynamic |     271.871 |      ms |
|                                                     error rate |               painless_dynamic |           0 |       % |
|                                                 Min Throughput | decay_geo_gauss_function_score |        3.12 |   ops/s |
|                                                Mean Throughput | decay_geo_gauss_function_score |        3.12 |   ops/s |
|                                              Median Throughput | decay_geo_gauss_function_score |        3.12 |   ops/s |
|                                                 Max Throughput | decay_geo_gauss_function_score |        3.12 |   ops/s |
|                                       100th percentile latency | decay_geo_gauss_function_score |     596.454 |      ms |
|                                  100th percentile service time | decay_geo_gauss_function_score |     275.282 |      ms |
|                                                     error rate | decay_geo_gauss_function_score |           0 |       % |
|                                                 Min Throughput |   decay_geo_gauss_script_score |        3.01 |   ops/s |
|                                                Mean Throughput |   decay_geo_gauss_script_score |        3.01 |   ops/s |
|                                              Median Throughput |   decay_geo_gauss_script_score |        3.01 |   ops/s |
|                                                 Max Throughput |   decay_geo_gauss_script_score |        3.01 |   ops/s |
|                                       100th percentile latency |   decay_geo_gauss_script_score |     654.099 |      ms |
|                                  100th percentile service time |   decay_geo_gauss_script_score |     321.686 |      ms |
|                                                     error rate |   decay_geo_gauss_script_score |           0 |       % |
|                                                 Min Throughput |     field_value_function_score |        3.26 |   ops/s |
|                                                Mean Throughput |     field_value_function_score |        3.26 |   ops/s |
|                                              Median Throughput |     field_value_function_score |        3.26 |   ops/s |
|                                                 Max Throughput |     field_value_function_score |        3.26 |   ops/s |
|                                       100th percentile latency |     field_value_function_score |     576.019 |      ms |
|                                  100th percentile service time |     field_value_function_score |     269.222 |      ms |
|                                                     error rate |     field_value_function_score |           0 |       % |
|                                                 Min Throughput |       field_value_script_score |        3.16 |   ops/s |
|                                                Mean Throughput |       field_value_script_score |        3.16 |   ops/s |
|                                              Median Throughput |       field_value_script_score |        3.16 |   ops/s |
|                                                 Max Throughput |       field_value_script_score |        3.16 |   ops/s |
|                                       100th percentile latency |       field_value_script_score |     589.479 |      ms |
|                                  100th percentile service time |       field_value_script_score |     272.822 |      ms |
|                                                     error rate |       field_value_script_score |           0 |       % |
|                                                 Min Throughput |                    large_terms |        0.88 |   ops/s |
|                                                Mean Throughput |                    large_terms |        0.88 |   ops/s |
|                                              Median Throughput |                    large_terms |        0.88 |   ops/s |
|                                                 Max Throughput |                    large_terms |        0.88 |   ops/s |
|                                       100th percentile latency |                    large_terms |     2206.36 |      ms |
|                                  100th percentile service time |                    large_terms |     1059.19 |      ms |
|                                                     error rate |                    large_terms |           0 |       % |
|                                                 Min Throughput |           large_filtered_terms |        0.95 |   ops/s |
|                                                Mean Throughput |           large_filtered_terms |        0.95 |   ops/s |
|                                              Median Throughput |           large_filtered_terms |        0.95 |   ops/s |
|                                                 Max Throughput |           large_filtered_terms |        0.95 |   ops/s |
|                                       100th percentile latency |           large_filtered_terms |     1972.34 |      ms |
|                                  100th percentile service time |           large_filtered_terms |       907.1 |      ms |
|                                                     error rate |           large_filtered_terms |           0 |       % |
|                                                 Min Throughput |         large_prohibited_terms |        0.89 |   ops/s |
|                                                Mean Throughput |         large_prohibited_terms |        0.89 |   ops/s |
|                                              Median Throughput |         large_prohibited_terms |        0.89 |   ops/s |
|                                                 Max Throughput |         large_prohibited_terms |        0.89 |   ops/s |
|                                       100th percentile latency |         large_prohibited_terms |     2178.87 |      ms |
|                                  100th percentile service time |         large_prohibited_terms |     1040.79 |      ms |
|                                                     error rate |         large_prohibited_terms |           0 |       % |
|                                                 Min Throughput |           desc_sort_population |        2.52 |   ops/s |
|                                                Mean Throughput |           desc_sort_population |        2.52 |   ops/s |
|                                              Median Throughput |           desc_sort_population |        2.52 |   ops/s |
|                                                 Max Throughput |           desc_sort_population |        2.52 |   ops/s |
|                                       100th percentile latency |           desc_sort_population |     734.395 |      ms |
|                                  100th percentile service time |           desc_sort_population |     337.457 |      ms |
|                                                     error rate |           desc_sort_population |           0 |       % |
|                                                 Min Throughput |            asc_sort_population |        3.05 |   ops/s |
|                                                Mean Throughput |            asc_sort_population |        3.05 |   ops/s |
|                                              Median Throughput |            asc_sort_population |        3.05 |   ops/s |
|                                                 Max Throughput |            asc_sort_population |        3.05 |   ops/s |
|                                       100th percentile latency |            asc_sort_population |     606.012 |      ms |
|                                  100th percentile service time |            asc_sort_population |      277.78 |      ms |
|                                                     error rate |            asc_sort_population |           0 |       % |
|                                                 Min Throughput | asc_sort_with_after_population |        3.19 |   ops/s |
|                                                Mean Throughput | asc_sort_with_after_population |        3.19 |   ops/s |
|                                              Median Throughput | asc_sort_with_after_population |        3.19 |   ops/s |
|                                                 Max Throughput | asc_sort_with_after_population |        3.19 |   ops/s |
|                                       100th percentile latency | asc_sort_with_after_population |     592.422 |      ms |
|                                  100th percentile service time | asc_sort_with_after_population |      278.19 |      ms |
|                                                     error rate | asc_sort_with_after_population |           0 |       % |
|                                                 Min Throughput |            desc_sort_geonameid |        3.26 |   ops/s |
|                                                Mean Throughput |            desc_sort_geonameid |        3.26 |   ops/s |
|                                              Median Throughput |            desc_sort_geonameid |        3.26 |   ops/s |
|                                                 Max Throughput |            desc_sort_geonameid |        3.26 |   ops/s |
|                                       100th percentile latency |            desc_sort_geonameid |     584.147 |      ms |
|                                  100th percentile service time |            desc_sort_geonameid |     277.245 |      ms |
|                                                     error rate |            desc_sort_geonameid |           0 |       % |
|                                                 Min Throughput | desc_sort_with_after_geonameid |        3.39 |   ops/s |
|                                                Mean Throughput | desc_sort_with_after_geonameid |        3.39 |   ops/s |
|                                              Median Throughput | desc_sort_with_after_geonameid |        3.39 |   ops/s |
|                                                 Max Throughput | desc_sort_with_after_geonameid |        3.39 |   ops/s |
|                                       100th percentile latency | desc_sort_with_after_geonameid |     594.957 |      ms |
|                                  100th percentile service time | desc_sort_with_after_geonameid |     299.676 |      ms |
|                                                     error rate | desc_sort_with_after_geonameid |           0 |       % |
|                                                 Min Throughput |             asc_sort_geonameid |        2.96 |   ops/s |
|                                                Mean Throughput |             asc_sort_geonameid |        2.96 |   ops/s |
|                                              Median Throughput |             asc_sort_geonameid |        2.96 |   ops/s |
|                                                 Max Throughput |             asc_sort_geonameid |        2.96 |   ops/s |
|                                       100th percentile latency |             asc_sort_geonameid |      737.66 |      ms |
|                                  100th percentile service time |             asc_sort_geonameid |     399.819 |      ms |
|                                                     error rate |             asc_sort_geonameid |           0 |       % |
|                                                 Min Throughput |  asc_sort_with_after_geonameid |        3.48 |   ops/s |
|                                                Mean Throughput |  asc_sort_with_after_geonameid |        3.48 |   ops/s |
|                                              Median Throughput |  asc_sort_with_after_geonameid |        3.48 |   ops/s |
|                                                 Max Throughput |  asc_sort_with_after_geonameid |        3.48 |   ops/s |
|                                       100th percentile latency |  asc_sort_with_after_geonameid |     579.819 |      ms |
|                                  100th percentile service time |  asc_sort_with_after_geonameid |     292.395 |      ms |
|                                                     error rate |  asc_sort_with_after_geonameid |           0 |       % |


--------------------------------
[INFO] SUCCESS (took 43 seconds)
--------------------------------
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
