### PR TITLE
Update results_publisher to publisher

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -62,6 +62,29 @@ make test
 make it
 ```
 
+We recommend users to look at the following two sections [Common issues in unittests](#common-issues-in-unittests) and [Important information related to integration tests](#important-information-related-to-integration-tests).
+
+### Common issues in Unittests
+#### OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
+When datastore password is assigned to env variable OSB_DATASTORE_PASSWORD instead of written in benchmark.ini, running make test will result in a failure as it's using the environment variable as seen here:
+```
+>           raise AssertionError(_error_message()) from cause
+E           AssertionError: expected call not found.
+E           Expected: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': 'JXkTu9JhzFq$', 'verify_certs': False})
+E           Actual: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'verify_certs': False, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': '<Value from OSB_DATASTORE_PASSWORD Environment Variable>'})
+
+../../../../.pyenv/versions/3.8.12/lib/python3.8/unittest/mock.py:913: AssertionError
+
+...
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/metrics_test.py::OsClientTests::test_config_opts_parsing_with_config - AssertionError: expected call not found.
+============ 1 failed, 1163 passed, 5 skipped, 3 warnings in 15.41s ============
+```
+To avoid issue when running unit tests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
+
+
 ### Important information related to integration tests
 
 To have all the tests run successfully JDK 17 is required, since one of the tests builds the latest version of OpenSearch from source, and the OpenSearch project uses JDK 17 for this purpose.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -71,26 +71,6 @@ make test
 
 ```
 
-#### OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
-OSB has the ability to store metrics into an OpenSearch datastore. To enable this, users can write the datastore password to the `benchmark.ini` config file or export it to the environment variable `OSB_DATASTORE_PASSWORD`. However, when the latter is done, users might encounter an assertion error when running unittests. This is because one unittest uses values assigned to `OSB_DATASTORE_PASSWORD`.
-
-The following is an example of the assertion error that comes up when users run unittests while the environment variable `OSB_DATASTORE_PASSWORD` is set.
-```
->           raise AssertionError(_error_message()) from cause
-E           AssertionError: expected call not found.
-E           Expected: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': 'JXkTu9JhzFq$', 'verify_certs': False})
-E           Actual: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'verify_certs': False, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': '<Value from OSB_DATASTORE_PASSWORD Environment Variable>'})
-
-../../../../.pyenv/versions/3.8.12/lib/python3.8/unittest/mock.py:913: AssertionError
-
-...
-
-=========================== short test summary info ============================
-FAILED tests/metrics_test.py::OsClientTests::test_config_opts_parsing_with_config - AssertionError: expected call not found.
-============ 1 failed, 1163 passed, 5 skipped, 3 warnings in 15.41s ============
-```
-To avoid this issue when running unittests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
-
 ### Integration Tests
 
 Integration tests can be run on the following operating systems:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -68,7 +68,7 @@ We recommend users to look at the following two sections [Common issues in unitt
 #### OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
 OSB has the ability to store metrics into an OpenSearch datastore. To enable this, users can write the datastore password to the `benchmark.ini` config file or export it to the environment variable `OSB_DATASTORE_PASSWORD`. However, when the latter is done, users might encounter an assertion error when running unittests. This is because one unittest uses values assigned to `OSB_DATASTORE_PASSWORD`.
 
-The following is an example of the assertion error the comes up when users run unittests while the environment variable `OSB_DATASTORE_PASSWORD` is set.
+The following is an example of the assertion error that comes up when users run unittests while the environment variable `OSB_DATASTORE_PASSWORD` is set.
 ```
 >           raise AssertionError(_error_message()) from cause
 E           AssertionError: expected call not found.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -3,19 +3,29 @@
 This document will walk you through on what's needed to start contributing code to OpenSearch Benchmark.
 
 ## Installation
+
 ### Prerequisites
 
-- Pyenv : Install `pyenv` and follow the instructions in the output of `pyenv init` to setup your shell and restart it before proceeding.
-For more details please refer to the [PyEnv installation instructions](https://github.com/pyenv/pyenv#installation).
-- JDK : JDK version required to build OpenSearch. Please refer to the [build setup requirements](https://github.com/opensearch-project/OpenSearch/blob/ca564fd04f5059cf9e3ce8aba442575afb3d99f1/DEVELOPER_GUIDE.md#install-prerequisites).
-- Docker : Docker and additionally `docker-compose`  on Linux.
-- Git : git 1.9 or latter.
+  - Pyenv : Install `pyenv` and follow the instructions in the output of `pyenv init` to set up your shell and restart it before proceeding.
+    For more details please refer to the [PyEnv installation instructions](https://github.com/pyenv/pyenv#installation).
+
+  - JDK: Although OSB is a Python application, it optionally builds and provisions OpenSearch clusters.  JDK version 17 is used to build the current version of OpenSearch.  Please refer to the [build setup requirements](https://github.com/opensearch-project/OpenSearch/blob/ca564fd04f5059cf9e3ce8aba442575afb3d99f1/DEVELOPER_GUIDE.md#install-prerequisites).
+    Note that the `javadoc` executable should be available in the JDK installation.  An earlier version of the JDK can be used, but not all the integration tests will pass.
+
+    ```
+    export JAVA_HOME=/path/to/JDK17
+
+    ```
+
+  - Install Docker and `docker-compose`.  Start the Docker server.  The user running the integration tests should have the permissions required to run docker commands.  Test by running `docker ps`.
+
+  - Git : git 1.9 or later.
 
 ### Setup
 
-Use the following command-line instructions to setup OpenSearch Benchmark for development:
+Use the following command-line instructions to set up OpenSearch Benchmark for development:
 ```
-git clone https://github.com/opensearch-project/OpenSearch-Benchmark.git
+git clone https://github.com/opensearch-project/OpenSearch-Benchmark
 cd OpenSearch-Benchmark
 make prereq
 make install
@@ -52,19 +62,15 @@ In order to run tests within the PyCharm IDE, ensure the `Python Integrated Tool
 
 ## Executing tests
 
-Once setup is complete, you may run unit/integration tests using the following :
+Once setup is complete, you may run the unit and integration tests.
+
+### Unit Tests
 
 ```
-## Run a unit test
 make test
 
-## Run integration tests
-make it
 ```
 
-We recommend users to look at the following two sections [Common issues in unittests](#common-issues-in-unittests) and [Important information related to integration tests](#important-information-related-to-integration-tests).
-
-### Common issues in Unittests
 #### OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
 OSB has the ability to store metrics into an OpenSearch datastore. To enable this, users can write the datastore password to the `benchmark.ini` config file or export it to the environment variable `OSB_DATASTORE_PASSWORD`. However, when the latter is done, users might encounter an assertion error when running unittests. This is because one unittest uses values assigned to `OSB_DATASTORE_PASSWORD`.
 
@@ -85,47 +91,20 @@ FAILED tests/metrics_test.py::OsClientTests::test_config_opts_parsing_with_confi
 ```
 To avoid this issue when running unittests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
 
+### Integration Tests
 
-### Important information related to integration tests
+Integration tests can be run on the following operating systems:
+  * RedHat
+  * CentOS
+  * Ubuntu
+  * Amazon Linux 2
+  * MacOS
 
-To have all the tests run successfully JDK 17 is required, since one of the tests builds the latest version of OpenSearch from source, and the OpenSearch project uses JDK 17 for this purpose.
-```
-export JAVA_HOME=/path/to/JDK17
-
-```
-
-Note that the `javadoc` executable should be available in the JDK installation.
-
-You could also use one of the following versions instead: 16, 15, 14, 13, 12, 11 or 8.  Most of the complement of tests included will work with these.
-
-If you have multiple JDKs installed, export them in the following format `JAVA(jdk_version)_HOME`. Here is an example of how one would export JDK 8, 11, 15, 16:
-```
-export JAVA8_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_231.jdk/Contents/Home/
-export JAVA11_HOME=/Library/Java/JavaVirtualMachines/jdk-11.0.8.jdk/Contents/Home
-export JAVA15_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-15.jdk/Contents/Home/
-export JAVA16_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-16.jdk/Contents/Home/
-```
-
-OpenSearch currently releases artifacts for the following operating systems:
-- Linux
-- Docker
-- FreeBSD
-
-If the operating system is not listed above then the artifacts used will default to Linux.
-
-For MacOS users running OpenSearch, please set JAVA_HOME to one of the local JDKs you exported as the JDK bundled with OpenSearch is not compatible with MacOS and prevent the metrics store from coming up correctly during integration tests.
-
-### Troubleshooting
-```
-root WARNING Unable to get address info for address xxxxyyyy (AddressFamily.AF_INET, SocketKind.SOCK_DGRAM, 17, 0): <class 'socket.gaierror'> [Errno 8] nodename nor servname provided, or not known
-```
-- VPN may be interfering. Try turning off the VPN. If you are connected to a VPN and face Docker-related issues when running the integration tests disconnecting from the VPN may fix this.
 
 ```
-Cannot download OpenSearch-1.0.1
-```
-- JAVA_HOME may not be correctly set.
+make it
 
+```
 
 ## Submitting your changes for a pull request
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,7 +66,9 @@ We recommend users to look at the following two sections [Common issues in unitt
 
 ### Common issues in Unittests
 #### OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
-When datastore password is assigned to env variable OSB_DATASTORE_PASSWORD instead of written in benchmark.ini, running make test will result in a failure as it's using the environment variable as seen here:
+OSB has the ability to store metrics into an OpenSearch datastore. To enable this, users can write the datastore password to the `benchmark.ini` config file or export it to the environment variable `OSB_DATASTORE_PASSWORD`. However, when the latter is done, users might encounter an assertion error when running unittests. This is because one unittest uses values assigned to `OSB_DATASTORE_PASSWORD`.
+
+The following is an example of the assertion error the comes up when users run unittests while the environment variable `OSB_DATASTORE_PASSWORD` is set.
 ```
 >           raise AssertionError(_error_message()) from cause
 E           AssertionError: expected call not found.
@@ -77,12 +79,11 @@ E           Actual: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 279
 
 ...
 
--- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 =========================== short test summary info ============================
 FAILED tests/metrics_test.py::OsClientTests::test_config_opts_parsing_with_config - AssertionError: expected call not found.
 ============ 1 failed, 1163 passed, 5 skipped, 3 warnings in 15.41s ============
 ```
-To avoid issue when running unit tests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
+To avoid this issue when running unittests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
 
 
 ### Important information related to integration tests

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 OpenSearch Benchmark
 ====================
 
-OpenSearch Benchmark is the macrobenchmarking framework for OpenSearch.
+OpenSearch Benchmark is a macrobenchmarking framework for OpenSearch, provided by the OpenSearch Project.
 
 What is OpenSearch Benchmark?
 -----------------------------
 
-If you are looking to performance test OpenSearch, then OpenSearch Benchmark is for you. It can help you with the following tasks:
+You can use OpenSearch Benchmark to gather performance metrics from an OpenSearch cluster for a variety of purposes, including:
 
-* Running performance benchmarks and recording results
-* Setting up and tearing down OpenSearch clusters for benchmarking
-* Managing benchmark data and specifications across OpenSearch versions
-* Discovering performance problems by attaching so-called telemetry devices
-* Comparing performance results
+* Tracking the overall performance of an OpenSearch cluster.
+* Informing decisions about when to upgrade your cluster to a new version.
+* Determining how changes to your workflow—such as modifying mappings or queries—might impact your cluster.
 * Creating customized workloads
 
 We have also put considerable effort into OpenSearch Benchmark to ensure that benchmarking data are reproducible.
+
+Official Documentation
+----------------------
+[Click here](https://opensearch.org/docs/latest/benchmark/index/) to view the official documentation website for OpenSearch Benchmark.
 
 Quick Start
 -----------
@@ -105,7 +107,7 @@ After the test execution, a summary report is written to the command line:
 
 Creating Your Own Workloads
 ---------------------------
-For more information on how users can create their own workloads, see [the Create Workload Guide](./CREATE_WORKLOAD_GUIDE.md)
+For more information on how users can create their own workloads, see [the Create Workload Guide](https://github.com/opensearch-project/opensearch-benchmark/blob/main/CREATE_WORKLOAD_GUIDE.md)
 
 Getting help
 ------------

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 OpenSearch Benchmark
 ====================
 
-OpenSearch Benchmark is a macrobenchmarking framework for OpenSearch, provided by the OpenSearch Project.
+OpenSearch Benchmark is the macrobenchmarking framework for OpenSearch.
 
 What is OpenSearch Benchmark?
 -----------------------------
 
-You can use OpenSearch Benchmark to gather performance metrics from an OpenSearch cluster for a variety of purposes, including:
+If you are looking to performance test OpenSearch, then OpenSearch Benchmark is for you. It can help you with the following tasks:
 
-* Tracking the overall performance of an OpenSearch cluster.
-* Informing decisions about when to upgrade your cluster to a new version.
-* Determining how changes to your workflow—such as modifying mappings or queries—might impact your cluster.
+* Running performance benchmarks and recording results
+* Setting up and tearing down OpenSearch clusters for benchmarking
+* Managing benchmark data and specifications across OpenSearch versions
+* Discovering performance problems by attaching so-called telemetry devices
+* Comparing performance results
 * Creating customized workloads
 
 We have also put considerable effort into OpenSearch Benchmark to ensure that benchmarking data are reproducible.
 
-Official Documentation
-----------------------
-[Click here](https://opensearch.org/docs/latest/benchmark/index/) to view the official documentation website for OpenSearch Benchmark.
+Documentation
+-------------
+
+Documentation for OpenSearch Benchmark is [available online](https://opensearch.org/docs/2.7/benchmark/index/).
 
 Quick Start
 -----------

--- a/it/resources/benchmark-in-memory-it.ini
+++ b/it/resources/benchmark-in-memory-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[publishing]
+[reporting]
 datastore.type = in-memory
 
 

--- a/it/resources/benchmark-in-memory-it.ini
+++ b/it/resources/benchmark-in-memory-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[results_publishing]
+[publishing]
 datastore.type = in-memory
 
 

--- a/it/resources/benchmark-os-it.ini
+++ b/it/resources/benchmark-os-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[publishing]
+[reporting]
 datastore.type = opensearch
 datastore.host = localhost
 datastore.port = 10200

--- a/it/resources/benchmark-os-it.ini
+++ b/it/resources/benchmark-os-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[results_publishing]
+[publishing]
 datastore.type = opensearch
 datastore.host = localhost
 datastore.port = 10200

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -35,7 +35,7 @@ import thespian.actors
 
 from osbenchmark import PROGRAM_NAME, BANNER, FORUM_LINK, SKULL, check_python_version, doc_link, telemetry
 from osbenchmark import version, actor, config, paths, \
-    test_execution_orchestrator, results_publisher, \
+    test_execution_orchestrator, publisher, \
         metrics, workload, chart_generator, exceptions, log
 from osbenchmark.builder import provision_config, builder
 from osbenchmark.workload_generator import workload_generator
@@ -815,11 +815,11 @@ def configure_connection_params(arg_parser, args, cfg):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 
 
-def configure_results_publishing_params(args, cfg):
-    cfg.add(config.Scope.applicationOverride, "results_publishing", "format", args.results_format)
-    cfg.add(config.Scope.applicationOverride, "results_publishing", "values", args.show_in_results)
-    cfg.add(config.Scope.applicationOverride, "results_publishing", "output.path", args.results_file)
-    cfg.add(config.Scope.applicationOverride, "results_publishing", "numbers.align", args.results_numbers_align)
+def configure_publishing_params(args, cfg):
+    cfg.add(config.Scope.applicationOverride, "publishing", "format", args.results_format)
+    cfg.add(config.Scope.applicationOverride, "publishing", "values", args.show_in_results)
+    cfg.add(config.Scope.applicationOverride, "publishing", "output.path", args.results_file)
+    cfg.add(config.Scope.applicationOverride, "publishing", "numbers.align", args.results_numbers_align)
 
 
 def dispatch_sub_command(arg_parser, args, cfg):
@@ -830,8 +830,8 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
     try:
         if sub_command == "compare":
-            configure_results_publishing_params(args, cfg)
-            results_publisher.compare(cfg, args.baseline, args.contender)
+            configure_publishing_params(args, cfg)
+            publisher.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
             cfg.add(config.Scope.applicationOverride, "system", "list.test_executions.max_results", args.limit)
@@ -903,7 +903,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "builder", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
 
-            configure_results_publishing_params(args, cfg)
+            configure_publishing_params(args, cfg)
 
             execute_test(cfg, args.kill_running_processes)
         elif sub_command == "generate":

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -815,11 +815,11 @@ def configure_connection_params(arg_parser, args, cfg):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 
 
-def configure_publishing_params(args, cfg):
-    cfg.add(config.Scope.applicationOverride, "publishing", "format", args.results_format)
-    cfg.add(config.Scope.applicationOverride, "publishing", "values", args.show_in_results)
-    cfg.add(config.Scope.applicationOverride, "publishing", "output.path", args.results_file)
-    cfg.add(config.Scope.applicationOverride, "publishing", "numbers.align", args.results_numbers_align)
+def configure_reporting_params(args, cfg):
+    cfg.add(config.Scope.applicationOverride, "reporting", "format", args.results_format)
+    cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_results)
+    cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.results_file)
+    cfg.add(config.Scope.applicationOverride, "reporting", "numbers.align", args.results_numbers_align)
 
 
 def dispatch_sub_command(arg_parser, args, cfg):
@@ -830,7 +830,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
     try:
         if sub_command == "compare":
-            configure_publishing_params(args, cfg)
+            configure_reporting_params(args, cfg)
             publisher.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
@@ -903,7 +903,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "builder", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
 
-            configure_publishing_params(args, cfg)
+            configure_reporting_params(args, cfg)
 
             execute_test(cfg, args.kill_running_processes)
         elif sub_command == "generate":

--- a/osbenchmark/config.py
+++ b/osbenchmark/config.py
@@ -114,7 +114,7 @@ def auto_load_local_config(base_config, additional_sections=None, config_file_cl
     cfg.load_config(auto_upgrade=True)
     # we override our some configuration with the one from the coordinator because it may contain more entries and we should be
     # consistent across all nodes here.
-    cfg.add_all(base_config, "results_publishing")
+    cfg.add_all(base_config, "publishing")
     cfg.add_all(base_config, "workloads")
     cfg.add_all(base_config, "provision_configs")
     cfg.add_all(base_config, "distributions")

--- a/osbenchmark/config.py
+++ b/osbenchmark/config.py
@@ -114,7 +114,7 @@ def auto_load_local_config(base_config, additional_sections=None, config_file_cl
     cfg.load_config(auto_upgrade=True)
     # we override our some configuration with the one from the coordinator because it may contain more entries and we should be
     # consistent across all nodes here.
-    cfg.add_all(base_config, "publishing")
+    cfg.add_all(base_config, "reporting")
     cfg.add_all(base_config, "workloads")
     cfg.add_all(base_config, "provision_configs")
     cfg.add_all(base_config, "distributions")

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -179,22 +179,22 @@ class OsClientFactory:
 
     def __init__(self, cfg):
         self._config = cfg
-        host = self._config.opts("results_publishing", "datastore.host")
-        port = self._config.opts("results_publishing", "datastore.port")
-        secure = convert.to_bool(self._config.opts("results_publishing", "datastore.secure"))
-        user = self._config.opts("results_publishing", "datastore.user")
+        host = self._config.opts("publishing", "datastore.host")
+        port = self._config.opts("publishing", "datastore.port")
+        secure = convert.to_bool(self._config.opts("publishing", "datastore.secure"))
+        user = self._config.opts("publishing", "datastore.user")
         try:
             password = os.environ["OSB_DATASTORE_PASSWORD"]
         except KeyError:
             try:
-                password = self._config.opts("results_publishing", "datastore.password")
+                password = self._config.opts("publishing", "datastore.password")
             except exceptions.ConfigError:
                 raise exceptions.ConfigError(
-                    "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                    "No password configured through [publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
                 ) from None
-        verify = self._config.opts("results_publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
-        ca_path = self._config.opts("results_publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
-        self.probe_version = self._config.opts("results_publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
+        verify = self._config.opts("publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
+        ca_path = self._config.opts("publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
+        self.probe_version = self._config.opts("publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
 
         # Instead of duplicating code, we're just adapting the metrics store specific properties to match the regular client options.
         client_options = {
@@ -290,7 +290,7 @@ def metrics_store(cfg, read_only=True, workload=None, test_procedure=None, provi
 
 
 def metrics_store_class(cfg):
-    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
+    if cfg.opts("publishing", "datastore.type") == "opensearch":
         return OsMetricsStore
     else:
         return InMemoryMetricsStore
@@ -1140,7 +1140,7 @@ def test_execution_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
+    if cfg.opts("publishing", "datastore.type") == "opensearch":
         logger.info("Creating OS test execution store")
         return CompositeTestExecutionStore(EsTestExecutionStore(cfg), FileTestExecutionStore(cfg))
     else:
@@ -1155,7 +1155,7 @@ def results_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
+    if cfg.opts("publishing", "datastore.type") == "opensearch":
         logger.info("Creating OS results store")
         return OsResultsStore(cfg)
     else:
@@ -1623,7 +1623,7 @@ class GlobalStatsCalculator:
                 op_type = task.operation.type
                 error_rate = self.error_rate(t, op_type)
                 duration = self.duration(t)
-                if task.operation.include_in_results_publishing or error_rate > 0:
+                if task.operation.include_in_publishing or error_rate > 0:
                     self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -179,22 +179,22 @@ class OsClientFactory:
 
     def __init__(self, cfg):
         self._config = cfg
-        host = self._config.opts("publishing", "datastore.host")
-        port = self._config.opts("publishing", "datastore.port")
-        secure = convert.to_bool(self._config.opts("publishing", "datastore.secure"))
-        user = self._config.opts("publishing", "datastore.user")
+        host = self._config.opts("reporting", "datastore.host")
+        port = self._config.opts("reporting", "datastore.port")
+        secure = convert.to_bool(self._config.opts("reporting", "datastore.secure"))
+        user = self._config.opts("reporting", "datastore.user")
         try:
             password = os.environ["OSB_DATASTORE_PASSWORD"]
         except KeyError:
             try:
-                password = self._config.opts("publishing", "datastore.password")
+                password = self._config.opts("reporting", "datastore.password")
             except exceptions.ConfigError:
                 raise exceptions.ConfigError(
-                    "No password configured through [publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                    "No password configured through [reporting] configuration or OSB_DATASTORE_PASSWORD environment variable."
                 ) from None
-        verify = self._config.opts("publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
-        ca_path = self._config.opts("publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
-        self.probe_version = self._config.opts("publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
+        verify = self._config.opts("reporting", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
+        ca_path = self._config.opts("reporting", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
+        self.probe_version = self._config.opts("reporting", "datastore.probe.cluster_version", default_value=True, mandatory=False)
 
         # Instead of duplicating code, we're just adapting the metrics store specific properties to match the regular client options.
         client_options = {
@@ -290,7 +290,7 @@ def metrics_store(cfg, read_only=True, workload=None, test_procedure=None, provi
 
 
 def metrics_store_class(cfg):
-    if cfg.opts("publishing", "datastore.type") == "opensearch":
+    if cfg.opts("reporting", "datastore.type") == "opensearch":
         return OsMetricsStore
     else:
         return InMemoryMetricsStore
@@ -1140,7 +1140,7 @@ def test_execution_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("publishing", "datastore.type") == "opensearch":
+    if cfg.opts("reporting", "datastore.type") == "opensearch":
         logger.info("Creating OS test execution store")
         return CompositeTestExecutionStore(EsTestExecutionStore(cfg), FileTestExecutionStore(cfg))
     else:
@@ -1155,7 +1155,7 @@ def results_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("publishing", "datastore.type") == "opensearch":
+    if cfg.opts("reporting", "datastore.type") == "opensearch":
         logger.info("Creating OS results store")
         return OsResultsStore(cfg)
     else:
@@ -1623,7 +1623,7 @@ class GlobalStatsCalculator:
                 op_type = task.operation.type
                 error_rate = self.error_rate(t, op_type)
                 duration = self.duration(t)
-                if task.operation.include_in_publishing or error_rate > 0:
+                if task.operation.include_in_reporting or error_rate > 0:
                     self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,

--- a/osbenchmark/publisher.py
+++ b/osbenchmark/publisher.py
@@ -99,14 +99,14 @@ def format_as_csv(headers, data):
 class SummaryResultsPublisher:
     def __init__(self, results, config):
         self.results = results
-        self.results_file = config.opts("publishing", "output.path")
-        self.results_format = config.opts("publishing", "format")
-        self.numbers_align = config.opts("publishing", "numbers.align",
+        self.results_file = config.opts("reporting", "output.path")
+        self.results_format = config.opts("reporting", "format")
+        self.numbers_align = config.opts("reporting", "numbers.align",
                                          mandatory=False, default_value="right")
-        publishing_values = config.opts("publishing", "values")
-        self.publish_all_values = publishing_values == "all"
-        self.publish_all_percentile_values = publishing_values == "all-percentiles"
-        self.show_processing_time = convert.to_bool(config.opts("publishing", "output.processingtime",
+        reporting_values = config.opts("reporting", "values")
+        self.publish_all_values = reporting_values == "all"
+        self.publish_all_percentile_values = reporting_values == "all-percentiles"
+        self.show_processing_time = convert.to_bool(config.opts("reporting", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.cwd = config.opts("node", "benchmark.cwd")
 
@@ -317,12 +317,12 @@ class SummaryResultsPublisher:
 
 class ComparisonResultsPublisher:
     def __init__(self, config):
-        self.results_file = config.opts("publishing", "output.path")
-        self.results_format = config.opts("publishing", "format")
-        self.numbers_align = config.opts("publishing", "numbers.align",
+        self.results_file = config.opts("reporting", "output.path")
+        self.results_format = config.opts("reporting", "format")
+        self.numbers_align = config.opts("reporting", "numbers.align",
                                          mandatory=False, default_value="right")
         self.cwd = config.opts("node", "benchmark.cwd")
-        self.show_processing_time = convert.to_bool(config.opts("publishing", "output.processingtime",
+        self.show_processing_time = convert.to_bool(config.opts("reporting", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.plain = False
 

--- a/osbenchmark/publisher.py
+++ b/osbenchmark/publisher.py
@@ -99,14 +99,14 @@ def format_as_csv(headers, data):
 class SummaryResultsPublisher:
     def __init__(self, results, config):
         self.results = results
-        self.results_file = config.opts("results_publishing", "output.path")
-        self.results_format = config.opts("results_publishing", "format")
-        self.numbers_align = config.opts("results_publishing", "numbers.align",
+        self.results_file = config.opts("publishing", "output.path")
+        self.results_format = config.opts("publishing", "format")
+        self.numbers_align = config.opts("publishing", "numbers.align",
                                          mandatory=False, default_value="right")
-        results_publishing_values = config.opts("results_publishing", "values")
-        self.publish_all_values = results_publishing_values == "all"
-        self.publish_all_percentile_values = results_publishing_values == "all-percentiles"
-        self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
+        publishing_values = config.opts("publishing", "values")
+        self.publish_all_values = publishing_values == "all"
+        self.publish_all_percentile_values = publishing_values == "all-percentiles"
+        self.show_processing_time = convert.to_bool(config.opts("publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.cwd = config.opts("node", "benchmark.cwd")
 
@@ -317,12 +317,12 @@ class SummaryResultsPublisher:
 
 class ComparisonResultsPublisher:
     def __init__(self, config):
-        self.results_file = config.opts("results_publishing", "output.path")
-        self.results_format = config.opts("results_publishing", "format")
-        self.numbers_align = config.opts("results_publishing", "numbers.align",
+        self.results_file = config.opts("publishing", "output.path")
+        self.results_format = config.opts("publishing", "format")
+        self.numbers_align = config.opts("publishing", "numbers.align",
                                          mandatory=False, default_value="right")
         self.cwd = config.opts("node", "benchmark.cwd")
-        self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
+        self.show_processing_time = convert.to_bool(config.opts("publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.plain = False
 

--- a/osbenchmark/resources/benchmark.ini
+++ b/osbenchmark/resources/benchmark.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[results_publishing]
+[publishing]
 datastore.type = in-memory
 datastore.host =
 datastore.port =

--- a/osbenchmark/resources/benchmark.ini
+++ b/osbenchmark/resources/benchmark.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[publishing]
+[reporting]
 datastore.type = in-memory
 datastore.host =
 datastore.port =

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -32,7 +32,7 @@ import thespian.actors
 
 from osbenchmark import actor, config, doc_link, \
     worker_coordinator, exceptions, builder, metrics, \
-        results_publisher, workload, version, PROGRAM_NAME
+        publisher, workload, version, PROGRAM_NAME
 from osbenchmark.utils import console, opts, versions
 
 
@@ -250,7 +250,7 @@ class BenchmarkCoordinator:
             self.test_execution.add_results(final_results)
             self.test_execution_store.store_test_execution(self.test_execution)
             metrics.results_store(self.cfg).store_results(self.test_execution)
-            results_publisher.summarize(final_results, self.cfg)
+            publisher.summarize(final_results, self.cfg)
         else:
             self.logger.info("Suppressing output of summary results. Cancelled = [%r], Error = [%r].", self.cancelled, self.error)
         self.metrics_store.close()

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -607,7 +607,7 @@ class WorkerCoordinator:
         self.test_procedure = select_test_procedure(self.config, self.workload)
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
         downsample_factor = int(self.config.opts(
-            "publishing", "metrics.request.downsample.factor",
+            "reporting", "metrics.request.downsample.factor",
             mandatory=False, default_value=1))
         self.metrics_store = metrics.metrics_store(cfg=self.config,
                                                    workload=self.workload.name,
@@ -1031,7 +1031,7 @@ class Worker(actor.BenchmarkActor):
         self.worker_id = msg.worker_id
         self.config = load_local_config(msg.config)
         self.on_error = self.config.opts("worker_coordinator", "on.error")
-        self.sample_queue_size = int(self.config.opts("publishing", "sample.queue.size", mandatory=False, default_value=1 << 20))
+        self.sample_queue_size = int(self.config.opts("reporting", "sample.queue.size", mandatory=False, default_value=1 << 20))
         self.workload = msg.workload
         workload.set_absolute_data_path(self.config, self.workload)
         self.client_allocations = msg.client_allocations

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -533,7 +533,7 @@ class WorkerCoordinator:
         # which client ids are assigned to which workers?
         self.clients_per_worker = {}
 
-        self.progress_results_publisher = console.progress()
+        self.progress_publisher = console.progress()
         self.progress_counter = 0
         self.quiet = False
         self.allocations = None
@@ -607,7 +607,7 @@ class WorkerCoordinator:
         self.test_procedure = select_test_procedure(self.config, self.workload)
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
         downsample_factor = int(self.config.opts(
-            "results_publishing", "metrics.request.downsample.factor",
+            "publishing", "metrics.request.downsample.factor",
             mandatory=False, default_value=1))
         self.metrics_store = metrics.metrics_store(cfg=self.config,
                                                    workload=self.workload.name,
@@ -791,7 +791,7 @@ class WorkerCoordinator:
         return self.current_step == self.number_of_steps
 
     def close(self):
-        self.progress_results_publisher.finish()
+        self.progress_publisher.finish()
         if self.metrics_store and self.metrics_store.opened:
             self.metrics_store.close()
 
@@ -817,9 +817,9 @@ class WorkerCoordinator:
 
                 num_clients = max(len(progress_per_client), 1)
                 total_progress = sum(progress_per_client) / num_clients
-            self.progress_results_publisher.print("Running %s" % tasks, "[%3d%% done]" % (round(total_progress * 100)))
+            self.progress_publisher.print("Running %s" % tasks, "[%3d%% done]" % (round(total_progress * 100)))
             if task_finished:
-                self.progress_results_publisher.finish()
+                self.progress_publisher.finish()
 
     def post_process_samples(self):
         # we do *not* do this here to avoid concurrent updates (actors are single-threaded) but rather to make it clear that we use
@@ -1031,7 +1031,7 @@ class Worker(actor.BenchmarkActor):
         self.worker_id = msg.worker_id
         self.config = load_local_config(msg.config)
         self.on_error = self.config.opts("worker_coordinator", "on.error")
-        self.sample_queue_size = int(self.config.opts("results_publishing", "sample.queue.size", mandatory=False, default_value=1 << 20))
+        self.sample_queue_size = int(self.config.opts("publishing", "sample.queue.size", mandatory=False, default_value=1 << 20))
         self.workload = msg.workload
         workload.set_absolute_data_path(self.config, self.workload)
         self.client_allocations = msg.client_allocations

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1365,7 +1365,7 @@ class WorkloadSpecificationReader:
                     task = self.parse_task(op, ops, name)
                 schedule.append(task)
 
-            # verify we don't have any duplicate task names (which can be confusing / misleading in publishing).
+            # verify we don't have any duplicate task names (which can be confusing / misleading in reporting).
             known_task_names = set()
             for task in schedule:
                 for sub_task in task:
@@ -1523,8 +1523,8 @@ class WorkloadSpecificationReader:
 
         try:
             op = workload.OperationType.from_hyphenated_string(op_type_name)
-            if "include-in-publishing" not in params:
-                params["include-in-publishing"] = not op.admin_op
+            if "include-in-reporting" not in params:
+                params["include-in-reporting"] = not op.admin_op
             self.logger.debug("Using built-in operation type [%s] for operation [%s].", op_type_name, op_name)
         except KeyError:
             self.logger.info("Using user-provided operation type [%s] for operation [%s].", op_type_name, op_name)

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1365,7 +1365,7 @@ class WorkloadSpecificationReader:
                     task = self.parse_task(op, ops, name)
                 schedule.append(task)
 
-            # verify we don't have any duplicate task names (which can be confusing / misleading in results_publishing).
+            # verify we don't have any duplicate task names (which can be confusing / misleading in publishing).
             known_task_names = set()
             for task in schedule:
                 for sub_task in task:
@@ -1523,8 +1523,8 @@ class WorkloadSpecificationReader:
 
         try:
             op = workload.OperationType.from_hyphenated_string(op_type_name)
-            if "include-in-results_publishing" not in params:
-                params["include-in-results_publishing"] = not op.admin_op
+            if "include-in-publishing" not in params:
+                params["include-in-publishing"] = not op.admin_op
             self.logger.debug("Using built-in operation type [%s] for operation [%s].", op_type_name, op_name)
         except KeyError:
             self.logger.info("Using user-provided operation type [%s] for operation [%s].", op_type_name, op_name)

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -202,11 +202,11 @@ class Documents:
         :param includes_action_and_meta_data: True, if the source file already includes the action and meta-data line. False, if it only
         contains documents.
         :param number_of_documents: The number of documents
-        in the benchmark document. Needed for proper progress results_publishing. Only needed if
+        in the benchmark document. Needed for proper progress publishing. Only needed if
          a document_archive is given.
         :param compressed_size_in_bytes: The compressed size in bytes of
         the benchmark document. Needed for verification of the download and
-         user results_publishing. Only useful if a document_archive is given (optional but recommended to be set).
+         user publishing. Only useful if a document_archive is given (optional but recommended to be set).
         :param uncompressed_size_in_bytes: The size in bytes of the benchmark document after decompressing it.
         Only useful if a document_archive is given (optional but recommended to be set).
         :param target_index: The index to target for bulk operations. May be ``None`` if ``includes_action_and_meta_data`` is ``False``.
@@ -970,8 +970,8 @@ class Operation:
         self.param_source = param_source
 
     @property
-    def include_in_results_publishing(self):
-        return self.params.get("include-in-results_publishing", True)
+    def include_in_publishing(self):
+        return self.params.get("include-in-publishing", True)
 
     def __hash__(self):
         return hash(self.name)

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -202,11 +202,11 @@ class Documents:
         :param includes_action_and_meta_data: True, if the source file already includes the action and meta-data line. False, if it only
         contains documents.
         :param number_of_documents: The number of documents
-        in the benchmark document. Needed for proper progress publishing. Only needed if
+        in the benchmark document. Needed for proper progress reporting. Only needed if
          a document_archive is given.
         :param compressed_size_in_bytes: The compressed size in bytes of
         the benchmark document. Needed for verification of the download and
-         user publishing. Only useful if a document_archive is given (optional but recommended to be set).
+         user reporting. Only useful if a document_archive is given (optional but recommended to be set).
         :param uncompressed_size_in_bytes: The size in bytes of the benchmark document after decompressing it.
         Only useful if a document_archive is given (optional but recommended to be set).
         :param target_index: The index to target for bulk operations. May be ``None`` if ``includes_action_and_meta_data`` is ``False``.
@@ -970,8 +970,8 @@ class Operation:
         self.param_source = param_source
 
     @property
-    def include_in_publishing(self):
-        return self.params.get("include-in-publishing", True)
+    def include_in_reporting(self):
+        return self.params.get("include-in-reporting", True)
 
     def __hash__(self):
         return hash(self.name)

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -122,7 +122,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${HOME}/.benchmark/benchmarks/data
 
-[publishing]
+[reporting]
 datastore.type = opensearch
 datastore.host = 127.0.0.1
 datastore.port = 9209

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -122,7 +122,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${HOME}/.benchmark/benchmarks/data
 
-[results_publishing]
+[publishing]
 datastore.type = opensearch
 datastore.host = 127.0.0.1
 datastore.port = 9209

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -185,7 +185,7 @@ class AutoLoadConfigTests(TestCase):
         base_cfg = config.Config(config_name="unittest", config_file_class=InMemoryConfigStore)
         base_cfg.add(config.Scope.application, "meta", "config.version", config.Config.CURRENT_CONFIG_VERSION)
         base_cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/base-config/data-set-cache")
-        base_cfg.add(config.Scope.application, "results_publishing", "datastore.type", "opensearch")
+        base_cfg.add(config.Scope.application, "publishing", "datastore.type", "opensearch")
         base_cfg.add(config.Scope.application, "workloads", "metrics.url", "http://github.com/org/metrics")
         base_cfg.add(config.Scope.application, "provision_configs", "private.url", "http://github.com/org/provision_configs")
         base_cfg.add(config.Scope.application, "distributions", "release.cache", False)
@@ -196,7 +196,7 @@ class AutoLoadConfigTests(TestCase):
         # did not just copy base config
         self.assertNotEqual(base_cfg.opts("benchmarks", "local.dataset.cache"), cfg.opts("benchmarks", "local.dataset.cache"))
         # copied sections from base config
-        self.assert_equals_base_config(base_cfg, cfg, "results_publishing", "datastore.type")
+        self.assert_equals_base_config(base_cfg, cfg, "publishing", "datastore.type")
         self.assert_equals_base_config(base_cfg, cfg, "workloads", "metrics.url")
         self.assert_equals_base_config(base_cfg, cfg, "provision_configs", "private.url")
         self.assert_equals_base_config(base_cfg, cfg, "distributions", "release.cache")
@@ -285,8 +285,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "results_publishing": {
-                "results.base.dir": "/tests/benchmark/results_publishing",
+            "publishing": {
+                "results.base.dir": "/tests/benchmark/publishing",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {
@@ -318,8 +318,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "results_publishing": {
-                "results.base.dir": "/tests/benchmark/results_publishing",
+            "publishing": {
+                "results.base.dir": "/tests/benchmark/publishing",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -185,7 +185,7 @@ class AutoLoadConfigTests(TestCase):
         base_cfg = config.Config(config_name="unittest", config_file_class=InMemoryConfigStore)
         base_cfg.add(config.Scope.application, "meta", "config.version", config.Config.CURRENT_CONFIG_VERSION)
         base_cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/base-config/data-set-cache")
-        base_cfg.add(config.Scope.application, "publishing", "datastore.type", "opensearch")
+        base_cfg.add(config.Scope.application, "reporting", "datastore.type", "opensearch")
         base_cfg.add(config.Scope.application, "workloads", "metrics.url", "http://github.com/org/metrics")
         base_cfg.add(config.Scope.application, "provision_configs", "private.url", "http://github.com/org/provision_configs")
         base_cfg.add(config.Scope.application, "distributions", "release.cache", False)
@@ -196,7 +196,7 @@ class AutoLoadConfigTests(TestCase):
         # did not just copy base config
         self.assertNotEqual(base_cfg.opts("benchmarks", "local.dataset.cache"), cfg.opts("benchmarks", "local.dataset.cache"))
         # copied sections from base config
-        self.assert_equals_base_config(base_cfg, cfg, "publishing", "datastore.type")
+        self.assert_equals_base_config(base_cfg, cfg, "reporting", "datastore.type")
         self.assert_equals_base_config(base_cfg, cfg, "workloads", "metrics.url")
         self.assert_equals_base_config(base_cfg, cfg, "provision_configs", "private.url")
         self.assert_equals_base_config(base_cfg, cfg, "distributions", "release.cache")
@@ -285,8 +285,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "publishing": {
-                "results.base.dir": "/tests/benchmark/publishing",
+            "reporting": {
+                "results.base.dir": "/tests/benchmark/reporting",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {
@@ -318,8 +318,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "publishing": {
-                "results.base.dir": "/tests/benchmark/publishing",
+            "reporting": {
+                "results.base.dir": "/tests/benchmark/reporting",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -201,19 +201,19 @@ class OsClientTests(TestCase):
         _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
         _datastore_verify_certs = random.choice([True, False])
 
-        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", _datastore_user)
 
         if password_configuration == "config":
-            cfg.add(config.Scope.applicationOverride, "publishing", "datastore.password", _datastore_password)
+            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", _datastore_password)
         elif password_configuration == "environment":
             monkeypatch = pytest.MonkeyPatch()
             monkeypatch.setenv("OSB_DATASTORE_PASSWORD", _datastore_password)
 
         if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "publishing", "datastore.ssl.verification_mode", "none")
+            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.verification_mode", "none")
 
         try:
             metrics.OsClientFactory(cfg)
@@ -223,7 +223,7 @@ class OsClientTests(TestCase):
 
             assert (
                 e.message
-                == "No password configured through [publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                == "No password configured through [reporting] configuration or OSB_DATASTORE_PASSWORD environment variable."
             )
             return
 
@@ -1782,7 +1782,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -1873,7 +1873,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -1931,7 +1931,7 @@ class GlobalStatsCalculatorTests(TestCase):
         del self.cfg
 
     def test_add_administrative_task_with_error_rate_in_results(self):
-        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-publishing': False})
+        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-reporting': False})
         task = Task('delete-index', operation=op, schedule='deterministic')
         test_procedure = TestProcedure(name='append-fast-with-conflicts', schedule=[task], meta_data={})
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -201,19 +201,19 @@ class OsClientTests(TestCase):
         _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
         _datastore_verify_certs = random.choice([True, False])
 
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "publishing", "datastore.user", _datastore_user)
 
         if password_configuration == "config":
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
+            cfg.add(config.Scope.applicationOverride, "publishing", "datastore.password", _datastore_password)
         elif password_configuration == "environment":
             monkeypatch = pytest.MonkeyPatch()
             monkeypatch.setenv("OSB_DATASTORE_PASSWORD", _datastore_password)
 
         if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
+            cfg.add(config.Scope.applicationOverride, "publishing", "datastore.ssl.verification_mode", "none")
 
         try:
             metrics.OsClientFactory(cfg)
@@ -223,7 +223,7 @@ class OsClientTests(TestCase):
 
             assert (
                 e.message
-                == "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                == "No password configured through [publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
             )
             return
 
@@ -1782,7 +1782,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -1873,7 +1873,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -1931,7 +1931,7 @@ class GlobalStatsCalculatorTests(TestCase):
         del self.cfg
 
     def test_add_administrative_task_with_error_rate_in_results(self):
-        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-results_publishing': False})
+        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-publishing': False})
         task = Task('delete-index', operation=op, schedule='deterministic')
         test_procedure = TestProcedure(name='append-fast-with-conflicts', schedule=[task], meta_data={})
 

--- a/tests/publisher_test.py
+++ b/tests/publisher_test.py
@@ -24,7 +24,7 @@
 
 from unittest import TestCase
 
-from osbenchmark import results_publisher
+from osbenchmark import publisher
 
 
 class FormatterTests(TestCase):
@@ -41,19 +41,19 @@ class FormatterTests(TestCase):
         self.numbers_align = "right"
 
     def test_formats_as_markdown(self):
-        formatted = results_publisher.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
+        formatted = publisher.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
         # 1 header line, 1 separation line + 0 data lines
         self.assertEqual(1 + 1 + 0, len(formatted.splitlines()))
 
-        formatted = results_publisher.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
+        formatted = publisher.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
         # 1 header line, 1 separation line + 3 data lines
         self.assertEqual(1 + 1 + 3, len(formatted.splitlines()))
 
     def test_formats_as_csv(self):
-        formatted = results_publisher.format_as_csv(self.empty_header, self.empty_data)
+        formatted = publisher.format_as_csv(self.empty_header, self.empty_data)
         # 1 header line, no separation line + 0 data lines
         self.assertEqual(1 + 0, len(formatted.splitlines()))
 
-        formatted = results_publisher.format_as_csv(self.metrics_header, self.metrics_data)
+        formatted = publisher.format_as_csv(self.metrics_header, self.metrics_data)
         # 1 header line, no separation line + 3 data lines
         self.assertEqual(1 + 3, len(formatted.splitlines()))

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -47,13 +47,13 @@ def create_config():
     # concrete path does not matter
     cfg.add(config.Scope.application, "node", "benchmark.root", "/some/root/path")
 
-    cfg.add(config.Scope.application, "results_publishing", "datastore.host", "localhost")
-    cfg.add(config.Scope.application, "results_publishing", "datastore.port", "0")
-    cfg.add(config.Scope.application, "results_publishing", "datastore.secure", False)
-    cfg.add(config.Scope.application, "results_publishing", "datastore.user", "")
-    cfg.add(config.Scope.application, "results_publishing", "datastore.password", "")
+    cfg.add(config.Scope.application, "publishing", "datastore.host", "localhost")
+    cfg.add(config.Scope.application, "publishing", "datastore.port", "0")
+    cfg.add(config.Scope.application, "publishing", "datastore.secure", False)
+    cfg.add(config.Scope.application, "publishing", "datastore.user", "")
+    cfg.add(config.Scope.application, "publishing", "datastore.password", "")
     # disable version probing to avoid any network calls in tests
-    cfg.add(config.Scope.application, "results_publishing", "datastore.probe.cluster_version", False)
+    cfg.add(config.Scope.application, "publishing", "datastore.probe.cluster_version", False)
     # only internal devices are active
     cfg.add(config.Scope.application, "telemetry", "devices", [])
     return cfg

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -47,13 +47,13 @@ def create_config():
     # concrete path does not matter
     cfg.add(config.Scope.application, "node", "benchmark.root", "/some/root/path")
 
-    cfg.add(config.Scope.application, "publishing", "datastore.host", "localhost")
-    cfg.add(config.Scope.application, "publishing", "datastore.port", "0")
-    cfg.add(config.Scope.application, "publishing", "datastore.secure", False)
-    cfg.add(config.Scope.application, "publishing", "datastore.user", "")
-    cfg.add(config.Scope.application, "publishing", "datastore.password", "")
+    cfg.add(config.Scope.application, "reporting", "datastore.host", "localhost")
+    cfg.add(config.Scope.application, "reporting", "datastore.port", "0")
+    cfg.add(config.Scope.application, "reporting", "datastore.secure", False)
+    cfg.add(config.Scope.application, "reporting", "datastore.user", "")
+    cfg.add(config.Scope.application, "reporting", "datastore.password", "")
     # disable version probing to avoid any network calls in tests
-    cfg.add(config.Scope.application, "publishing", "datastore.probe.cluster_version", False)
+    cfg.add(config.Scope.application, "reporting", "datastore.probe.cluster_version", False)
     # only internal devices are active
     cfg.add(config.Scope.application, "telemetry", "devices", [])
     return cfg

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -140,9 +140,9 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
 
-        progress_results_publisher.print(message=message, progress=".")
+        progress_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -156,8 +156,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.print(message=message, progress=".")
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -174,8 +174,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.print(message=message, progress=".")
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.print(message=message, progress=".")
         mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
             mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
@@ -195,8 +195,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.print(message=message, progress=".")
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.print(message=message, progress=".")
         mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
             mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
@@ -213,8 +213,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.print(message=message, progress=".")
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -228,8 +228,8 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.finish()
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.finish()
         mock_printer.assert_not_called()
 
     @mock.patch("sys.stdout.isatty")
@@ -243,8 +243,8 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.finish()
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.finish()
         mock_printer.assert_called_once_with("")
 
     @mock.patch("sys.stdout.isatty")
@@ -258,6 +258,6 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_results_publisher.finish()
+        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_publisher.finish()
         mock_printer.assert_called_once_with("")

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -111,7 +111,7 @@ class WorkerCoordinatorTests(TestCase):
                      WorkerCoordinatorTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
-        self.cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
+        self.cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
             workload.Task(name="index", operation=workload.Operation("index", operation_type=workload.OperationType.Bulk), clients=4)

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -111,7 +111,7 @@ class WorkerCoordinatorTests(TestCase):
                      WorkerCoordinatorTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
-        self.cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
+        self.cfg.add(config.Scope.application, "publishing", "datastore.type", "in-memory")
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
             workload.Task(name="index", operation=workload.Operation("index", operation_type=workload.OperationType.Bulk), clients=4)


### PR DESCRIPTION
### Description
This PR addresses the following:
- Updates `results_publisher` to `publisher`
- Updates `publishing` to `reporting`
- Updates README to add documentation link and correct link to CREATE_WORKLOAD_GUIDE.md
- Updates DEVELOPER_GUIDE.md with important information how to get around conflict with unittests when `OSB_DATASTORE_PASSWORD` is set. 

### Issues Resolved
#311 
#315 

### Testing
- [x] New functionality includes testing
- Ran `make test`
- Ran three benchmark tests -- one with in-memory data store, one with external OpenSearch cluster datastore with password in benchmark.ini, and one with external OpenSearch cluster datastore with password in environment variable. All three succeeded. Confirmed the external datastore tests had data properly ingested.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
