### PR TITLE
Validate index.codec when user provides as workload params

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -128,3 +128,16 @@ make install
 ```
 ### Adding New Major and Minor Python Versions to OpenSearch-Benchmark
 To streamline the process, please refer to [this guide](./PYTHON_SUPPORT_GUIDE.md)
+
+### Debugging Unittests in VS Code
+To debug the unittests in VS Code, add the following blurb to the Python `launch.json` file.
+```
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-k ${file}"]
+        }
+```
+This will allow users to run and debug unittests easily without invoking pytest on the command line.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -129,8 +129,8 @@ make install
 ### Adding New Major and Minor Python Versions to OpenSearch-Benchmark
 To streamline the process, please refer to [this guide](./PYTHON_SUPPORT_GUIDE.md)
 
-### Debugging Unittests in VS Code
-To debug the unittests in VS Code, add the following blurb to the Python `launch.json` file.
+### Debugging Unittests in Visual Studio Code
+To run and debug unittests in Visual Studio Code, add the following configuration to the Python Debugger `launch.json` file. See [the official Visual Studio Code documentation](https://code.visualstudio.com/docs/editor/debugging) for more information on setting up and accessing `launch.json` file.
 ```
         {
             "name": "Python: Module",
@@ -140,4 +140,4 @@ To debug the unittests in VS Code, add the following blurb to the Python `launch
             "args": ["-k ${file}"]
         }
 ```
-This will allow users to run and debug unittests easily without invoking pytest on the command line.
+With this, users can easily run and debug unittests within Visual Studio Code without invoking pytest manually on the command line.

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -200,23 +200,27 @@ class CreateIndexParamSource(ParamSource):
                         if "settings" in body:
                             # merge (and potentially override)
                             body["settings"].update(settings)
+                            self.validate_index_codec(body["settings"])
                         else:
                             body["settings"] = settings
                     elif not body and settings:
                         body = {
                             "settings": settings
                         }
-
                     self.index_definitions.append((idx.name, body))
         else:
             try:
                 # only 'index' is mandatory, the body is optional (may be ok to create an index without a body)
                 idx = params["index"]
                 body = params.get("body")
+                if body and "settings" in body:
+                    self.validate_index_codec(body["settings"])
                 if isinstance(idx, str):
                     idx = [idx]
                 for i in idx:
                     self.index_definitions.append((i, body))
+            except ValueError as e:
+                raise exceptions.InvalidSyntax(f"Please set value properly for create-index operation. {e}")
             except KeyError:
                 raise exceptions.InvalidSyntax("Please set the property 'index' for the create-index operation")
 
@@ -230,6 +234,9 @@ class CreateIndexParamSource(ParamSource):
         })
         return p
 
+    def validate_index_codec(self, settings):
+        if "index.codec" in settings:
+            return workload.IndexCodec.is_codec_valid(settings["index.codec"])
 
 class CreateDataStreamParamSource(ParamSource):
     def __init__(self, workload, params, **kwargs):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -220,7 +220,7 @@ class CreateIndexParamSource(ParamSource):
                 for i in idx:
                     self.index_definitions.append((i, body))
             except ValueError as e:
-                raise exceptions.InvalidSyntax(f"Please set value properly for create-index operation. {e}")
+                raise exceptions.InvalidSyntax(f"Please set the value properly for the create-index operation. {e}")
             except KeyError:
                 raise exceptions.InvalidSyntax("Please set the property 'index' for the create-index operation")
 

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -720,8 +720,8 @@ class IndexCodec(Enum):
 
     @classmethod
     def is_codec_valid(cls, codec):
-        for available_codec in cls:
-            if available_codec.value == codec:
+        for valid_codec in cls:
+            if codec == valid_codec.value:
                 return True
 
         raise ValueError(f"Invalid index.codec value '{codec}'")

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -713,6 +713,19 @@ class OperationType(Enum):
         else:
             raise KeyError(f"No enum value for [{v}]")
 
+@unique
+class IndexCodec(Enum):
+    Default = "default"
+    BestCompression = "BEST_COMPRESSION"
+
+    @classmethod
+    def is_codec_valid(cls, codec):
+        for available_codec in cls:
+            if available_codec.value == codec:
+                return True
+
+        raise ValueError(f"Invalid index.codec value '{codec}'")
+
 
 class TaskNameFilter:
     def __init__(self, name):

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -716,7 +716,7 @@ class OperationType(Enum):
 @unique
 class IndexCodec(Enum):
     Default = "default"
-    BestCompression = "BEST_COMPRESSION"
+    BestCompression = "best_compression"
 
     @classmethod
     def is_codec_valid(cls, codec):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1576,6 +1576,84 @@ class CreateIndexParamSourceTests(TestCase):
         index, _ = p["indices"][0]
         self.assertEqual("index2", index)
 
+    def test_create_index_with_codec_default(self):
+        source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
+            "index": "test",
+            "body": {
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.codec": "default"
+                },
+                "mappings": {
+                    "doc": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+        p = source.params()
+        self.assertEqual(1, len(p["indices"]))
+        index, body = p["indices"][0]
+        self.assertEqual("test", index)
+        self.assertTrue(len(body) > 0)
+        self.assertEqual({}, p["request-params"])
+        self.assertEqual("default", body["settings"]["index.codec"])
+
+    def test_create_index_with_codec_best_compression(self):
+        source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
+            "index": "test",
+            "body": {
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.codec": "BEST_COMPRESSION"
+                },
+                "mappings": {
+                    "doc": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+        p = source.params()
+        self.assertEqual(1, len(p["indices"]))
+        index, body = p["indices"][0]
+        self.assertEqual("test", index)
+        self.assertTrue(len(body) > 0)
+        self.assertEqual({}, p["request-params"])
+        self.assertEqual("BEST_COMPRESSION", body["settings"]["index.codec"])
+
+    def test_create_index_with_codec_invalid(self):
+        with self.assertRaises(exceptions.InvalidSyntax) as context:
+            params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
+                "index": "test",
+                "body": {
+                    "settings": {
+                        "index.number_of_replicas": 0,
+                        "index.codec": "invalid_codec"
+                    },
+                    "mappings": {
+                        "doc": {
+                            "properties": {
+                                "name": {
+                                    "type": "keyword",
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.assertEqual(str(context.exception), "Please set value properly for create-index operation. Invalid index.codec value 'invalid_codec'")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1654,7 +1654,7 @@ class CreateIndexParamSourceTests(TestCase):
             })
 
         self.assertEqual(str(context.exception),
-                         "Please set value properly for create-index operation. Invalid index.codec value 'invalid_codec'")
+                         "Please set the value properly for the create-index operation. Invalid index.codec value 'invalid_codec'")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1576,7 +1576,7 @@ class CreateIndexParamSourceTests(TestCase):
         index, _ = p["indices"][0]
         self.assertEqual("index2", index)
 
-    def test_create_index_with_codec_default(self):
+    def test_create_index_with_default_codec(self):
         source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
             "index": "test",
             "body": {
@@ -1604,7 +1604,7 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
         self.assertEqual("default", body["settings"]["index.codec"])
 
-    def test_create_index_with_codec_best_compression(self):
+    def test_create_index_with_best_compression_codec(self):
         source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
             "index": "test",
             "body": {
@@ -1632,7 +1632,7 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
         self.assertEqual("BEST_COMPRESSION", body["settings"]["index.codec"])
 
-    def test_create_index_with_codec_invalid(self):
+    def test_create_index_with_invalid_codec(self):
         with self.assertRaises(exceptions.InvalidSyntax) as context:
             params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
                 "index": "test",

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1610,7 +1610,7 @@ class CreateIndexParamSourceTests(TestCase):
             "body": {
                 "settings": {
                     "index.number_of_replicas": 0,
-                    "index.codec": "BEST_COMPRESSION"
+                    "index.codec": "best_compression"
                 },
                 "mappings": {
                     "doc": {
@@ -1630,7 +1630,7 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual("test", index)
         self.assertTrue(len(body) > 0)
         self.assertEqual({}, p["request-params"])
-        self.assertEqual("BEST_COMPRESSION", body["settings"]["index.codec"])
+        self.assertEqual("best_compression", body["settings"]["index.codec"])
 
     def test_create_index_with_invalid_codec(self):
         with self.assertRaises(exceptions.InvalidSyntax) as context:

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1653,7 +1653,8 @@ class CreateIndexParamSourceTests(TestCase):
                 }
             })
 
-        self.assertEqual(str(context.exception), "Please set value properly for create-index operation. Invalid index.codec value 'invalid_codec'")
+        self.assertEqual(str(context.exception),
+                         "Please set value properly for create-index operation. Invalid index.codec value 'invalid_codec'")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):


### PR DESCRIPTION
### Description
Users are witnessing that OSB falls back silently to use LZ4 (default) index.codec when provided with an invalid index codec. OSB should check if the index.codec is valid and raise an error if it isn't. See #268 for more

### Issues Resolved
#268 

### Testing
- [x] New functionality includes testing

- Added additional unittests
- Tested manually and got the outcome that was desired 
```
$ opensearch-benchmark execute-test \
--pipeline=benchmark-only \
 --workload=geonames \
--target-host="<TARGET_ENDPOINT>" \
--client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" \
 --include-tasks=delete-index,create-index,index-append \
--workload-params='{"index_settings":{"index.codec": "this_should_be_invalid"}}' \

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.

[ERROR] Cannot execute-test. Error in workload preparator (Invalid index.codec value 'this_should_be_invalid')

Getting further help:
*********************
* Check the log files in /Users/hoangia/.benchmark/logs for errors.
* Read the documentation at https://opensearch.org/docs.
* Ask a question on the forum at https://forum.opensearch.org/.
* Raise an issue at https://github.com/opensearch-project/OpenSearch-Benchmark/issues and include the log files in /Users/hoangia/.benchmark/logs.

-------------------------------
[INFO] FAILURE (took 8 seconds)
-------------------------------
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
