### PR TITLE
Adding SigV4 support to opensearch-benchmarks for connecting to test clusters and results publishing

### DIFF
--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -124,12 +124,17 @@ class OsClientFactory:
         self.client_options = dict(client_options)
         self.ssl_context = None
         self.logger = logging.getLogger(__name__)
+        self.aws_log_in_dict = {}
 
         masked_client_options = dict(client_options)
         if "basic_auth_password" in masked_client_options:
             masked_client_options["basic_auth_password"] = "*****"
         if "http_auth" in masked_client_options:
             masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
+        if "amazon_aws_log_in" in masked_client_options:
+            self.aws_log_in_dict = self.parse_aws_log_in_params()
+            masked_client_options["aws_access_key_id"] = "*****"
+            masked_client_options["aws_secret_access_key"] = "*****"
         self.logger.info("Creating OpenSearch client connected to %s with options [%s]", hosts, masked_client_options)
 
         # we're using an SSL context now and it is not allowed to have use_ssl present in client options anymore
@@ -236,10 +241,52 @@ class OsClientFactory:
         except KeyError:
             return False
 
+    def parse_aws_log_in_params(self):
+        # pylint: disable=import-outside-toplevel
+        import os
+        aws_log_in_dict = {}
+        # aws log in : option 1) pass in parameters from os environment variables
+        if self.client_options["amazon_aws_log_in"] == "environment":
+            aws_log_in_dict["aws_access_key_id"] = os.environ.get("aws_access_key_id")
+            aws_log_in_dict["aws_secret_access_key"] = os.environ.get("aws_secret_access_key")
+            aws_log_in_dict["region"] = os.environ.get("region")
+            aws_log_in_dict["service"] = os.environ.get("service")
+        # aws log in : option 2) parameters are passed in from command line
+        elif self.client_options["amazon_aws_log_in"] == "client_option":
+            aws_log_in_dict["aws_access_key_id"] = self.client_options.get("aws_access_key_id")
+            aws_log_in_dict["aws_secret_access_key"] = self.client_options.get("aws_secret_access_key")
+            aws_log_in_dict["region"] = self.client_options.get("region")
+            aws_log_in_dict["service"] = self.client_options.get("service")
+        if (not aws_log_in_dict["aws_access_key_id"] or not aws_log_in_dict["aws_secret_access_key"]
+                or not aws_log_in_dict["service"] or not aws_log_in_dict["region"]):
+            self.logger.error("Invalid amazon aws log in parameters, required input aws_access_key_id, "
+                              "aws_secret_access_key, service and region.")
+            raise exceptions.SystemSetupError(
+                "Invalid amazon aws log in parameters, required input aws_access_key_id, "
+                "aws_secret_access_key, and region."
+            )
+        if aws_log_in_dict["service"] not in ['es', 'aoss']:
+            self.logger.error("Service for aws log in should be one of 'es' or 'aoss'")
+            raise exceptions.SystemSetupError(
+                "Cannot specify service as '{}'. Accepted values are 'es' or 'aoss'.".format(
+                    aws_log_in_dict["service"])
+            )
+        return aws_log_in_dict
+
     def create(self):
         # pylint: disable=import-outside-toplevel
         import opensearchpy
-        return opensearchpy.OpenSearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
+        from botocore.credentials import Credentials
+
+        if "amazon_aws_log_in" not in self.client_options:
+            return opensearchpy.OpenSearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
+
+        credentials = Credentials(access_key=self.aws_log_in_dict["aws_access_key_id"],
+                                  secret_key=self.aws_log_in_dict["aws_secret_access_key"])
+        aws_auth = opensearchpy.AWSV4SignerAuth(credentials, self.aws_log_in_dict["region"],
+                                                self.aws_log_in_dict["service"])
+        return opensearchpy.OpenSearch(hosts=self.hosts, use_ssl=True, verify_certs=True, http_auth=aws_auth,
+                                       connection_class=opensearchpy.RequestsHttpConnection)
 
     def create_async(self):
         # pylint: disable=import-outside-toplevel
@@ -249,6 +296,7 @@ class OsClientFactory:
         import aiohttp
 
         from opensearchpy.serializer import JSONSerializer
+        from botocore.credentials import Credentials
 
         class LazyJSONSerializer(JSONSerializer):
             def loads(self, s):
@@ -277,10 +325,20 @@ class OsClientFactory:
         class BenchmarkAsyncOpenSearch(opensearchpy.AsyncOpenSearch, RequestContextHolder):
             pass
 
+        if "amazon_aws_log_in" not in self.client_options:
+            return BenchmarkAsyncOpenSearch(hosts=self.hosts,
+                                            connection_class=osbenchmark.async_connection.AIOHttpConnection,
+                                            ssl_context=self.ssl_context,
+                                            **self.client_options)
+
+        credentials = Credentials(access_key=self.aws_log_in_dict["aws_access_key_id"],
+                                  secret_key=self.aws_log_in_dict["aws_secret_access_key"])
+        aws_auth = opensearchpy.AWSV4SignerAsyncAuth(credentials, self.aws_log_in_dict["region"],
+                                                     self.aws_log_in_dict["service"])
         return BenchmarkAsyncOpenSearch(hosts=self.hosts,
-                                       connection_class=osbenchmark.async_connection.AIOHttpConnection,
-                                       ssl_context=self.ssl_context,
-                                       **self.client_options)
+                                        connection_class=osbenchmark.async_connection.AsyncHttpConnection,
+                                        use_ssl=True, verify_certs=True, http_auth=aws_auth,
+                                        **self.client_options)
 
 
 def wait_for_rest_layer(opensearch, max_attempts=40):

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -247,10 +247,10 @@ class OsClientFactory:
         aws_log_in_dict = {}
         # aws log in : option 1) pass in parameters from os environment variables
         if self.client_options["amazon_aws_log_in"] == "environment":
-            aws_log_in_dict["aws_access_key_id"] = os.environ.get("aws_access_key_id")
-            aws_log_in_dict["aws_secret_access_key"] = os.environ.get("aws_secret_access_key")
-            aws_log_in_dict["region"] = os.environ.get("region")
-            aws_log_in_dict["service"] = os.environ.get("service")
+            aws_log_in_dict["aws_access_key_id"] = os.environ.get("OSB_AWS_ACCESS_KEY_ID")
+            aws_log_in_dict["aws_secret_access_key"] = os.environ.get("OSB_AWS_SECRET_ACCESS_KEY")
+            aws_log_in_dict["region"] = os.environ.get("OSB_REGION")
+            aws_log_in_dict["service"] = os.environ.get("OSB_SERVICE")
         # aws log in : option 2) parameters are passed in from command line
         elif self.client_options["amazon_aws_log_in"] == "client_option":
             aws_log_in_dict["aws_access_key_id"] = self.client_options.get("aws_access_key_id")

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -183,6 +183,53 @@ class OsClientFactory:
         port = self._config.opts("results_publishing", "datastore.port")
         secure = convert.to_bool(self._config.opts("results_publishing", "datastore.secure"))
         user = self._config.opts("results_publishing", "datastore.user")
+
+        metrics_amazon_aws_log_in = self._config.opts("results_publishing", "datastore.amazon_aws_log_in",
+                                                      default_value=None, mandatory=False)
+        metrics_aws_access_key_id = None
+        metrics_aws_secret_access_key = None
+        metrics_aws_region = None
+        metrics_aws_service = None
+
+        if metrics_amazon_aws_log_in == 'config':
+            metrics_aws_access_key_id = self._config.opts("results_publishing", "datastore.aws_access_key_id",
+                                                          default_value=None, mandatory=False)
+            metrics_aws_secret_access_key = self._config.opts("results_publishing", "datastore.aws_secret_access_key",
+                                                              default_value=None, mandatory=False)
+            metrics_aws_region = self._config.opts("results_publishing", "datastore.region",
+                                                   default_value=None, mandatory=False)
+            metrics_aws_service = self._config.opts("results_publishing", "datastore.service",
+                                                    default_value=None, mandatory=False)
+        elif metrics_amazon_aws_log_in == 'environment':
+            metrics_aws_access_key_id = os.getenv("OSB_DATASTORE_AWS_ACCESS_KEY_ID", default=None)
+            metrics_aws_secret_access_key = os.getenv("OSB_DATASTORE_AWS_SECRET_ACCESS_KEY", default=None)
+            metrics_aws_region = os.getenv("OSB_DATASTORE_REGION", default=None)
+            metrics_aws_service = os.getenv("OSB_DATASTORE_SERVICE", default=None)
+
+        if metrics_amazon_aws_log_in is not None:
+            if (
+                    not metrics_aws_access_key_id or not metrics_aws_secret_access_key
+                    or not metrics_aws_region or not metrics_aws_service
+            ):
+                if metrics_amazon_aws_log_in == 'environment':
+                    missing_aws_credentials_message = "Missing AWS credentials through " \
+                                                      "OSB_DATASTORE_AWS_ACCESS_KEY_ID, " \
+                                                      "OSB_DATASTORE_AWS_SECRET_ACCESS_KEY, " \
+                                                      "OSB_DATASTORE_REGION, OSB_DATASTORE_SERVICE " \
+                                                      "environment variables."
+                elif metrics_amazon_aws_log_in == 'config':
+                    missing_aws_credentials_message = "Missing AWS credentials through datastore.aws_access_key_id, " \
+                                                      "datastore.aws_secret_access_key, datastore.region, " \
+                                                      "datastore.service in the config file."
+                else:
+                    missing_aws_credentials_message = "datastore.amazon_aws_log_in can only be one of " \
+                                                      "'environment' or 'config'"
+                raise exceptions.ConfigError(missing_aws_credentials_message) from None
+
+            if (metrics_aws_service not in ['es', 'aoss']):
+                raise exceptions.ConfigError("datastore.service can only be one of 'es' or 'aoss'") from None
+
+
         try:
             password = os.environ["OSB_DATASTORE_PASSWORD"]
         except KeyError:
@@ -207,6 +254,14 @@ class OsClientFactory:
         if user and password:
             client_options["basic_auth_user"] = user
             client_options["basic_auth_password"] = password
+
+        #add options for aws user login: pass in aws access key id, aws secret access key, service and region on command
+        if metrics_amazon_aws_log_in is not None:
+            client_options["amazon_aws_log_in"] = 'client_option'
+            client_options["aws_access_key_id"] = metrics_aws_access_key_id
+            client_options["aws_secret_access_key"] = metrics_aws_secret_access_key
+            client_options["service"] = metrics_aws_service
+            client_options["region"] = metrics_aws_region
 
         factory = client.OsClientFactory(hosts=[{"host": host, "port": port}], client_options=client_options)
         self._client = factory.create()

--- a/setup.py
+++ b/setup.py
@@ -91,10 +91,7 @@ install_requires = [
     # License: Apache 2.0
     "google-auth==1.22.1",
     # License: MIT
-    "wheel==0.38.4"
-]
-
-s3_require = [
+    "wheel==0.38.4",
     # License: Apache 2.0
     # transitive dependencies:
     #   botocore: Apache 2.0
@@ -160,8 +157,7 @@ setup(name="opensearch-benchmark",
       test_suite="tests",
       tests_require=tests_require,
       extras_require={
-          "develop": tests_require + develop_require + s3_require,
-          "s3": s3_require
+          "develop": tests_require + develop_require
       },
       entry_points={
           "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "opensearch-py[async]==1.0.0",
+    "opensearch-py[async]==2.2.0",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -323,11 +323,14 @@ class OsClientTests(TestCase):
         cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
         cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
         cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
-        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.amazon_aws_log_in", _datastore_amazon_aws_log_in)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.amazon_aws_log_in",
+                _datastore_amazon_aws_log_in)
 
         if _datastore_amazon_aws_log_in == 'config':
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_access_key_id", _datastore_aws_access_key_id)
-            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_secret_access_key", _datastore_aws_secret_access_key)
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_access_key_id",
+                    _datastore_aws_access_key_id)
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_secret_access_key",
+                    _datastore_aws_secret_access_key)
             cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.service", _datastore_aws_service)
             cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.region", _datastore_aws_region)
         elif _datastore_amazon_aws_log_in == 'environment':
@@ -368,7 +371,7 @@ class OsClientTests(TestCase):
             else:
                 missing_aws_credentials_message = "datastore.amazon_aws_log_in can only be one of " \
                                                   "'environment' or 'config'"
-            assert (e.message == missing_aws_credentials_message)
+            assert e.message == missing_aws_credentials_message
             return
 
         return {


### PR DESCRIPTION
### Description
This PR adds support in OpenSearch benchmark to connect to OpenSearch clusters using SigV4 for running tests or reporting test results.

New configuration options added with this change:
1. New parameters supported with `--client-options` argument in `execute-test`:
  - `amazon_aws_log_in`: Value can be one of `client-options` or `environment`
    - if `amazon_aws_log_in` is  set as `client-options`, then the below configuration is mandatory in client-options:
      - `aws_access_key_id`: The AWS access key ID to use
      - `aws_secret_access_key`: The AWS secret key to use
      - `service`: `es` for Amazon OpenSearch service
      - `region`: The region in which the cluster is available, example: `us-east-1`
    - if `amazon_aws_log_in` is  set as `environment`, then the below environment variables should be set:
      - `OSB_AWS_ACCESS_KEY_ID`: The AWS access key ID to use
      - `OSB_AWS_SECRET_ACCESS_KEY`: The AWS secret key to use
      - `OSB_SERVICE`: `es` for Amazon OpenSearch service
      - `OSB_REGION`: The region in which the cluster is available, example: `us-east-1`
2. New parameters in `reporting` section of benchmark.ini:
  - `datastore.amazon_aws_log_in`: Value can be one of `config` or `environment`
    - if `datastore.amazon_aws_log_in` is  set as `config`, then below configuration is mandatory in `reporting` section in benchmark.ini:
      -  `datastore.aws_access_key_id`: The AWS access key ID to use
      - `datastore.aws_secret_access_key`:  The AWS secret key to use
      - `datastore.service`: `es` for Amazon OpenSearch service
      - `datastore.region`: The region in which the cluster is available, example: `us-east-1`
    - if `datastore.amazon_aws_log_in` is  set as `environment`, then the below environment variables should be set:
      - `OSB_DATASTORE_AWS_ACCESS_KEY_ID`: The AWS access key ID to use
      - `OSB_DATASTORE_AWS_SECRET_ACCESS_KEY`: The AWS secret key to use
      - `OSB_DATASTORE_SERVICE`: `es` for Amazon OpenSearch service
      - `OSB_DATASTORE_REGION`: The region in which the cluster is available, example: `us-east-1`

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/158

### Testing
- [x] New functionality includes testing
- [x] Executed `make test`
- [x] Executed benchmark tests using `percolator` and `http_logs` workloads using external OpenSearch cluster with SigV4 authentication for testing and another external OpenSearch cluster with SigV4 authentication for results reporting.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
