### PR TITLE
Allow users to specify number of docs per index when creating workloads

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -182,8 +182,10 @@ def create_arg_parser():
         help="Input JSON file to use containing custom workload queries that override the default match_all query")
     create_workload_parser.add_argument(
         "--number-of-docs",
-        type=opts.csv_to_list,
-        help="Comma-separated list of doc counts for each index specified in indices parameter. Ensure that order is preserved.")
+        action=opts.StoreKeyPairAsDict,
+        nargs='+',
+        metavar="KEY:VAL",
+        help="Map of index name and doc count to extract. Ensure that index name in key field exists in --indices parameter.")
 
     generate_parser = subparsers.add_parser("generate", help="Generate artifacts")
     generate_parser.add_argument(

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -55,12 +55,6 @@ def create_arg_parser():
             raise argparse.ArgumentError(argument=None, message="At least one argument required!")
         return lst
 
-    def list_or_none(arg):
-        lst = opts.csv_to_list(arg)
-        if len(lst) < 1:
-            return None
-        return lst
-
     def runtime_jdk(v):
         if v == "bundled":
             return v
@@ -185,11 +179,10 @@ def create_arg_parser():
     create_workload_parser.add_argument(
         "--custom-queries",
         type=argparse.FileType('r'),
-        help="Input JSON file to use containing custom workload queries that override the default match_all query"
-    )
+        help="Input JSON file to use containing custom workload queries that override the default match_all query")
     create_workload_parser.add_argument(
-        "--total-docs",
-        type=list_or_none,
+        "--number-of-docs",
+        type=opts.csv_to_list,
         help="Comma-separated list of doc counts for each index specified in indices parameter. Ensure that order is preserved.")
 
     generate_parser = subparsers.add_parser("generate", help="Generate artifacts")
@@ -917,7 +910,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             generate(cfg)
         elif sub_command == "create-workload":
             cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
-            cfg.add(config.Scope.applicationOverride, "generator", "total_docs", args.total_docs)
+            cfg.add(config.Scope.applicationOverride, "generator", "number_of_docs", args.number_of_docs)
             cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
             cfg.add(config.Scope.applicationOverride, "workload", "workload.name", args.workload)
             cfg.add(config.Scope.applicationOverride, "workload", "custom_queries", args.custom_queries)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -55,6 +55,12 @@ def create_arg_parser():
             raise argparse.ArgumentError(argument=None, message="At least one argument required!")
         return lst
 
+    def list_or_none(arg):
+        lst = opts.csv_to_list(arg)
+        if len(lst) < 1:
+            return None
+        return lst
+
     def runtime_jdk(v):
         if v == "bundled":
             return v
@@ -181,6 +187,10 @@ def create_arg_parser():
         type=argparse.FileType('r'),
         help="Input JSON file to use containing custom workload queries that override the default match_all query"
     )
+    create_workload_parser.add_argument(
+        "--total-docs",
+        type=list_or_none,
+        help="Comma-separated list of doc counts for each index specified in indices parameter. Ensure that order is preserved.")
 
     generate_parser = subparsers.add_parser("generate", help="Generate artifacts")
     generate_parser.add_argument(
@@ -907,6 +917,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             generate(cfg)
         elif sub_command == "create-workload":
             cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
+            cfg.add(config.Scope.applicationOverride, "generator", "total_docs", args.total_docs)
             cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
             cfg.add(config.Scope.applicationOverride, "workload", "workload.name", args.workload)
             cfg.add(config.Scope.applicationOverride, "workload", "custom_queries", args.custom_queries)

--- a/osbenchmark/resources/custom-query-workload.json.j2
+++ b/osbenchmark/resources/custom-query-workload.json.j2
@@ -6,6 +6,7 @@
       "operation": {
         "name": "{{query.name}}",
         "operation-type": "{{query['operation-type']}}",
+        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},
         "body": {{query.body | replace("'", '"') }}
       }
     }{% if not loop.last %},{% endif -%}

--- a/osbenchmark/resources/default-query-workload.json.j2
+++ b/osbenchmark/resources/default-query-workload.json.j2
@@ -4,6 +4,7 @@
     {
       "operation": {
         "operation-type": "search",
+        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},
         "body": {
           "query": {
             "match_all": {}

--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -24,6 +24,7 @@
 
 import difflib
 import json
+import argparse
 
 from osbenchmark.utils import io
 
@@ -35,7 +36,6 @@ def csv_to_list(csv):
         return []
     else:
         return [e.strip() for e in csv.split(",")]
-
 
 def to_bool(v):
     if v is None:
@@ -116,6 +116,24 @@ def make_list_of_close_matches(word_list, all_possibilities):
             close_matches.append(matched_word[0])
 
     return close_matches
+
+class StoreKeyPairAsDict(argparse.Action):
+     """
+     Custom Argparse action that allows users to pass in a key:value pairs after specifying a parameter.
+     Used as action for --number-of-docs parameter for create-workload subcommand.
+     """
+     def __init__(self, option_strings, dest, nargs=None, **kwargs):
+         self._nargs = nargs
+         super(StoreKeyPairAsDict, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
+
+     def __call__(self, parser, namespace, values, option_string=None):
+         my_dict = {}
+         for kv in values:
+             k,v = kv.split(":")
+             my_dict[k] = v
+         setattr(namespace, self.dest, my_dict)
+
+         return my_dict
 
 
 class ConnectOptions:

--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -118,22 +118,22 @@ def make_list_of_close_matches(word_list, all_possibilities):
     return close_matches
 
 class StoreKeyPairAsDict(argparse.Action):
-     """
-     Custom Argparse action that allows users to pass in a key:value pairs after specifying a parameter.
-     Used as action for --number-of-docs parameter for create-workload subcommand.
-     """
-     def __init__(self, option_strings, dest, nargs=None, **kwargs):
-         self._nargs = nargs
-         super(StoreKeyPairAsDict, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
+    """
+    Custom Argparse action that allows users to pass in a key:value pairs after specifying a parameter.
+    Used as action for --number-of-docs parameter for create-workload subcommand.
+    """
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        self._nargs = nargs
+        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-     def __call__(self, parser, namespace, values, option_string=None):
-         my_dict = {}
-         for kv in values:
-             k,v = kv.split(":")
-             my_dict[k] = v
-         setattr(namespace, self.dest, my_dict)
+    def __call__(self, parser, namespace, values, option_string=None):
+        my_dict = {}
+        for kv in values:
+            k,v = kv.split(":")
+            my_dict[k] = v
+        setattr(namespace, self.dest, my_dict)
 
-         return my_dict
+        return my_dict
 
 
 class ConnectOptions:

--- a/osbenchmark/workload_generator/corpus.py
+++ b/osbenchmark/workload_generator/corpus.py
@@ -50,7 +50,7 @@ def get_doc_outpath(outdir, name, suffix=""):
     return os.path.join(outdir, f"{name}-documents{suffix}.json")
 
 
-def extract(client, output_path, index):
+def extract(client, output_path, index, total_docs_requested=None):
     """
     Scroll an index with a match-all query, dumping document source to ``outdir/documents.json``.
 
@@ -62,7 +62,14 @@ def extract(client, output_path, index):
 
     logger = logging.getLogger(__name__)
 
-    total_docs = client.count(index=index)["count"]
+    total_docs_found = client.count(index=index)["count"]
+    if total_docs_requested is None:
+        # If none, just use all documents found
+        total_docs_requested = total_docs_found
+
+    # If total_docs_requested is >= than total_docs_found, it will just use total_docs_found. Other wise, use total_docs_requested
+    total_docs = min(total_docs_requested, total_docs_found)
+
     if total_docs > 0:
         logger.info("[%d] total docs in index [%s].", total_docs, index)
         docs_path = get_doc_outpath(output_path, index)

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -51,7 +51,7 @@ def check_if_indices_and_number_of_docs_match(indices, number_of_docs, docs_were
     --indices=movies --number-of-docs=1000,2000
     '''
     if docs_were_requested and len(indices) != len(number_of_docs):
-        raise exceptions.SystemSetupError("Both --indices and --number-of-docs were provided but missing corresponding indices or total docs.")
+        raise exceptions.SystemSetupError("Both --indices and --number-of-docs were provided but missing indices or docs.")
 
 def extract_mappings_and_corpora(client, output_path, indices_to_extract, number_of_docs_requested):
     indices = []
@@ -98,10 +98,10 @@ def create_workload(cfg):
     root_path = cfg.opts("generator", "output.path")
     target_hosts = cfg.opts("client", "hosts")
     client_options = cfg.opts("client", "options")
+    number_of_docs = cfg.opts("generator", "number_of_docs")
     unprocessed_custom_queries = cfg.opts("workload", "custom_queries")
 
     custom_queries = process_custom_queries(unprocessed_custom_queries)
-    number_of_docs = cfg.opts("generator", "number_of_docs")
 
     logger.info("Creating workload [%s] matching indices [%s]", workload_name, indices)
 

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -48,8 +48,8 @@ def check_if_indices_and_number_of_docs_match(indices, number_of_docs, docs_were
     the number of pairs need to be less than or equal to number of indices
     '''
     if docs_were_requested and len(indices) < len(number_of_docs):
-        raise exceptions.SystemSetupError(f"Number of key:value pairs exceeds number of indices mentioned in --indices. "
-                                          f"Ensure it is less than or equal to.")
+        raise exceptions.SystemSetupError("Number of key:value pairs exceeds number of indices mentioned in --indices. " +
+                                          "Ensure it is less than or equal to.")
 
 def extract_mappings_and_corpora(client, output_path, indices_to_extract, number_of_docs_requested):
     indices = []


### PR DESCRIPTION
### Description
`create-workload` currently fetches all documents from specified indices in `--indices`. Users should have the option to specify a subset of documents if they do not want to use all of the documents. In this PR, OSB now supports running `--total-docs` in conjunction with `--indices`. It takes in a comma-separated list of document counts that correspond to the respective index in the list of indices in `--indices`.
```
# Example: if movies and actors has a total document count of 3000 and 2000 respectively, users can specify that they want only 1500 documents from movies index and 1200 documents from actors index with these parameters.
--indices=movies,actors --number-of-docs movies:1500 actors:1200
```

See #289 for more details.

### Issues Resolved
#289 

### Testing
- [x] New functionality includes testing

Tested it with a few indices in private cluster. Tested the following cases:
- with single index and single doc count 
- with multiple indices and multiple doc counts
- with multiple indices and single doc count (should result in error as both doc counts need to be provided)
- with single index (should get all documents)
- with multiple indices (should get all documents)

See #289 for outputs and more details

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
