### PR TITLE
Fix issues with the git module

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -86,7 +86,7 @@ def osbenchmark(cfg, command_line):
     This method should be used for benchmark invocations of the all commands besides test_execution.
     These commands may have different CLI options than test_execution.
     """
-    err, retcode = process.run_subprocess_get_stderr(osbenchmark_command_line_for(cfg, command_line))
+    err, retcode = process.run_subprocess_with_stderr(osbenchmark_command_line_for(cfg, command_line))
     if retcode != 0:
         print(err)
     return retcode
@@ -166,7 +166,7 @@ class TestCluster:
         self.http_port = http_port
         transport_port = http_port + 100
         try:
-            err, retcode = process.run_subprocess_get_stderr(
+            err, retcode = process.run_subprocess_with_stderr(
                 "opensearch-benchmark install --configuration-name={cfg} --distribution-version={dist} --build-type=tar "
                 "--http-port={http_port} --node={node_name} --master-nodes="
                 "{node_name} --provision-config-instance={provision_config_instance} "

--- a/osbenchmark/utils/process.py
+++ b/osbenchmark/utils/process.py
@@ -52,15 +52,26 @@ def run_subprocess_with_output(command_line):
     return lines
 
 
-def run_subprocess_get_stderr(command_line):
+def run_subprocess_with_out_and_err(command_line):
     logger = logging.getLogger(__name__)
-    logger.debug("Running subprocess [%s] with output and err.", command_line)
+    logger.debug("Running subprocess [%s] with stdout and stderr.", command_line)
+    command_line_args = shlex.split(command_line)
+
+    sp = subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp.wait()
+    out, err = sp.communicate()
+    return out.decode('UTF-8'), err.decode('UTF-8'), sp.returncode
+
+
+def run_subprocess_with_stderr(command_line):
+    logger = logging.getLogger(__name__)
+    logger.debug("Running subprocess [%s] with stderr but no stdout.", command_line)
     command_line_args = shlex.split(command_line)
 
     sp = subprocess.Popen(command_line_args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     sp.wait()
     _, err = sp.communicate()
-    return err.decode("UTF-8"), sp.returncode
+    return err.decode('UTF-8'), sp.returncode
 
 
 def exit_status_as_bool(runnable, quiet=False):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -22,7 +22,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 import os
 import unittest.mock as mock
 from unittest import TestCase
@@ -38,17 +37,14 @@ class GitTests(TestCase):
         self.assertFalse(git.is_working_copy(test_dir))
         self.assertTrue(git.is_working_copy(os.path.dirname(test_dir)))
 
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_git_version_too_old(self, run_subprocess_with_logging, run_subprocess):
-        # any non-zero return value will do
-        run_subprocess_with_logging.return_value = 64
-        run_subprocess.return_value = "1.0.0"
-
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_version_too_old(self, run_subprocess_with_out_and_err):
+        run_subprocess_with_out_and_err.return_value = ("git version 1.4.0", None, 0)
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             git.head_revision("/src")
-        self.assertEqual("Your git version is [1.0.0] but Benchmark requires at least git 1.9. Please update git.", ctx.exception.args[0])
-        run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
+        self.assertEqual("OpenSearch Benchmark requires at least version 2 of git.  You have git version 1.4.0.  Please update git.",
+                         ctx.exception.args[0])
+        run_subprocess_with_out_and_err.assert_called_with("git -C /src --version")
 
     @mock.patch("osbenchmark.utils.io.ensure_dir")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
@@ -77,37 +73,45 @@ class GitTests(TestCase):
         run_subprocess_with_logging.assert_called_with("git clone http://github.com/some/project /src")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_fetch_successful(self, run_subprocess_with_logging):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_fetch_successful(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
         git.fetch("/src", remote="my-origin")
         run_subprocess_with_logging.assert_called_with("git -C /src fetch --prune --tags my-origin")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_fetch_with_error(self, run_subprocess_with_logging):
-        # first call is to check the git version (0 -> succeeds), the second call is the failing checkout (1 -> fails)
-        run_subprocess_with_logging.side_effect = [0, 1]
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_fetch_with_error(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
+        run_subprocess_with_logging.return_value = 1
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.fetch("/src", remote="my-origin")
         self.assertEqual("Could not fetch source tree from [my-origin]", ctx.exception.args[0])
         run_subprocess_with_logging.assert_called_with("git -C /src fetch --prune --tags my-origin")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_checkout_successful(self, run_subprocess_with_logging):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_checkout_successful(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
         git.checkout("/src", "feature-branch")
         run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_checkout_with_error(self, run_subprocess_with_logging):
-        # first call is to check the git version (0 -> succeeds), the second call is the failing checkout (1 -> fails)
-        run_subprocess_with_logging.side_effect = [0, 1]
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_checkout_with_error(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
+        run_subprocess_with_logging.return_value = 1
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.checkout("/src", "feature-branch")
         self.assertEqual("Could not checkout [feature-branch]. Do you have uncommitted changes?", ctx.exception.args[0])
         run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_rebase(self, run_subprocess_with_logging):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_rebase(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
         git.rebase("/src", remote="my-origin", branch="feature-branch")
         calls = [
@@ -117,63 +121,62 @@ class GitTests(TestCase):
         run_subprocess_with_logging.assert_has_calls(calls)
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_pull(self, run_subprocess_with_logging):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_pull(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
         git.pull("/src", remote="my-origin", branch="feature-branch")
+        run_subprocess_with_out_and_err.assert_has_calls([
+            # pull, fetch, rebase, checkout
+            mock.call("git -C /src --version")
+            ] * 4)
         calls = [
-            # pull
-            mock.call('git -C /src --version', level=logging.DEBUG),
-            # fetch
-            mock.call('git -C /src --version', level=logging.DEBUG),
             mock.call("git -C /src fetch --prune --tags my-origin"),
-            # rebase
-            mock.call('git -C /src --version', level=logging.DEBUG),
-            # checkout
-            mock.call('git -C /src --version', level=logging.DEBUG),
             mock.call("git -C /src checkout feature-branch"),
             mock.call("git -C /src rebase my-origin/feature-branch")
         ]
         run_subprocess_with_logging.assert_has_calls(calls)
 
-    @mock.patch("osbenchmark.utils.process.run_subprocess")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_pull_ts(self, run_subprocess_with_logging, run_subprocess_with_output, run_subprocess):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_pull_ts(self, run_subprocess_with_out_and_err, run_subprocess_with_logging,
+                     run_subprocess_with_output):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
         run_subprocess_with_output.return_value = ["3694a07"]
-        run_subprocess.side_effect = [False, False]
         git.pull_ts("/src", "20160101T110000Z")
 
         run_subprocess_with_output.assert_called_with(
             "git -C /src rev-list -n 1 --before=\"20160101T110000Z\" --date=iso8601 origin/main")
-        run_subprocess.has_calls([
-            mock.call("git -C /src fetch --prune --tags --quiet origin"),
+        run_subprocess_with_logging.assert_has_calls([
+            mock.call("git -C /src fetch --prune --tags origin"),
             mock.call("git -C /src checkout 3694a07")
         ])
 
-    @mock.patch("osbenchmark.utils.process.run_subprocess")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_pull_revision(self, run_subprocess_with_logging, run_subprocess):
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_pull_revision(self, run_subprocess_with_out_and_err, run_subprocess_with_logging):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.side_effect = [False, False]
         git.pull_revision("/src", "3694a07")
-        run_subprocess.has_calls([
-            mock.call("git -C /src fetch --prune --tags --quiet origin"),
-            mock.call("git -C /src checkout --quiet 3694a07"),
+        run_subprocess_with_logging.assert_has_calls([
+            mock.call("git -C /src fetch --prune --tags origin"),
+            mock.call("git -C /src checkout 3694a07"),
         ])
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_head_revision(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = ["3694a07"]
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_head_revision(self, run_subprocess_with_out_and_err, run_subprocess_with_output):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
+        run_subprocess_with_output.return_value = ["3694a07"]
         self.assertEqual("3694a07", git.head_revision("/src"))
-        run_subprocess.assert_called_with("git -C /src rev-parse --short HEAD")
+        run_subprocess_with_output.assert_called_with("git -C /src rev-parse --short HEAD")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_list_remote_branches(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_list_remote_branches(self, run_subprocess_with_out_and_err, run_subprocess):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess.return_value = ["  origin/HEAD",
                                        "  origin/main",
                                        "  origin/5.0.0-alpha1",
@@ -182,9 +185,9 @@ class GitTests(TestCase):
         run_subprocess.assert_called_with("git -C /src for-each-ref refs/remotes/ --format='%(refname)'")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_list_local_branches(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_list_local_branches(self, run_subprocess_with_out_and_err, run_subprocess):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess.return_value = ["  HEAD",
                                        "  main",
                                        "  5.0.0-alpha1",
@@ -193,18 +196,18 @@ class GitTests(TestCase):
         run_subprocess.assert_called_with("git -C /src for-each-ref refs/heads/ --format='%(refname:short)'")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_list_tags_with_tags_present(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_list_tags_with_tags_present(self, run_subprocess_with_out_and_err, run_subprocess):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess.return_value = ["  v1",
                                        "  v2"]
         self.assertEqual(["v1", "v2"], git.tags("/src"))
         run_subprocess.assert_called_with("git -C /src tag")
 
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_output")
-    @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_list_tags_no_tags_available(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
+    def test_list_tags_no_tags_available(self, run_subprocess_with_out_and_err, run_subprocess):
+        run_subprocess_with_out_and_err.return_value = ("git version 2.4.0", None, 0)
         run_subprocess.return_value = ""
         self.assertEqual([], git.tags("/src"))
         run_subprocess.assert_called_with("git -C /src tag")


### PR DESCRIPTION
### Description
There were several errors with the `git` module.  The version check did not actually work.  Also, the error message generated when OSB atarted up if the git package was not installed, was not user-friendly:
```
ERROR] Cannot execute-test. Error in test execution orchestrator ([Errno 2] No such file or directory: 'git')
```

### Testing
The git module tests were updated to incorporate the code changes.  There were some errors as well in the earlier tests, which resulted in some of then not actually working.

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
