### PR TITLE
Add Issue Template for RFCs and Proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/proposal_template.md
@@ -1,0 +1,40 @@
+---
+name: 💭 Proposal
+about: Suggest an idea for a specific feature you wish to propose to the community for comment
+title: '[RFC/PROPOSAL]'
+labels: RFC
+assignees: ''
+---
+## What/Why
+### What are you proposing?
+_In a few sentences, describe the feature and its core capabilities._
+
+### What users have asked for this feature?
+_Highlight any research, proposals, requests or anecdotes that signal this is the right thing to build. Include links to GitHub Issues, Forums, Stack Overflow, Twitter, Etc_
+
+### What problems are you trying to solve?
+_Summarize the core use cases and user problems and needs you are trying to solve. Describe the most important user needs, pain points and jobs as expressed by the user asks above. Template: When \<a situation arises> , a \<type of user> wants to \<do something>, so they can \<expected outcome>._
+
+### What is the developer experience going to be?
+_Does this have a REST API? If so, please describe the API and any impact it may have to existing APIs. In a brief summary (not a spec), highlight what new REST APIs or changes to REST APIs are planned. as well as any other API, CLI or Configuration changes that are planned as part of this feature._
+
+#### Are there any security considerations?
+_Describe if the feature has any security considerations or impact. What is the security model of the new APIs? Features should be integrated into the OpenSearch security suite and so if they are not, we should highlight the reasons here._
+
+#### Are there any breaking changes to the API
+_If this feature will require breaking changes to any APIs, ouline what those are and why they are needed. What is the path to minimizing impact? (example, add new API and deprecate the old one)_
+
+### What is the user experience going to be?
+_Describe the feature requirements and or user stories. You may include low-fidelity sketches, wireframes, APIs stubs, or other examples of how a user would use the feature via CLI. Using a bulleted list or simple diagrams to outline features is okay. If this is net new functionality, call this out as well._
+
+#### Are there breaking changes to the User Experience?
+_Will this change the existing user experience? Will this be a breaking change from a user flow or user experience perspective?_
+
+### Why should it be built? Any reason not to?
+_Describe the value that this feature will bring to the OpenSearch community, as well as what impact it has if it isn't built, or new risks if it is. Highlight opportunities for additional research._
+
+### What will it take to execute?
+_Describe what it will take to build this feature. Are there any assumptions you may be making that could limit scope or add limitations? Are there performance, cost, or technical constraints that may impact the user experience? Does this feature depend on other feature work? What additional risks are there?_
+
+### Any remaining open questions?
+_What are known enhancements to this feature? Any enhancements that may be out of scope but that we will want to track long term? List any other open questions that may need to be answered before proceeding with an implementation._


### PR DESCRIPTION
### Description
This quick PR adds a new issue template to allow users to easily create RFCs and Proposals for OSB. This issue template provides a basic template of questions to address. 

### Issues Resolved
N/A

### Testing
- [ ] New functionality includes testing

N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
