### PR TITLE
Update Codec Enum to support ZSTD and ZSTDNODICT

### DIFF
--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -717,14 +717,21 @@ class OperationType(Enum):
 class IndexCodec(Enum):
     Default = "default"
     BestCompression = "best_compression"
+    ZSTD = "zstd"
+    ZSTDNODICT = "zstdnodict"
 
     @classmethod
     def is_codec_valid(cls, codec):
         for valid_codec in cls:
-            if codec == valid_codec.value:
+            if codec.lower() == valid_codec.value:
                 return True
 
-        raise ValueError(f"Invalid index.codec value '{codec}'")
+        available_codecs = cls.get_available_codecs()
+        raise ValueError(f"Invalid index.codec value '{codec}'. Choose from available codecs: {available_codecs}")
+
+    @classmethod
+    def get_available_codecs(cls):
+        return list(map(lambda codec: codec.value, cls))
 
 
 class TaskNameFilter:

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -722,11 +722,10 @@ class IndexCodec(Enum):
 
     @classmethod
     def is_codec_valid(cls, codec):
-        for valid_codec in cls:
-            if codec.lower() == valid_codec.value:
-                return True
-
         available_codecs = cls.get_available_codecs()
+        if codec.lower() in available_codecs:
+            return True
+
         raise ValueError(f"Invalid index.codec value '{codec}'. Choose from available codecs: {available_codecs}")
 
     @classmethod

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1632,6 +1632,62 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
         self.assertEqual("best_compression", body["settings"]["index.codec"])
 
+    def test_create_index_with_zstd_codec(self):
+        source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
+            "index": "test",
+            "body": {
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.codec": "zstd"
+                },
+                "mappings": {
+                    "doc": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+        p = source.params()
+        self.assertEqual(1, len(p["indices"]))
+        index, body = p["indices"][0]
+        self.assertEqual("test", index)
+        self.assertTrue(len(body) > 0)
+        self.assertEqual({}, p["request-params"])
+        self.assertEqual("zstd", body["settings"]["index.codec"])
+
+    def test_create_index_with_zstdnodict_codec(self):
+        source = params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
+            "index": "test",
+            "body": {
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.codec": "zstdnodict"
+                },
+                "mappings": {
+                    "doc": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
+                        }
+                    }
+                }
+            }
+        })
+
+        p = source.params()
+        self.assertEqual(1, len(p["indices"]))
+        index, body = p["indices"][0]
+        self.assertEqual("test", index)
+        self.assertTrue(len(body) > 0)
+        self.assertEqual({}, p["request-params"])
+        self.assertEqual("zstdnodict", body["settings"]["index.codec"])
+
     def test_create_index_with_invalid_codec(self):
         with self.assertRaises(exceptions.InvalidSyntax) as context:
             params.CreateIndexParamSource(workload.Workload(name="unit-test"), params={
@@ -1654,7 +1710,8 @@ class CreateIndexParamSourceTests(TestCase):
             })
 
         self.assertEqual(str(context.exception),
-                         "Please set the value properly for the create-index operation. Invalid index.codec value 'invalid_codec'")
+                         "Please set the value properly for the create-index operation. Invalid index.codec value " +
+                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstdnodict']")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):


### PR DESCRIPTION
### Description
This PR:
- Updates OSB to support ZSTD and ZSTDNODICT, two new codecs that are supported since OpenSearch 2.7.0+.
- Enhance error message to provide list of available codecs

```
"Please set the value properly for the create-index operation. Invalid index.codec value 'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstdnodict']"
```


### Issues Resolved
#306 

### Testing
- [x] New functionality includes testing

Added new tests for ZSTD and ZSTDNODICT. Also added more description to show what available codecs there are for users. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
