### PR TITLE
Update DEVELOPER_GUIDE.md on how to mitigate unittest conflict

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -71,6 +71,26 @@ make test
 
 ```
 
+#### NOTE: OSB_DATASTORE_PASSWORD environment variable conflicts with unittests
+OSB has the ability to store metrics into an OpenSearch datastore. To enable this, users can write the datastore password to the `benchmark.ini` config file or export it to the environment variable `OSB_DATASTORE_PASSWORD`. However, when the latter is done, users might encounter an assertion error when running unittests. This is because one unittest uses values assigned to `OSB_DATASTORE_PASSWORD`.
+
+The following is an example of the assertion error that comes up when users run unittests while the environment variable `OSB_DATASTORE_PASSWORD` is set.
+```
+>           raise AssertionError(_error_message()) from cause
+E           AssertionError: expected call not found.
+E           Expected: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': 'JXkTu9JhzFq$', 'verify_certs': False})
+E           Actual: OsClientFactory(hosts=[{'host': '27.158.71.181', 'port': 27959}], client_options={'use_ssl': True, 'verify_certs': False, 'timeout': 120, 'basic_auth_user': 'WuxfoBBk', 'basic_auth_password': '<Value from OSB_DATASTORE_PASSWORD Environment Variable>'})
+
+../../../../.pyenv/versions/3.8.12/lib/python3.8/unittest/mock.py:913: AssertionError
+
+...
+
+=========================== short test summary info ============================
+FAILED tests/metrics_test.py::OsClientTests::test_config_opts_parsing_with_config - AssertionError: expected call not found.
+============ 1 failed, 1163 passed, 5 skipped, 3 warnings in 15.41s ============
+```
+To avoid this issue when running unittests, unset your datastore password by running `unset OSB_DATASTORE_PASSWORD`.
+
 ### Integration Tests
 
 Integration tests can be run on the following operating systems:


### PR DESCRIPTION
### Description
This PR adds a quick guidance on how to mitigate the conflict that arises when running unittests with OSB_DATASTORE_PASSWORD is set. 

### Issues Resolved


### Testing
- [x] New functionality includes testing

Performed unittests when config has password, when environment variable has password, and after environment variable is unset. 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
