### PR TITLE
Give users ability to set number_of_shards and number_of_replicas via datastore config

### DIFF
--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -4,9 +4,6 @@
   ],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 10,
-      "number_of_replicas": 1
     }
   },
   "mappings": {

--- a/osbenchmark/resources/results-template.json
+++ b/osbenchmark/resources/results-template.json
@@ -4,8 +4,6 @@
   ],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 1
     }
   },
   "mappings": {

--- a/osbenchmark/resources/test-executions-template.json
+++ b/osbenchmark/resources/test-executions-template.json
@@ -4,8 +4,6 @@
   ],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 1
     }
   },
   "mappings": {


### PR DESCRIPTION
### Description
This PR allows users to set number_of_shards and number_of_replicas for `benchmark-*` indices. 

### Why are we reverting the changes of PR #321? 
The changes introduced in PR #321 can potentially impact OSB users with varying datastore cluster configurations since it forces their datastore clusters to have `benchmark-metrics-*` indices of 10 primary shards and 2 replicas shards. 10 primary shards and 2 replica shards are not suitable for all kinds of OpenSearch clusters. A better solution is to offer flexibility and allow users to override the defaults imposed by OpenSearch (1 primary and 0 replicas according to the documentation). With this PR, users can now do this by setting their own primary and replica shards with the benchmark.ini config. See #330 for more information.

### Issues Resolved
#330 #188 

### Testing
- [x] New functionality includes testing
- [x] Added new unittests
- [x] Tested with single node datastore cluster with 1AZ
- [x] Tested with multi node datastore cluster with 3AZ

See issue #330 for more testing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
