### PR TITLE
Refactoring zstdnodict to zstd_no_dict

### DIFF
--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -718,7 +718,7 @@ class IndexCodec(Enum):
     Default = "default"
     BestCompression = "best_compression"
     ZSTD = "zstd"
-    ZSTDNODICT = "zstdnodict"
+    ZSTDNODICT = "zstd_no_dict"
 
     @classmethod
     def is_codec_valid(cls, codec):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1666,7 +1666,7 @@ class CreateIndexParamSourceTests(TestCase):
             "body": {
                 "settings": {
                     "index.number_of_replicas": 0,
-                    "index.codec": "zstdnodict"
+                    "index.codec": "zstd_no_dict"
                 },
                 "mappings": {
                     "doc": {
@@ -1686,7 +1686,7 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual("test", index)
         self.assertTrue(len(body) > 0)
         self.assertEqual({}, p["request-params"])
-        self.assertEqual("zstdnodict", body["settings"]["index.codec"])
+        self.assertEqual("zstd_no_dict", body["settings"]["index.codec"])
 
     def test_create_index_with_invalid_codec(self):
         with self.assertRaises(exceptions.InvalidSyntax) as context:
@@ -1711,7 +1711,7 @@ class CreateIndexParamSourceTests(TestCase):
 
         self.assertEqual(str(context.exception),
                          "Please set the value properly for the create-index operation. Invalid index.codec value " +
-                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstdnodict']")
+                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstd_no_dict']")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):


### PR DESCRIPTION
### Description
This is to refactor the ```zstdnodict``` codec name to ```zstd_no_dict```

### Issues Resolved
#335 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
