### PR TITLE
Increase the shard and replica count for the benchmark-metrics-* indices in the data store

### DIFF
--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -5,7 +5,8 @@
   "settings": {
     "index": {
       "refresh_interval": "5s",
-      "number_of_shards": 1
+      "number_of_shards": 10,
+      "number_of_replicas": 1
     }
   },
   "mappings": {


### PR DESCRIPTION
### Description
This change will increase the number of primary shards in the monthly index "benchmark-metrics-yyyy-mm" to accomodate more documents and avoid reaching the shard limit of 2B on the metrics data store.

We reached the max. number of 2 billion documents per shard in the monthly "benchmark-metrics-2023-05" index, a limit imposed by lucene, on our metrics data store which we use to rigorously benchmark domain(s). This doc limit was reached within first 3-4 days of the month. 
Considering this amount of data to be created consistently throughout the month , we made the decision to have 10 primary shards. We created a new index with 10 primary shards and re-indexed with new same-index index having 10 primary shards and 1 replica shard to make sure no data loss happens in case of node failures or write block during re-indexing.

### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/opensearch-benchmark/issues/188

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
