### PR TITLE
Create workloads with default query or custom queries

### DIFF
--- a/CREATE_WORKLOAD_GUIDE.md
+++ b/CREATE_WORKLOAD_GUIDE.md
@@ -1,0 +1,114 @@
+# Create Workload Guide
+
+This guide explores how users can use the `create-workload` subcommand in OpenSearch Benchmark to create a workload based on pre-existing data in a cluster.
+
+### Create a Workload from Pre-Existing Indices in a Cluster
+
+**Prerequisites:**
+* OpenSearch cluster with data ingested into it in an index. Ensure that index has 1000+ docs. If not, a workload will be created but users cannot run the workload with `--test-mode`.
+* Ensure that your cluster is permissive.
+
+Create a workload with the following command:
+```
+$ opensearch-benchmark create-workload \
+--workload="<WORKLOAD NAME>" \
+--target-hosts="<CLUSTER ENDPOINT>" \
+--client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" \
+--indices="<INDICES TO GENERATE WORKLOAD FROM>" \
+--output-path="<LOCAL DIRECTORY PATH TO STORE WORKLOAD>"
+```
+Note that:
+* `--indices` can be 1+ indices specified in a comma-separated list.
+* If the cluster uses basic authentication and has TLS enabled, users will need to provide them through `--client-options`.
+
+The following is an example output of when a user creates a workload from an index called movies that contains 2000 docs.
+
+```
+   ____                  _____                      __       ____                  __                         __
+  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
+ / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
+/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
+\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
+    /_/
+
+[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
+[INFO] Connected to OpenSearch cluster [380d8fd64dd85b5f77c0ad81b0799e1e] version [1.1.0].
+
+Extracting documents for index [movies] for test mode...      1000/1000 docs [100.0% done]
+Extracting documents for index [movies]...                    2000/2000 docs [100.0% done]
+
+[INFO] Workload movies has been created. Run it with: opensearch-benchmark --workload-path=/Users/hoangia/Desktop/workloads/movies
+
+-------------------------------
+[INFO] SUCCESS (took 2 seconds)
+-------------------------------
+```
+
+By default, workloads created will come with the following operations run in the following order:
+* **delete-index**: Deletes any pre-existing indices with the same name(s) as the indices provided in `--indices`
+* **create-index**: Creates the index with the same name(s) as the indices provided in `--indices`
+* **cluster-health**: Verifies that cluster health is green before proceeding with the ingestion
+* **bulk**: Ingests documents collected from the indices specified in `--indices`
+* **default**: Runs a match-all query on the index for a number of iterations
+
+To invoke the newly created workload, run the following:
+```
+$ opensearch-benchmark execute_test \
+--pipeline="benchmark-only" \
+--workload-path="<PATH OUTPUTTED IN THE OUTPUT OF THE CREATE-WORKLOAD COMMAND>" \
+--target-host="<CLUSTER ENDPOINT>" \
+--client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+```
+
+Users have the options to specify a subset of documents from the index or override the default match_all query. See the following sections for more information on how.
+
+### Adding Custom Queries
+Add `--custom-queries` to the `create-workload` command. This parameter takes in a JSON filepath. This overrides the default match_all query with the queries present in the input file.
+
+Requirements:
+* Ensure that queries are properly formatted and adhere to JSON schema
+* Ensure that all queries are contained within a list. Exception: If providing only a single query, it does not have to be in a list.
+
+Adding to the previous example, a user wants to override default query with the following two custom queries in a JSON file.
+```
+[
+  {
+    "name": "default",
+    "operation-type": "search",
+    "body": {
+      "query": {
+        "match_all": {}
+      }
+    }
+  },
+  {
+    "name": "term",
+    "operation-type": "search",
+    "body": {
+      "query": {
+        "term": {
+          "director": "Ian"
+        }
+      }
+    }
+  }
+]
+```
+
+To do this, the user can provide the JSON filepath to `--custom-queries` parameter:
+```
+$ opensearch-benchmark create-workload \
+--workload="<WORKLOAD NAME>" \
+--target-hosts="<CLUSTER ENDPOINT>" \
+--client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" \
+--indices="<INDICES TO GENERATE WORKLOAD FROM>" \
+--output-path="<LOCAL DIRECTORY PATH TO STORE WORKLOAD>" \
+--custom-queries="<JSON filepath containing queries>"
+```
+
+### Common Errors
+When adding custom queries, users might experience the following error will occur if the queries do not adhere to JSON schema standards or are not in a list.
+```
+[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
+[ERROR] Cannot create-workload. Ensure JSON schema is valid and queries are contained in a list: Extra data: line 9 column 2 (char 113)
+```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ After the test execution, a summary report is written to the command line:
     [INFO] SUCCESS (took 2634 seconds)
     ----------------------------------
 
+Creating Your Own Workloads
+---------------------------
+For more information on how users can create their own workloads, see [the Create Workload Guide](./CREATE_WORKLOAD_GUIDE.md)
 
 Getting help
 ------------

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -176,6 +176,11 @@ def create_arg_parser():
         "--output-path",
         default=os.path.join(os.getcwd(), "workloads"),
         help="Workload output directory (default: workloads/)")
+    create_workload_parser.add_argument(
+        "--custom-queries",
+        type=argparse.FileType('r'),
+        help="Input JSON file to use containing custom workload queries that override the default match_all query"
+    )
 
     generate_parser = subparsers.add_parser("generate", help="Generate artifacts")
     generate_parser.add_argument(
@@ -904,6 +909,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
             cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
             cfg.add(config.Scope.applicationOverride, "workload", "workload.name", args.workload)
+            cfg.add(config.Scope.applicationOverride, "workload", "custom_queries", args.custom_queries)
             configure_connection_params(arg_parser, args, cfg)
 
             workload_generator.create_workload(cfg)

--- a/osbenchmark/resources/base-workload.json.j2
+++ b/osbenchmark/resources/base-workload.json.j2
@@ -50,17 +50,7 @@
         "ingest-percentage": {{ingest_percentage | default(100)}}
       },
       "clients": {{bulk_indexing_clients | default(8)}}
-    },
-    {
-      "operation": {
-        "operation-type": "search",
-        "body": {
-          "query": {
-            "match_all": {}
-          }
-        }
-      },
-      "clients": {{search_clients | default(8)}}
-    }
-  ]{% endraw %}
+    },{% endraw -%}
+    {% block queries %}{% endblock %}
+  ]
 }

--- a/osbenchmark/resources/custom-query-workload.json.j2
+++ b/osbenchmark/resources/custom-query-workload.json.j2
@@ -1,0 +1,64 @@
+{% raw %}{% import "benchmark.helpers" as benchmark with context %}{% endraw %}
+{
+  "version": 2,
+  "description": "Tracker-generated workload for {{workload_name}}",
+  "indices": [{% set comma = joiner() %}{% for index in indices %}{{comma()}}
+    {
+      "name": "{{index.name}}",
+      "body": "{{index.filename}}"
+    }{% endfor %}
+  ],
+  "corpora": [{% set comma = joiner() %}{% for corpus in corpora %}{{comma()}}
+    {
+      "name": "{{corpus.index_name}}",
+      "documents": [
+        {
+          "target-index": "{{corpus.index_name}}",
+          "source-file": "{{corpus.filename}}",
+          "document-count": {{corpus.doc_count}},
+          "compressed-bytes": {{corpus.compressed_bytes}},
+          "uncompressed-bytes": {{corpus.uncompressed_bytes}}
+        }
+      ]
+    }{% endfor %}
+  ],
+  "schedule": [
+    {
+      "operation": "delete-index"
+    },{% raw %}
+    {
+      "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
+      }
+    },{% endraw %}
+    {
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},{% raw %}
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(5000)}},
+        "ingest-percentage": {{ingest_percentage | default(100)}}
+      },
+      "clients": {{bulk_indexing_clients | default(8)}}
+    },{% endraw -%}
+    {% for query in custom_queries %}
+    {
+      "operation": {
+        "name": "{{query.name}}",
+        "operation-type": "{{query['operation-type']}}",
+        "body": {{query.body | replace("'", '"') }}
+      }
+    }{% if not loop.last %},{% endif -%}
+    {% endfor %}
+  ]
+}

--- a/osbenchmark/resources/custom-query-workload.json.j2
+++ b/osbenchmark/resources/custom-query-workload.json.j2
@@ -1,56 +1,6 @@
-{% raw %}{% import "benchmark.helpers" as benchmark with context %}{% endraw %}
-{
-  "version": 2,
-  "description": "Tracker-generated workload for {{workload_name}}",
-  "indices": [{% set comma = joiner() %}{% for index in indices %}{{comma()}}
-    {
-      "name": "{{index.name}}",
-      "body": "{{index.filename}}"
-    }{% endfor %}
-  ],
-  "corpora": [{% set comma = joiner() %}{% for corpus in corpora %}{{comma()}}
-    {
-      "name": "{{corpus.index_name}}",
-      "documents": [
-        {
-          "target-index": "{{corpus.index_name}}",
-          "source-file": "{{corpus.filename}}",
-          "document-count": {{corpus.doc_count}},
-          "compressed-bytes": {{corpus.compressed_bytes}},
-          "uncompressed-bytes": {{corpus.uncompressed_bytes}}
-        }
-      ]
-    }{% endfor %}
-  ],
-  "schedule": [
-    {
-      "operation": "delete-index"
-    },{% raw %}
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "settings": {{index_settings | default({}) | tojson}}
-      }
-    },{% endraw %}
-    {
-      "operation": {
-        "operation-type": "cluster-health",
-        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},{% raw %}
-        "request-params": {
-          "wait_for_status": "{{cluster_health | default('green')}}",
-          "wait_for_no_relocating_shards": "true"
-        },
-        "retry-until-success": true
-      }
-    },
-    {
-      "operation": {
-        "operation-type": "bulk",
-        "bulk-size": {{bulk_size | default(5000)}},
-        "ingest-percentage": {{ingest_percentage | default(100)}}
-      },
-      "clients": {{bulk_indexing_clients | default(8)}}
-    },{% endraw -%}
+{% extends "base-workload.json.j2" %}
+
+{%- block queries -%}
     {% for query in custom_queries %}
     {
       "operation": {
@@ -60,5 +10,4 @@
       }
     }{% if not loop.last %},{% endif -%}
     {% endfor %}
-  ]
-}
+{%- endblock %}

--- a/osbenchmark/resources/default-query-workload.json.j2
+++ b/osbenchmark/resources/default-query-workload.json.j2
@@ -1,0 +1,15 @@
+{% extends "base-workload.json.j2" %}
+
+{% block queries %}
+    {
+      "operation": {
+        "operation-type": "search",
+        "body": {
+          "query": {
+            "match_all": {}
+          }
+        }
+      },{% raw %}
+      "clients": {{search_clients | default(8)}}{% endraw %}
+    }
+{%- endblock %}

--- a/osbenchmark/resources/workload.json.j2
+++ b/osbenchmark/resources/workload.json.j2
@@ -50,6 +50,17 @@
         "ingest-percentage": {{ingest_percentage | default(100)}}
       },
       "clients": {{bulk_indexing_clients | default(8)}}
+    },
+    {
+      "operation": {
+        "operation-type": "search",
+        "body": {
+          "query": {
+            "match_all": {}
+          }
+        }
+      },
+      "clients": {{search_clients | default(8)}}
     }
   ]{% endraw %}
 }

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -113,7 +113,7 @@ def create_workload(cfg):
     if custom_queries:
         process_template(templates_path, "custom-query-workload.json.j2", template_vars, workload_path)
     else:
-        process_template(templates_path, "workload.json.j2", template_vars, workload_path)
+        process_template(templates_path, "default-query-workload.json.j2", template_vars, workload_path)
 
     console.println("")
     console.info(f"Workload {workload_name} has been created. Run it with: {PROGRAM_NAME} --workload-path={output_path}")

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -29,7 +29,7 @@ import json
 from opensearchpy import OpenSearchException
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from osbenchmark import PROGRAM_NAME
+from osbenchmark import PROGRAM_NAME, exceptions
 from osbenchmark.client import OsClientFactory
 from osbenchmark.workload_generator import corpus, index
 from osbenchmark.utils import io, opts, console
@@ -67,7 +67,12 @@ def process_custom_queries(custom_queries):
         return []
 
     with custom_queries as queries:
-        data = json.load(queries)
+        try:
+            data = json.load(queries)
+            if isinstance(data, dict):
+                data = [data]
+        except ValueError as err:
+            raise exceptions.SystemSetupError(f"Ensure JSON schema is valid and queries are contained in a list: {err}")
 
     return data
 

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -63,10 +63,11 @@ def extract_mappings_and_corpora(client, output_path, indices_to_extract):
     return indices, corpora
 
 def process_custom_queries(custom_queries):
+    if not custom_queries:
+        return []
+
     with custom_queries as queries:
-        logger = logging.getLogger(__name__)
         data = json.load(queries)
-        logger.info("DATA: %s", data)
 
     return data
 
@@ -81,7 +82,6 @@ def create_workload(cfg):
     unprocessed_custom_queries = cfg.opts("workload", "custom_queries")
 
     custom_queries = process_custom_queries(unprocessed_custom_queries)
-    logger.info("Custom Queries: %s", type(custom_queries))
 
     logger.info("Creating workload [%s] matching indices [%s]", workload_name, indices)
 
@@ -111,7 +111,6 @@ def create_workload(cfg):
     templates_path = os.path.join(cfg.opts("node", "benchmark.root"), "resources")
 
     if custom_queries:
-        logger.info("HERE IN CUSTOM QUERIES")
         process_template(templates_path, "custom-query-workload.json.j2", template_vars, workload_path)
     else:
         process_template(templates_path, "workload.json.j2", template_vars, workload_path)


### PR DESCRIPTION
### Description
### Current situation
OSB's `create-workload` subcommand creates a custom workload based off of a specific index in a cluster. However, it only generates operations: 
- delete index
- create index
- cluster health check
- bulk ingestion into index

Users will benefit if the command is extended and allows users to provide queries to use. If no queries are specified, then the workload should come with a default query, such as `match_all` query, which is the simplest query that matches all documents in the index.

### This PR adds the following changes:
- For Jinja2 best practices, have renamed the current `workload.json.j2` to be `base-workload.json.j2`. This acts as a parent template that child templates -- `default-query-workloads.json.j2` and `custom-query-workloads.json.j2` -- inherit from. 
-if `create-workloads` subcommand invoked without `--custom-queries`, the `default-query-workloads.json.j2` template is used. This just appends a `match_all` query to the end of `base-workload.json.j2`
- if `create-workloads` subcommand invoked with `--custom-queries`, the `custom-query-workloads.json.j2` template is used and appends all the queries the user has provided to the end of `base-workload.json.j2`. This parameter requires a JSON file that contains an array of queries like the following. Each query entry in the array needs to have a `name`, `operation-type`, and a `body`.
```
# Example of queries to provide to --custom-queries parameter
[
  {
    "name": "<NAME>",
    "operation-type": "<OPERATION-TYPE>",
    "body": {
             <BODY OF QUERY>
    }
  },
  {
    "name": "<NAME>",
    "operation-type": "<OPERATION-TYPE>",
    "body": {
            <BODY OF QUERY>
    }
  }
]
```
### Issues Resolved
#290 

### Testing
- [x] New functionality includes testing

Generated various workloads with both default query and custom queries tailored to corpus data. Tested out the workloads after creating.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
