### PR TITLE
Add support for providing datastore password via environment variable

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -184,19 +184,17 @@ class OsClientFactory:
         secure = convert.to_bool(self._config.opts("results_publishing", "datastore.secure"))
         user = self._config.opts("results_publishing", "datastore.user")
         try:
-            password = os.environ["OSB_RESULTS_PUBLISHING_PASSWORD"]
+            password = os.environ["OSB_DATASTORE_PASSWORD"]
         except KeyError:
             try:
                 password = self._config.opts("results_publishing", "datastore.password")
             except exceptions.ConfigError:
                 raise exceptions.ConfigError(
-                    "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
+                    "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
                 ) from None
         verify = self._config.opts("results_publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
         ca_path = self._config.opts("results_publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
         self.probe_version = self._config.opts("results_publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
-
-        # Use environment variable
 
         # Instead of duplicating code, we're just adapting the metrics store specific properties to match the regular client options.
         client_options = {

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -183,10 +183,20 @@ class OsClientFactory:
         port = self._config.opts("results_publishing", "datastore.port")
         secure = convert.to_bool(self._config.opts("results_publishing", "datastore.secure"))
         user = self._config.opts("results_publishing", "datastore.user")
-        password = self._config.opts("results_publishing", "datastore.password")
+        try:
+            password = os.environ["OSB_RESULTS_PUBLISHING_PASSWORD"]
+        except KeyError:
+            try:
+                password = self._config.opts("results_publishing", "datastore.password")
+            except exceptions.ConfigError:
+                raise exceptions.ConfigError(
+                    "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
+                ) from None
         verify = self._config.opts("results_publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
         ca_path = self._config.opts("results_publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
         self.probe_version = self._config.opts("results_publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
+
+        # Use environment variable
 
         # Instead of duplicating code, we're just adapting the metrics store specific properties to match the regular client options.
         client_options = {
@@ -1538,7 +1548,7 @@ class EsTestExecutionStore(TestExecutionStore):
 class OsResultsStore:
     """
     Stores the results of a test_execution in a format that is
-    better suited for reporting with Kibana.
+    better suited for reporting with OpenSearch Dashboards.
     """
     INDEX_PREFIX = "benchmark-results-"
     RESULTS_DOC_TYPE = "_doc"

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -210,7 +210,7 @@ class OsClientTests(TestCase):
             cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
         elif password_configuration == "environment":
             monkeypatch = pytest.MonkeyPatch()
-            monkeypatch.setenv("OSB_RESULTS_PUBLISHING_PASSWORD", _datastore_password)
+            monkeypatch.setenv("OSB_DATASTORE_PASSWORD", _datastore_password)
 
         if not _datastore_verify_certs:
             cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
@@ -223,7 +223,7 @@ class OsClientTests(TestCase):
 
             assert (
                 e.message
-                == "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
+                == "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
             )
             return
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -153,102 +153,88 @@ class OsClientTests(TestCase):
         def __init__(self, hosts):
             self.transport = OsClientTests.TransportMock(hosts)
 
-    @mock.patch("osbenchmark.client.OsClientFactory")
-    def test_config_opts_parsing_with_none(self, client_OsClientfactory):
-        password_configuration = None
-        cfg = config.Config()
-
-        _datastore_host = ".".join([str(random.randint(1, 254)) for _ in range(4)])
-        _datastore_port = random.randint(1024, 65535)
-        _datastore_secure = random.choice(["True", "true"])
-        _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
-        _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
-        _datastore_verify_certs = random.choice([True, False])
-
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
-
-        if password_configuration == "config":
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
-        elif password_configuration == "environment":
-            monkeypatch = pytest.MonkeyPatch()
-            monkeypatch.setenv("OSB_RESULTS_PUBLISHING_PASSWORD", _datastore_password)
-
-        if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
-
-        try:
-            metrics.OsClientFactory(cfg)
-        except exceptions.ConfigError as e:
-            if password_configuration is not None:
-                raise
-
-            assert (
-                e.message
-                == "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
-            )
-            # It doesn't exit here
-            return
+    def test_config_opts_parsing_with_none(self):
+        # Tries parsing but fails because it does not detect password from ENV or Config
+        self.config_opts_parsing(None)
 
     @mock.patch("osbenchmark.client.OsClientFactory")
     def test_config_opts_parsing_with_config(self, client_OsClientfactory):
-        self.config_opts_parsing(client_OsClientfactory, "config")
-
-    @mock.patch("osbenchmark.client.OsClientFactory")
-    def test_config_opts_parsing_with_env(self, client_OsClientfactory):
-        self.config_opts_parsing(client_OsClientfactory, "environment")
-
-    def config_opts_parsing(self, client_OsClientfactory, password_configuration):
-        cfg = config.Config()
-
-        _datastore_host = ".".join([str(random.randint(1, 254)) for _ in range(4)])
-        _datastore_port = random.randint(1024, 65535)
-        _datastore_secure = random.choice(["True", "true"])
-        _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
-        _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
-        _datastore_verify_certs = random.choice([True, False])
-
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
-
-        if password_configuration == "config":
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
-        elif password_configuration == "environment":
-            monkeypatch = pytest.MonkeyPatch()
-            monkeypatch.setenv("OSB_RESULTS_PUBLISHING_PASSWORD", _datastore_password)
-
-        if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
-
-        try:
-            metrics.OsClientFactory(cfg)
-        except exceptions.ConfigError as e:
-            if password_configuration is not None:
-                raise
-
-            assert (
-                e.message
-                == "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
-            )
-            # It doesn't exit here
-            return
+        config_opts = self.config_opts_parsing("config")
 
         expected_client_options = {
             "use_ssl": True,
             "timeout": 120,
-            "basic_auth_user": _datastore_user,
-            "basic_auth_password": _datastore_password,
-            "verify_certs": _datastore_verify_certs
+            "basic_auth_user": config_opts["_datastore_user"],
+            "basic_auth_password": config_opts["_datastore_password"],
+            "verify_certs": config_opts["_datastore_verify_certs"]
         }
 
         client_OsClientfactory.assert_called_with(
-            hosts=[{"host": _datastore_host, "port": _datastore_port}],
+            hosts=[{"host": config_opts["_datastore_host"], "port": config_opts["_datastore_port"]}],
             client_options=expected_client_options
         )
+
+    @mock.patch("osbenchmark.client.OsClientFactory")
+    def test_config_opts_parsing_with_env(self, client_OsClientfactory):
+        config_opts = self.config_opts_parsing("environment")
+
+        expected_client_options = {
+            "use_ssl": True,
+            "timeout": 120,
+            "basic_auth_user": config_opts["_datastore_user"],
+            "basic_auth_password": config_opts["_datastore_password"],
+            "verify_certs": config_opts["_datastore_verify_certs"]
+        }
+
+        client_OsClientfactory.assert_called_with(
+            hosts=[{"host": config_opts["_datastore_host"], "port": config_opts["_datastore_port"]}],
+            client_options=expected_client_options
+        )
+
+    def config_opts_parsing(self, password_configuration):
+        cfg = config.Config()
+
+        _datastore_host = ".".join([str(random.randint(1, 254)) for _ in range(4)])
+        _datastore_port = random.randint(1024, 65535)
+        _datastore_secure = random.choice(["True", "true"])
+        _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
+        _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
+        _datastore_verify_certs = random.choice([True, False])
+
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
+
+        if password_configuration == "config":
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
+        elif password_configuration == "environment":
+            monkeypatch = pytest.MonkeyPatch()
+            monkeypatch.setenv("OSB_RESULTS_PUBLISHING_PASSWORD", _datastore_password)
+
+        if not _datastore_verify_certs:
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
+
+        try:
+            metrics.OsClientFactory(cfg)
+        except exceptions.ConfigError as e:
+            if password_configuration is not None:
+                raise
+
+            assert (
+                e.message
+                == "No password configured through [results_publishing] configuration or OSB_RESULTS_PUBLISHING_PASSWORD environment variable."
+            )
+            return
+
+        return {
+            "_datastore_user": _datastore_user,
+            "_datastore_host": _datastore_host,
+            "_datastore_password": _datastore_password,
+            "_datastore_port": _datastore_port,
+            "_datastore_verify_certs": _datastore_verify_certs
+        }
+
 
     def test_raises_sytem_setup_error_on_connection_problems(self):
         def raise_connection_error():


### PR DESCRIPTION
### Description
Users can now specify datastore password as environment variable instead of through plain text on config `benchmark.ini`

### Issues Resolved

### Testing
- [x] New functionality includes testing

- Fixed unittests
- Tested it manually locally with no config and no env password, with config, and with env password only

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
