### PR TITLE
Remove unnecessary super().__init__ in opts class

### DIFF
--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -123,10 +123,6 @@ class StoreKeyPairAsDict(argparse.Action):
     Custom Argparse action that allows users to pass in a key:value pairs after specifying a parameter.
     Used as action for --number-of-docs parameter for create-workload subcommand.
     """
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        self._nargs = nargs
-        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
-
     def __call__(self, parser, namespace, values, option_string=None):
         custom_dict = {}
         for kv in values:


### PR DESCRIPTION
### Description
Removing unnecessary `super().__init__()` in opts class.

### Issues Resolved
N/A

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
Tested it again with create-workoads `--number-of-docs` feature and ran a test

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
