### PR TITLE
Updating integ tests to use current versions of OpenSearch

### DIFF
--- a/.github/workflows/manual-integ.yml
+++ b/.github/workflows/manual-integ.yml
@@ -44,6 +44,12 @@ jobs:
           distribution: 'adopt'
           java-version: '16'
       - run: echo "JAVA16_HOME=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Install JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+      - run: echo "JAVA17_HOME=$JAVA_HOME" >> $GITHUB_ENV
       - name: Run the CI build_it script
         run: bash .ci/build.sh build_it ${{ matrix.python-version }}
         env:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -64,7 +64,17 @@ make it
 
 ### Important information related to integration tests
 
-If you have multiple JDKs installed, export them to the following format `JAVA(jdk_version)_HOME`. Here is an example of how one would export JDK 8, 11, 15, 16:
+To have all the tests run successfully JDK 17 is required, since one of the tests builds the latest version of OpenSearch from source, and the OpenSearch project uses JDK 17 for this purpose.
+```
+export JAVA_HOME=/path/to/JDK17
+
+```
+
+Note that the `javadoc` executable should be available in the JDK installation.
+
+You could also use one of the following versions instead: 16, 15, 14, 13, 12, 11 or 8.  Most of the complement of tests included will work with these.
+
+If you have multiple JDKs installed, export them in the following format `JAVA(jdk_version)_HOME`. Here is an example of how one would export JDK 8, 11, 15, 16:
 ```
 export JAVA8_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_231.jdk/Contents/Home/
 export JAVA11_HOME=/Library/Java/JavaVirtualMachines/jdk-11.0.8.jdk/Contents/Home

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ docs-clean:
 
 # Avoid conflicts between .pyc/pycache related files created by local Python interpreters and other interpreters in Docker
 python-caches-clean:
-	-@find . -name "__pycache__" -exec rm -rf -- \{\} \;
-	-@find . -name ".pyc" -exec rm -rf -- \{\} \;
+	-@find . -name "__pycache__" -prune -exec rm -rf -- \{\} \;
+	-@find . -name ".pyc" -prune -exec rm -rf -- \{\} \;
 
 # Force recreation of the virtual environment used by tox.
 #

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -36,7 +36,7 @@ from osbenchmark import client, config, version
 from osbenchmark.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "os-it"]
-DISTRIBUTIONS = ["1.0.0", "1.0.1"]
+DISTRIBUTIONS = ["1.3.9", "2.5.0"]
 WORKLOADS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -194,7 +194,7 @@ class TestCluster:
 
 
 class OsMetricsStore:
-    VERSION = "1.0.1"
+    VERSION = "1.3.9"
 
     def __init__(self):
         self.cluster = TestCluster("in-memory-it")

--- a/osbenchmark/resources/provision_configs/1.0/provision_config_instances/v1/vanilla/config.ini
+++ b/osbenchmark/resources/provision_configs/1.0/provision_config_instances/v1/vanilla/config.ini
@@ -18,5 +18,5 @@ docker_image=opensearchproject/opensearch
 # major version of the JDK that is used to build OpenSearch
 build.jdk = 12
 # list of JDK major versions that are used to run OpenSearch
-runtime.jdk = 12,11,8
+runtime.jdk = 17,16,15,14,13,12,11,8
 runtime.jdk.bundled = true

--- a/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/config.ini
+++ b/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/config.ini
@@ -16,7 +16,7 @@ jdk.unbundled.release_url = https://artifacts.opensearch.org/releases/bundle/ope
 
 docker_image=opensearchproject/opensearch
 # major version of the JDK that is used to build OpenSearch
-build.jdk = 16
+build.jdk = 17
 # list of JDK major versions that are used to run OpenSearch
-runtime.jdk = 16,15,14,13,12,11
+runtime.jdk = 17,16,15,14,13,12,11,8
 runtime.jdk.bundled = true

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps=
     pytest
 passenv =
     HOME
+    JAVA_HOME
     JAVA8_HOME
     JAVA9_HOME
     JAVA10_HOME


### PR DESCRIPTION
### Description
The integration tests are currently using obsolete versions of OpenSearch, 1.0.0 and 1.0.1.  This updates the versions to the newer ones in the v1 and v2 branches.  There is a separate batch of improvements to these tests, which will be checked in post the next OSB release.

### Testing
Ran the integ tests on Ubuntu and Amazon Linux 2.  All passed.

On Mac, most of the tests passed, but there were occasional timeouts with one of the tests when runs were repeated.  This seemed to be the case even prior to these changes, so that will be made more robust separately.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
