### PR TITLE
Rename subcommand execute-test to run

### DIFF
--- a/CREATE_WORKLOAD_GUIDE.md
+++ b/CREATE_WORKLOAD_GUIDE.md
@@ -53,7 +53,7 @@ By default, workloads created will come with the following operations run in the
 
 To invoke the newly created workload, run the following:
 ```
-$ opensearch-benchmark execute_test \
+$ opensearch-benchmark run \
 --pipeline="benchmark-only" \
 --workload-path="<PATH OUTPUTTED IN THE OUTPUT OF THE CREATE-WORKLOAD COMMAND>" \
 --target-host="<CLUSTER ENDPOINT>" \

--- a/PYTHON_SUPPORT_GUIDE.md
+++ b/PYTHON_SUPPORT_GUIDE.md
@@ -27,17 +27,17 @@ supported_python_versions = [(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)]
 
 **Basic OpenSearch Benchmark command with distribution version and test mode**
 ```
-opensearch-benchmark execute-test --distribution-version=1.0.0 --workload=geonames --test-mode
+opensearch-benchmark run --distribution-version=1.0.0 --workload=geonames --test-mode
 ```
 
 **OpenSearch Benchmark command executing test on target-host in test mode**
 ```
-opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
+opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
 ```
 
 **OpenSearch-Benchmark command executing test on target-host without test mode**
 ```
-opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 To ensure that users are using the correct python versions, install the repository with `python3 -m pip install -e .` and run `which opensearch-benchmark` to get the path. Pre-append this path to each of the three commands above and re-run them in the command line.
@@ -46,12 +46,12 @@ Keep in mind the file path outputted differs for each operating system and might
 
 - For example: When running `which opensearch-benchmark` on an Ubuntu environment, the commad line outputs `/home/ubuntu/.pyenv/shims/opensearch-benchmark`. On closer inspection, the path points to a shell script. Thus, to invoke OpenSearch Benchmark, pre-=append the OpenSearch Benchmark command with `bash` and the path outputted earlier:
 ```
-bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 - Another example: When running `which opensearch-benchmark` on an Amazon Linux 2 environment, the command line outputs `~/.local/bin/opensearch-benchmark`. On closer inspection, the path points to a Python script. Thus, to invoke OpenSearch Benchmark, pre-append the OpenSearch Benchmark command with `python3` and the path outputted earlier:
 ```
-python3 ~/.local/bin/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+python3 ~/.local/bin/opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 ### Creating a Pull Request After Adding Changes and Testing Them Out

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run your first test execution
 
 Now we're ready to run our first test execution:
 
-    opensearch-benchmark execute-test --distribution-version=1.0.0 --workload=geonames --test-mode
+    opensearch-benchmark run --distribution-version=1.0.0 --workload=geonames --test-mode
 
 This will download OpenSearch 1.0.0 and run one of OpenSearch Benchmark's official workloads - the [geonames workload](<https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/geonames>) - against it.
 Note that this uses the `--test-mode` argument to only run a single instance of each operation in order to reduce the time needed for a test execution. This argument is used as a sanity check and should be removed in an actual benchmarking scenario.

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ Install Python 3.8+ including ``pip3``, git 1.9+ and an [appropriate JDK to run 
 
 If you have any trouble or need more detailed instructions, please look in the [detailed installation guide](<https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md>).
 
-Run your first test execution
+Run your first test run
 -----------------------------
 
-Now we're ready to run our first test execution:
+Now we're ready to run our first test run:
 
     opensearch-benchmark run --distribution-version=1.0.0 --workload=geonames --test-mode
 
 This will download OpenSearch 1.0.0 and run one of OpenSearch Benchmark's official workloads - the [geonames workload](<https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/geonames>) - against it.
-Note that this uses the `--test-mode` argument to only run a single instance of each operation in order to reduce the time needed for a test execution. This argument is used as a sanity check and should be removed in an actual benchmarking scenario.
-After the test execution, a summary report is written to the command line:
+Note that this uses the `--test-mode` argument to only run a single instance of each operation in order to reduce the time needed for a test run. This argument is used as a sanity check and should be removed in an actual benchmarking scenario.
+After the test run, a summary report is written to the command line:
 
     ------------------------------------------------------
         _______             __   _____

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -64,7 +64,7 @@ Argument | Description | Required
 `provision-config-path` | Define the path to the provision_config_instance and plugin configurations to use. | No
 `provision-config-repository` | Define repository from where Benchmark will load provision_configs and provision_config_instances (default: `default`). | No
 `provision-config-revision` | Define a specific revision in the provision_config repository that Benchmark should use. | No
-`test-execution-id` | Define a unique id for this test_execution. | No
+`test-run-id` | Define a unique id for this test run. | No
 `pipeline` | Select the pipeline to run. | No
 `revision` | Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is, 'latest' fetches the latest version on main. It is also possible to specify a commit id or an ISO timestamp. The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, e.g. "@2013-07-27T10:37:00Z" (default: `current`). | No
 `workload-repository` | Define the repository from where Benchmark will load workloads (default: `default`). | No

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -5,13 +5,13 @@ parent: Benchmark API
 nav_order: 10
 ---
 
-The `execute-test` command of OpenSearch Benchmark executes tests against your OpenSearch cluster.
+The `run` command of OpenSearch Benchmark runs tests against your OpenSearch cluster.
 
 
 ## Syntax
 
 ```bash
-opensearch-benchmark execute-test <arguments>
+opensearch-benchmark run <arguments>
 ```
 
 
@@ -34,7 +34,7 @@ Argument | Description | Required
 *Example 1*
 
 ```
-opensearch-benchmark execute-test --workload eventdata --test-mode
+opensearch-benchmark run --workload eventdata --test-mode
 ```
 
 Provision an OpenSearch node on the local machine based on the latest source code in Github and execute the `eventdata` workload in test mode.
@@ -42,7 +42,7 @@ Provision an OpenSearch node on the local machine based on the latest source cod
 *Example 2*
 
 ```
-opensearch-benchmark execute-test --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
+opensearch-benchmark run --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
 ```
 
 Execute the `http_logs` workload against an existing OpenSearch cluster but only use one client for indexing and only ingest 10% of the total data corpus.
@@ -50,7 +50,7 @@ Execute the `http_logs` workload against an existing OpenSearch cluster but only
 *Example 3*
 
 ```
-opensearch-benchmark execute-test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
+opensearch-benchmark run --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
 ```
 
 Execute the `nyc_taxis` workload against an existing OpenSearch cluster with the security plugin enabled.

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Execute Test
+title: Run
 parent: Benchmark API
 nav_order: 10
 ---

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -92,12 +92,12 @@ def osbenchmark(cfg, command_line):
     return retcode
 
 
-def execute_test(cfg, command_line):
+def run(cfg, command_line):
     """
     This method should be used for benchmark invocations of the test_execution command.
     It sets up some defaults for how the integration tests expect to run test_executions.
     """
-    return osbenchmark(cfg, f"execute-test {command_line} --kill-running-processes --on-error='abort'")
+    return osbenchmark(cfg, f"run {command_line} --kill-running-processes --on-error='abort'")
 
 
 def shell_cmd(command_line):

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -83,8 +83,8 @@ def osbenchmark_command_line_for(cfg, command_line):
 
 def osbenchmark(cfg, command_line):
     """
-    This method should be used for benchmark invocations of the all commands besides test_execution.
-    These commands may have different CLI options than test_execution.
+    This method should be used for benchmark invocations of all commands except for "run".
+    These commands may have different CLI options than "run".
     """
     err, retcode = process.run_subprocess_get_stderr(osbenchmark_command_line_for(cfg, command_line))
     if retcode != 0:
@@ -94,8 +94,8 @@ def osbenchmark(cfg, command_line):
 
 def run_test(cfg, command_line):
     """
-    This method should be used for benchmark invocations of the test_execution command.
-    It sets up some defaults for how the integration tests expect to run test_executions.
+    This method should be used for invocations with the "run" command.
+    It sets up some defaults for how the integration tests expect to run benchmarks.
     """
     return osbenchmark(cfg, f"run {command_line} --kill-running-processes --on-error='abort'")
 
@@ -182,8 +182,8 @@ class TestCluster:
         except BaseException as e:
             raise AssertionError("Failed to install OpenSearch {}.".format(distribution_version), e)
 
-    def start(self, test_execution_id):
-        cmd = "start --runtime-jdk=\"bundled\" --installation-id={} --test-execution-id={}".format(self.installation_id, test_execution_id)
+    def start(self, test_run_id):
+        cmd = "start --runtime-jdk=\"bundled\" --installation-id={} --test-run-id={}".format(self.installation_id, test_run_id)
         if osbenchmark(self.cfg, cmd) != 0:
             raise AssertionError("Failed to start OpenSearch test cluster.")
         opensearch = client.OsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
@@ -209,7 +209,7 @@ class OsMetricsStore:
                              node_name="metrics-store",
                              provision_config_instance="defaults",
                              http_port=10200)
-        self.cluster.start(test_execution_id="metrics-store")
+        self.cluster.start(test_run_id="metrics-store")
 
     def stop(self):
         self.cluster.stop()

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -92,7 +92,7 @@ def osbenchmark(cfg, command_line):
     return retcode
 
 
-def run(cfg, command_line):
+def run_test(cfg, command_line):
     """
     This method should be used for benchmark invocations of the test_execution command.
     It sets up some defaults for how the integration tests expect to run test_executions.

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -31,7 +31,7 @@ def test_tar_distributions(cfg):
     for dist in it.DISTRIBUTIONS:
         for workload in it.WORKLOADS:
             it.wait_until_port_is_free(port_number=port)
-            assert it.run(cfg, f"--distribution-version=\"{dist}\" --workload=\"{workload}\" "
+            assert it.run_test(cfg, f"--distribution-version=\"{dist}\" --workload=\"{workload}\" "
                                 f"--test-mode --provision-config-instance=4gheap --target-hosts=127.0.0.1:{port}") == 0
 
 
@@ -41,6 +41,6 @@ def test_docker_distribution(cfg):
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
     it.wait_until_port_is_free(port_number=port)
-    assert it.run(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
+    assert it.run_test(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
                         f"--workload=\"geonames\" --test-procedure=\"append-no-conflicts-index-only\" --test-mode "
                         f"--provision-config-instance=4gheap --target-hosts=127.0.0.1:{port}") == 0

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -31,7 +31,7 @@ def test_tar_distributions(cfg):
     for dist in it.DISTRIBUTIONS:
         for workload in it.WORKLOADS:
             it.wait_until_port_is_free(port_number=port)
-            assert it.execute_test(cfg, f"--distribution-version=\"{dist}\" --workload=\"{workload}\" "
+            assert it.run(cfg, f"--distribution-version=\"{dist}\" --workload=\"{workload}\" "
                                 f"--test-mode --provision-config-instance=4gheap --target-hosts=127.0.0.1:{port}") == 0
 
 
@@ -41,6 +41,6 @@ def test_docker_distribution(cfg):
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
     it.wait_until_port_is_free(port_number=port)
-    assert it.execute_test(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
+    assert it.run(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
                         f"--workload=\"geonames\" --test-procedure=\"append-no-conflicts-index-only\" --test-mode "
                         f"--provision-config-instance=4gheap --target-hosts=127.0.0.1:{port}") == 0

--- a/it/generate_test.py
+++ b/it/generate_test.py
@@ -30,7 +30,7 @@ import it
 @it.benchmark_in_mem
 def test_workload_info_with_test_procedure(cfg, tmp_path):
     cwd = os.path.dirname(__file__)
-    chart_spec_path = os.path.join(cwd, "resources", "sample-test-execution-config.json")
+    chart_spec_path = os.path.join(cwd, "resources", "sample-test-run-config.json")
     output_path = os.path.join(tmp_path, "nightly-charts.ndjson")
     assert it.osbenchmark(cfg, f"generate charts "
                            f"--chart-spec-path={chart_spec_path} "

--- a/it/list_test.py
+++ b/it/list_test.py
@@ -26,8 +26,8 @@ import it
 
 
 @it.all_benchmark_configs
-def test_list_test_executions(cfg):
-    assert it.osbenchmark(cfg, "list test_executions") == 0
+def test_list_test_runs(cfg):
+    assert it.osbenchmark(cfg, "list test-runs") == 0
 
 
 @it.benchmark_in_mem

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -28,10 +28,10 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.execute_test(cfg, f"--revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+    assert it.run(cfg, f"--revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts --provision-config-instance=4gheap "
                         f"--opensearch-plugins=analysis-icu") == 0
 
     it.wait_until_port_is_free(port_number=port)
-    assert it.execute_test(cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+    assert it.run(cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts-index-only --provision-config-instance=\"4gheap,ea\"") == 0

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -28,10 +28,10 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.run(cfg, f"--revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+    assert it.run_test(cfg, f"--revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts --provision-config-instance=4gheap "
                         f"--opensearch-plugins=analysis-icu") == 0
 
     it.wait_until_port_is_free(port_number=port)
-    assert it.run(cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+    assert it.run_test(cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts-index-only --provision-config-instance=\"4gheap,ea\"") == 0

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -49,7 +49,7 @@ def test_create_workload(cfg, tmp_path, test_cluster):
     # prepare some data
     cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} " \
           f" --workload=geonames --test-procedure=append-no-conflicts-index-only --quiet"
-    assert it.run(cfg, cmd) == 0
+    assert it.run_test(cfg, cmd) == 0
 
     # create the workload
     workload_name = f"test-workload-{uuid.uuid4()}"
@@ -71,4 +71,4 @@ def test_create_workload(cfg, tmp_path, test_cluster):
 
     # run a benchmark with the created workload
     cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} --workload-path={workload_path}"
-    assert it.run(cfg, cmd) == 0
+    assert it.run_test(cfg, cmd) == 0

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -35,11 +35,11 @@ def test_cluster():
     # test with a recent distribution
     dist = it.DISTRIBUTIONS[-1]
     port = 19200
-    test_execution_id = str(uuid.uuid4())
+    test_run_id = str(uuid.uuid4())
 
     it.wait_until_port_is_free(port_number=port)
     cluster.install(distribution_version=dist, node_name="benchmark-node", provision_config_instance="4gheap", http_port=port)
-    cluster.start(test_execution_id=test_execution_id)
+    cluster.start(test_run_id=test_run_id)
     yield cluster
     cluster.stop()
 

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -49,7 +49,7 @@ def test_create_workload(cfg, tmp_path, test_cluster):
     # prepare some data
     cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} " \
           f" --workload=geonames --test-procedure=append-no-conflicts-index-only --quiet"
-    assert it.execute_test(cfg, cmd) == 0
+    assert it.run(cfg, cmd) == 0
 
     # create the workload
     workload_name = f"test-workload-{uuid.uuid4()}"
@@ -71,4 +71,4 @@ def test_create_workload(cfg, tmp_path, test_cluster):
 
     # run a benchmark with the created workload
     cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} --workload-path={workload_path}"
-    assert it.execute_test(cfg, cmd) == 0
+    assert it.run(cfg, cmd) == 0

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -111,7 +111,7 @@ def create_arg_parser():
         dest="subcommand",
         help="")
 
-    test_execution_parser = subparsers.add_parser("execute-test", help="Run a benchmark")
+    test_execution_parser = subparsers.add_parser("run", help="Run a benchmark")
     # change in favor of "list telemetry", "list workloads", "list pipelines"
     list_parser = subparsers.add_parser("list", help="List configuration options")
     list_parser.add_argument(
@@ -649,7 +649,7 @@ def print_help_on_errors():
                     f"and include the log files in {paths.logs()}.")
 
 
-def execute_test(cfg, kill_running_processes=False):
+def run(cfg, kill_running_processes=False):
     logger = logging.getLogger(__name__)
 
     if kill_running_processes:
@@ -869,10 +869,10 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             builder.stop(cfg)
-        elif sub_command == "execute-test":
-            # As the execute-test command is doing more work than necessary at the moment, we duplicate several parameters
+        elif sub_command == "run":
+            # As the run command is doing more work than necessary at the moment, we duplicate several parameters
             # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
-            # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute-test" only
+            # these duplicated parameters will vanish as we move towards dedicated subcommands and use "run" only
             # to run the actual benchmark (i.e. generating load).
             if args.effective_start_date:
                 cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)
@@ -905,7 +905,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
             configure_reporting_params(args, cfg)
 
-            execute_test(cfg, args.kill_running_processes)
+            run(cfg, args.kill_running_processes)
         elif sub_command == "generate":
             cfg.add(config.Scope.applicationOverride, "generator", "chart.spec.path", args.chart_spec_path)
             cfg.add(config.Scope.applicationOverride, "generator", "chart.type", args.chart_type)

--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -368,7 +368,7 @@ class BuilderActor(actor.BenchmarkActor):
             self.on_all_nodes_started()
             self.status = "cluster_started"
         else:
-            console.info("Preparing for test execution ...", flush=True)
+            console.info("Preparing for test run ...", flush=True)
             self.logger.info("Cluster consisting of %s will be provisioned by Benchmark.", hosts)
             msg.hosts = hosts
             # Initialize the children array to have the right size to

--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -86,7 +86,7 @@ def install(cfg):
 
 def start(cfg):
     root_path = paths.install_root(cfg)
-    test_execution_id = cfg.opts("system", "test_execution.id")
+    test_run_id = cfg.opts("system", "test_run.id")
     # avoid double-launching - we expect that the node file is absent
     with contextlib.suppress(FileNotFoundError):
         _load_node_file(root_path)
@@ -103,7 +103,7 @@ def start(cfg):
     else:
         raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
     nodes = node_launcher.start([node_config])
-    _store_node_file(root_path, (nodes, test_execution_id))
+    _store_node_file(root_path, (nodes, test_run_id))
 
 
 def stop(cfg):
@@ -116,35 +116,35 @@ def stop(cfg):
     else:
         raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
 
-    nodes, test_execution_id = _load_node_file(root_path)
+    nodes, test_run_id = _load_node_file(root_path)
 
     cls = metrics.metrics_store_class(cfg)
     metrics_store = cls(cfg)
 
-    test_execution_store = metrics.test_execution_store(cfg)
+    test_run_store = metrics.test_run_store(cfg)
     try:
-        current_test_execution = test_execution_store.find_by_test_execution_id(test_execution_id)
+        current_test_run = test_run_store.find_by_test_run_id(test_run_id)
         metrics_store.open(
-            test_ex_id=current_test_execution.test_execution_id,
-            test_ex_timestamp=current_test_execution.test_execution_timestamp,
-            workload_name=current_test_execution.workload_name,
-            test_procedure_name=current_test_execution.test_procedure_name
+            test_ex_id=current_test_run.test_run_id,
+            test_ex_timestamp=current_test_run.test_run_timestamp,
+            workload_name=current_test_run.workload_name,
+            test_procedure_name=current_test_run.test_procedure_name
         )
     except exceptions.NotFound:
-        logging.getLogger(__name__).info("Could not find test_execution [%s] and will thus not persist system metrics.", test_execution_id)
-        # Don't persist system metrics if we can't retrieve the test_execution as we cannot derive the required meta-data.
-        current_test_execution = None
+        logging.getLogger(__name__).info("Could not find test-run [%s] and will thus not persist system metrics.", test_run_id)
+        # Don't persist system metrics if we can't retrieve the test_run as we cannot derive the required meta-data.
+        current_test_run = None
         metrics_store = None
 
     node_launcher.stop(nodes, metrics_store)
     _delete_node_file(root_path)
 
-    if current_test_execution:
+    if current_test_run:
         metrics_store.flush(refresh=True)
         for node in nodes:
             results = metrics.calculate_system_results(metrics_store, node.node_name)
-            current_test_execution.add_results(results)
-            metrics.results_store(cfg).store_results(current_test_execution)
+            current_test_run.add_results(results)
+            metrics.results_store(cfg).store_results(current_test_run)
 
         metrics_store.close()
 
@@ -318,7 +318,7 @@ class BuilderActor(actor.BenchmarkActor):
     def __init__(self):
         super().__init__()
         self.cfg = None
-        self.test_execution_orchestrator = None
+        self.test_run_orchestrator = None
         self.cluster_launcher = None
         self.cluster = None
         self.provision_config_instance = None
@@ -334,7 +334,7 @@ class BuilderActor(actor.BenchmarkActor):
             return
         failmsg = "Child actor exited with [%s] while in status [%s]." % (msg, self.status)
         self.logger.error(failmsg)
-        self.send(self.test_execution_orchestrator, actor.BenchmarkFailure(failmsg))
+        self.send(self.test_run_orchestrator, actor.BenchmarkFailure(failmsg))
 
     def receiveMsg_PoisonMessage(self, msg, sender):
         self.logger.info("BuilderActor#receiveMessage poison(msg = [%s] sender = [%s])", str(msg.poisonMessage), str(sender))
@@ -344,12 +344,12 @@ class BuilderActor(actor.BenchmarkActor):
         else:
             failmsg = msg.details
         self.logger.error(failmsg)
-        self.send(self.test_execution_orchestrator, actor.BenchmarkFailure(failmsg))
+        self.send(self.test_run_orchestrator, actor.BenchmarkFailure(failmsg))
 
     @actor.no_retry("builder")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StartEngine(self, msg, sender):
-        self.logger.info("Received signal from test execution orchestrator to start engine.")
-        self.test_execution_orchestrator = sender
+        self.logger.info("Received signal from test run orchestrator to start engine.")
+        self.test_run_orchestrator = sender
         self.cfg = msg.cfg
         self.provision_config_instance, _ = load_provision_config(self.cfg, msg.external)
         # TODO: This is implicitly set by #load_provision_config() - can we gather this elsewhere?
@@ -404,7 +404,7 @@ class BuilderActor(actor.BenchmarkActor):
             raise exceptions.BenchmarkAssertionError("Unknown wakeup reason [{}]".format(msg.payload))
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
-        self.send(self.test_execution_orchestrator, msg)
+        self.send(self.test_run_orchestrator, msg)
 
     @actor.no_retry("builder")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StopEngine(self, msg, sender):
@@ -420,14 +420,14 @@ class BuilderActor(actor.BenchmarkActor):
         self.transition_when_all_children_responded(sender, msg, "cluster_stopping", "cluster_stopped", self.on_all_nodes_stopped)
 
     def on_all_nodes_started(self):
-        self.send(self.test_execution_orchestrator, EngineStarted(self.provision_config_revision))
+        self.send(self.test_run_orchestrator, EngineStarted(self.provision_config_revision))
 
     def reset_relative_time(self):
         for m in self.children:
             self.send(m, ResetRelativeTime(0))
 
     def on_all_nodes_stopped(self):
-        self.send(self.test_execution_orchestrator, EngineStopped())
+        self.send(self.test_run_orchestrator, EngineStopped())
         # clear all state as the builder might get reused later
         for m in self.children:
             self.send(m, thespian.actors.ActorExitRequest())
@@ -544,8 +544,8 @@ class NodeBuilderActor(actor.BenchmarkActor):
             cfg = config.auto_load_local_config(msg.cfg, additional_sections=[
                 # only copy the relevant bits
                 "workload", "builder", "client", "telemetry",
-                # allow metrics store to extract test_execution meta-data
-                "test_execution",
+                # allow metrics store to extract test_run meta-data
+                "test_run",
                 "source"
             ])
             # set root path (normally done by the main entry point)
@@ -623,7 +623,7 @@ def load_provision_config(cfg, external):
 
 def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_ids, sources=False, distribution=False,
            external=False, docker=False):
-    test_execution_root_path = paths.test_execution_root(cfg)
+    test_run_root_path = paths.test_run_root(cfg)
     node_ids = cfg.opts("provisioning", "node.ids", mandatory=False)
     node_name_prefix = cfg.opts("provisioning", "node.name.prefix")
     provision_config_instance, plugins = load_provision_config(cfg, external)
@@ -636,7 +636,7 @@ def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_i
             node_name = "%s-%s" % (node_name_prefix, node_id)
             p.append(
                 provisioner.local(cfg, provision_config_instance, plugins, node_ip, node_http_port, all_node_ips,
-                                  all_node_names, test_execution_root_path, node_name))
+                                  all_node_names, test_run_root_path, node_name))
         l = launcher.ProcessLauncher(cfg)
     elif external:
         raise exceptions.BenchmarkAssertionError("Externally provisioned clusters should not need to be managed by Benchmark's builder")
@@ -648,7 +648,7 @@ def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_i
         p = []
         for node_id in node_ids:
             node_name = "%s-%s" % (node_name_prefix, node_id)
-            p.append(provisioner.docker(cfg, provision_config_instance, node_ip, node_http_port, test_execution_root_path, node_name))
+            p.append(provisioner.docker(cfg, provision_config_instance, node_ip, node_http_port, test_run_root_path, node_name))
         l = launcher.DockerLauncher(cfg)
     else:
         # It is a programmer error (and not a user error) if this function is called with wrong parameters
@@ -695,9 +695,9 @@ class Builder:
         self.launcher.stop(self.nodes, self.metrics_store)
         self.flush_metrics(refresh=True)
         try:
-            current_test_execution = self._current_test_execution()
+            current_test_run = self._current_test_run()
             for node in self.nodes:
-                self._add_results(current_test_execution, node)
+                self._add_results(current_test_run, node)
         except exceptions.NotFound as e:
             self.logger.warning("Cannot store system metrics: %s.", str(e))
 
@@ -709,11 +709,11 @@ class Builder:
                                 data_paths=node_config.data_paths)
         self.node_configs = []
 
-    def _current_test_execution(self):
-        test_execution_id = self.cfg.opts("system", "test_execution.id")
-        return metrics.test_execution_store(self.cfg).find_by_test_execution_id(test_execution_id)
+    def _current_test_run(self):
+        test_run_id = self.cfg.opts("system", "test_run.id")
+        return metrics.test_run_store(self.cfg).find_by_test_run_id(test_run_id)
 
-    def _add_results(self, current_test_execution, node):
+    def _add_results(self, current_test_run, node):
         results = metrics.calculate_system_results(self.metrics_store, node.node_name)
-        current_test_execution.add_results(results)
-        metrics.results_store(self.cfg).store_results(current_test_execution)
+        current_test_run.add_results(results)
+        metrics.results_store(self.cfg).store_results(current_test_run)

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -31,7 +31,7 @@ class DockerInstaller(Installer):
     def _create_node(self):
         node_name = str(uuid.uuid4())
         node_port = int(self.provision_config_instance.variables["node"]["port"])
-        node_root_dir = os.path.join(self.provision_config_instance.variables["test_execution_root"], node_name)
+        node_root_dir = os.path.join(self.provision_config_instance.variables["test_run_root"], node_name)
         node_data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
         node_binary_path = os.path.join(node_root_dir, "install")
         node_log_dir = os.path.join(node_root_dir, "logs", "server")

--- a/osbenchmark/builder/installers/installer.py
+++ b/osbenchmark/builder/installers/installer.py
@@ -25,7 +25,7 @@ class Installer(ABC):
     @abstractmethod
     def cleanup(self, host):
         """
-        Removes the data that was downloaded, installed, and created on a given host during the test execution
+        Removes the data that was downloaded, installed, and created on a given host during the test run
 
         ;param host: A Host object defining the host on which to remove the data
         ;return None

--- a/osbenchmark/builder/installers/preparers/opensearch_preparer.py
+++ b/osbenchmark/builder/installers/preparers/opensearch_preparer.py
@@ -29,7 +29,7 @@ class OpenSearchPreparer(Preparer):
     def _create_node(self):
         node_name = str(uuid.uuid4())
         node_port = int(self.provision_config_instance.variables["node"]["port"])
-        node_root_dir = os.path.join(self.provision_config_instance.variables["test_execution_root"], node_name)
+        node_root_dir = os.path.join(self.provision_config_instance.variables["test_run_root"], node_name)
         node_binary_path = os.path.join(node_root_dir, "install")
         node_log_dir = os.path.join(node_root_dir, "logs", "server")
         node_heap_dump_dir = os.path.join(node_root_dir, "heapdump")

--- a/osbenchmark/builder/installers/preparers/preparer.py
+++ b/osbenchmark/builder/installers/preparers/preparer.py
@@ -55,7 +55,7 @@ class Preparer(ABC):
     @abstractmethod
     def cleanup(self, host):
         """
-        Removes the data that was downloaded, installed, and created on a given host during the test execution
+        Removes the data that was downloaded, installed, and created on a given host during the test run
 
         ;param host: A Host object defining the host on which to remove the data
         ;return None

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1155,7 +1155,7 @@ def test_run_store(cfg):
     logger = logging.getLogger(__name__)
     if cfg.opts("reporting", "datastore.type") == "opensearch":
         logger.info("Creating OS test run store")
-        return CompositeTestRunStore(EsTestRunStore(cfg), FileTestRunStore(cfg))
+        return CompositeTestRunStore(OsTestRunStore(cfg), FileTestRunStore(cfg))
     else:
         logger.info("Creating file test-run store")
         return FileTestRunStore(cfg)
@@ -1465,7 +1465,7 @@ class FileTestRunStore(TestRunStore):
         return sorted(test_runs, key=lambda r: r.test_run_timestamp, reverse=True)
 
 
-class EsTestRunStore(TestRunStore):
+class OsTestRunStore(TestRunStore):
     INDEX_PREFIX = "benchmark-test-runs-"
     TEST_RUN_DOC_TYPE = "_doc"
 
@@ -1488,13 +1488,13 @@ class EsTestRunStore(TestRunStore):
         self.client.put_template("benchmark-test-runs", self.index_template_provider.test_runs_template())
         self.client.index(
             index=self.index_name(test_run),
-            doc_type=EsTestRunStore.TEST_RUN_DOC_TYPE,
+            doc_type=OsTestRunStore.TEST_RUN_DOC_TYPE,
             item=doc,
             id=test_run.test_run_id)
 
     def index_name(self, test_run):
         test_run_timestamp = test_run.test_run_timestamp
-        return f"{EsTestRunStore.INDEX_PREFIX}{test_run_timestamp:%Y-%m}"
+        return f"{OsTestRunStore.INDEX_PREFIX}{test_run_timestamp:%Y-%m}"
 
     def list(self):
         filters = [{
@@ -1518,7 +1518,7 @@ class EsTestRunStore(TestRunStore):
                 }
             ]
         }
-        result = self.client.search(index="%s*" % EsTestRunStore.INDEX_PREFIX, body=query)
+        result = self.client.search(index="%s*" % OsTestRunStore.INDEX_PREFIX, body=query)
         hits = result["hits"]["total"]
         # OpenSearch 1.0+
         if isinstance(hits, dict):
@@ -1542,7 +1542,7 @@ class EsTestRunStore(TestRunStore):
                 }
             }
         }
-        result = self.client.search(index="%s*" % EsTestRunStore.INDEX_PREFIX, body=query)
+        result = self.client.search(index="%s*" % OsTestRunStore.INDEX_PREFIX, body=query)
         hits = result["hits"]["total"]
         # OpenSearch 1.0+
         if isinstance(hits, dict):

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -33,19 +33,19 @@ def benchmark_root():
     return os.path.dirname(os.path.realpath(__file__))
 
 
-def test_excecutions_root(cfg):
-    return os.path.join(cfg.opts("node", "root.dir"), "test_executions")
+def test_runs_root(cfg):
+    return os.path.join(cfg.opts("node", "root.dir"), "test-runs")
 
 
-def test_execution_root(cfg, test_execution_id=None):
-    if not test_execution_id:
-        test_execution_id = cfg.opts("system", "test_execution.id")
-    return os.path.join(test_excecutions_root(cfg), test_execution_id)
+def test_run_root(cfg, test_run_id=None):
+    if not test_run_id:
+        test_run_id = cfg.opts("system", "test_run.id")
+    return os.path.join(test_runs_root(cfg), test_run_id)
 
 
 def install_root(cfg=None):
     install_id = cfg.opts("system", "install.id")
-    return os.path.join(test_excecutions_root(cfg), install_id)
+    return os.path.join(test_runs_root(cfg), install_id)
 
 
 # There is a weird bug manifesting in jenkins that is somehow saying the following line has an invalid docstring

--- a/osbenchmark/publisher.py
+++ b/osbenchmark/publisher.py
@@ -51,10 +51,10 @@ def summarize(results, cfg):
 def compare(cfg, baseline_id, contender_id):
     if not baseline_id or not contender_id:
         raise exceptions.SystemSetupError("compare needs baseline and a contender")
-    test_execution_store = metrics.test_execution_store(cfg)
+    test_run_store = metrics.test_run_store(cfg)
     ComparisonResultsPublisher(cfg).publish(
-        test_execution_store.find_by_test_execution_id(baseline_id),
-        test_execution_store.find_by_test_execution_id(contender_id))
+        test_run_store.find_by_test_run_id(baseline_id),
+        test_run_store.find_by_test_run_id(contender_id))
 
 
 def print_internal(message):
@@ -327,15 +327,15 @@ class ComparisonResultsPublisher:
         self.plain = False
 
     def publish(self, r1, r2):
-        # we don't verify anything about the test_executions as it is possible
+        # we don't verify anything about the test_runs as it is possible
         # that the user benchmarks two different workloads intentionally
         baseline_stats = metrics.GlobalStats(r1.results)
         contender_stats = metrics.GlobalStats(r2.results)
 
         print_internal("")
         print_internal("Comparing baseline")
-        print_internal("  TestExecution ID: %s" % r1.test_execution_id)
-        print_internal("  TestExecution timestamp: %s" % r1.test_execution_timestamp)
+        print_internal("  TestRun ID: %s" % r1.test_run_id)
+        print_internal("  TestRun timestamp: %s" % r1.test_run_timestamp)
         if r1.test_procedure_name:
             print_internal("  TestProcedure: %s" % r1.test_procedure_name)
         print_internal("  ProvisionConfigInstance: %s" % r1.provision_config_instance_name)
@@ -344,8 +344,8 @@ class ComparisonResultsPublisher:
             print_internal("  User tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
-        print_internal("  TestExecution ID: %s" % r2.test_execution_id)
-        print_internal("  TestExecution timestamp: %s" % r2.test_execution_timestamp)
+        print_internal("  TestRun ID: %s" % r2.test_run_id)
+        print_internal("  TestRun timestamp: %s" % r2.test_run_timestamp)
         if r2.test_procedure_name:
             print_internal("  TestProcedure: %s" % r2.test_procedure_name)
         print_internal("  ProvisionConfigInstance: %s" % r2.provision_config_instance_name)

--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -30,10 +30,10 @@
       "relative-time-ms": {
         "type": "float"
       },
-      "test-execution-id": {
+      "test-run-id": {
         "type": "keyword"
       },
-      "test-execution-timestamp": {
+      "test-run-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/resources/results-template.json
+++ b/osbenchmark/resources/results-template.json
@@ -23,10 +23,10 @@
       "enabled": true
     },
     "properties": {
-      "test-execution-id": {
+      "test-run-id": {
         "type": "keyword"
       },
-      "test-execution-timestamp": {
+      "test-run-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/resources/test-runs-template.json
+++ b/osbenchmark/resources/test-runs-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "benchmark-test-executions-*"
+    "benchmark-test-runs-*"
   ],
   "settings": {
     "index": {
@@ -23,10 +23,10 @@
       "enabled": true
     },
     "properties": {
-      "test-execution-id": {
+      "test-run-id": {
         "type": "keyword"
       },
-      "test-execution-timestamp": {
+      "test-run-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -1370,7 +1370,7 @@ class ExternalEnvironmentInfo(InternalTelemetryDevice):
 
 class JvmStatsSummary(InternalTelemetryDevice):
     """
-    Gathers a summary of various JVM statistics during the whole test execution.
+    Gathers a summary of various JVM statistics during the whole test run.
     """
     def __init__(self, client, metrics_store):
         super().__init__()

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -256,7 +256,7 @@ class BenchmarkCoordinator:
         self.metrics_store.close()
 
 
-def run(cfg, sources=False, distribution=False, external=False, docker=False):
+def run_test(cfg, sources=False, distribution=False, external=False, docker=False):
     logger = logging.getLogger(__name__)
     # at this point an actor system has to run and we should only join
     actor_system = actor.bootstrap_actor_system(try_join=True)
@@ -298,25 +298,25 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
 def from_sources(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
-    return run(cfg, sources=True)
+    return run_test(cfg, sources=True)
 
 
 def from_distribution(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
-    return run(cfg, distribution=True)
+    return run_test(cfg, distribution=True)
 
 
 def benchmark_only(cfg):
     set_default_hosts(cfg)
     # We'll use a special provision_config_instance name for external benchmarks.
     cfg.add(config.Scope.benchmark, "builder", "provision_config_instance.names", ["external"])
-    return run(cfg, external=True)
+    return run_test(cfg, external=True)
 
 
 def docker(cfg):
     set_default_hosts(cfg)
-    return run(cfg, docker=True)
+    return run_test(cfg, docker=True)
 
 
 Pipeline("from-sources",

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -256,7 +256,7 @@ class BenchmarkCoordinator:
         self.metrics_store.close()
 
 
-def execute_test(cfg, sources=False, distribution=False, external=False, docker=False):
+def run(cfg, sources=False, distribution=False, external=False, docker=False):
     logger = logging.getLogger(__name__)
     # at this point an actor system has to run and we should only join
     actor_system = actor.bootstrap_actor_system(try_join=True)
@@ -298,25 +298,25 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
 def from_sources(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
-    return execute_test(cfg, sources=True)
+    return run(cfg, sources=True)
 
 
 def from_distribution(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
-    return execute_test(cfg, distribution=True)
+    return run(cfg, distribution=True)
 
 
 def benchmark_only(cfg):
     set_default_hosts(cfg)
     # We'll use a special provision_config_instance name for external benchmarks.
     cfg.add(config.Scope.benchmark, "builder", "provision_config_instance.names", ["external"])
-    return execute_test(cfg, external=True)
+    return run(cfg, external=True)
 
 
 def docker(cfg):
     set_default_hosts(cfg)
-    return execute_test(cfg, docker=True)
+    return run(cfg, docker=True)
 
 
 Pipeline("from-sources",

--- a/osbenchmark/test_run_orchestrator.py
+++ b/osbenchmark/test_run_orchestrator.py
@@ -100,7 +100,7 @@ class BenchmarkActor(actor.BenchmarkActor):
     def receiveUnrecognizedMessage(self, msg, sender):
         self.logger.info("BenchmarkActor received unknown message [%s] (ignoring).", (str(msg)))
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_Setup(self, msg, sender):
         self.start_sender = sender
         self.cfg = msg.cfg
@@ -115,10 +115,10 @@ class BenchmarkActor(actor.BenchmarkActor):
                                                       msg.external,
                                                       msg.docker))
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_EngineStarted(self, msg, sender):
         self.logger.info("Builder has started engine successfully.")
-        self.coordinator.test_execution.provision_config_revision = msg.provision_config_revision
+        self.coordinator.test_run.provision_config_revision = msg.provision_config_revision
         self.main_worker_coordinator = self.createActor(
             worker_coordinator.WorkerCoordinatorActor,
             targetActorRequirements={"coordinator": True}
@@ -126,33 +126,33 @@ class BenchmarkActor(actor.BenchmarkActor):
         self.logger.info("Telling worker_coordinator to prepare for benchmarking.")
         self.send(self.main_worker_coordinator, worker_coordinator.PrepareBenchmark(self.cfg, self.coordinator.current_workload))
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_PreparationComplete(self, msg, sender):
         self.coordinator.on_preparation_complete(msg.distribution_flavor, msg.distribution_version, msg.revision)
         self.logger.info("Telling worker_coordinator to start benchmark.")
         self.send(self.main_worker_coordinator, worker_coordinator.StartBenchmark())
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_TaskFinished(self, msg, sender):
         self.coordinator.on_task_finished(msg.metrics)
         # We choose *NOT* to reset our own metrics store's timer as this one is only used to collect complete metrics records from
         # other stores (used by worker_coordinator and builder). Hence there is no need to reset the timer in our own metrics store.
         self.send(self.builder, builder.ResetRelativeTime(msg.next_task_scheduled_in))
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_BenchmarkCancelled(self, msg, sender):
         self.coordinator.cancelled = True
         # even notify the start sender if it is the originator. The reason is that we call #ask() which waits for a reply.
-        # We also need to ask in order to avoid test_executions between this notification and the following ActorExitRequest.
+        # We also need to ask in order to avoid test_runs between this notification and the following ActorExitRequest.
         self.send(self.start_sender, msg)
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_BenchmarkFailure(self, msg, sender):
         self.logger.info("Received a benchmark failure from [%s] and will forward it now.", sender)
         self.coordinator.error = True
         self.send(self.start_sender, msg)
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_BenchmarkComplete(self, msg, sender):
         self.coordinator.on_benchmark_complete(msg.metrics)
         self.send(self.main_worker_coordinator, thespian.actors.ActorExitRequest())
@@ -160,7 +160,7 @@ class BenchmarkActor(actor.BenchmarkActor):
         self.logger.info("Asking builder to stop the engine.")
         self.send(self.builder, builder.StopEngine())
 
-    @actor.no_retry("test execution orchestrator")  # pylint: disable=no-value-for-parameter
+    @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_EngineStopped(self, msg, sender):
         self.logger.info("Builder has stopped engine successfully.")
         self.send(self.start_sender, Success())
@@ -170,9 +170,9 @@ class BenchmarkCoordinator:
     def __init__(self, cfg):
         self.logger = logging.getLogger(__name__)
         self.cfg = cfg
-        self.test_execution = None
+        self.test_run = None
         self.metrics_store = None
-        self.test_execution_store = None
+        self.test_run_store = None
         self.cancelled = False
         self.error = False
         self.workload_revision = None
@@ -202,37 +202,37 @@ class BenchmarkCoordinator:
                     self.current_workload.name, test_procedure_name, PROGRAM_NAME))
         if self.current_test_procedure.user_info:
             console.info(self.current_test_procedure.user_info)
-        self.test_execution = metrics.create_test_execution(
+        self.test_run = metrics.create_test_run(
             self.cfg, self.current_workload,
             self.current_test_procedure,
             self.workload_revision)
 
         self.metrics_store = metrics.metrics_store(
             self.cfg,
-            workload=self.test_execution.workload_name,
-            test_procedure=self.test_execution.test_procedure_name,
+            workload=self.test_run.workload_name,
+            test_procedure=self.test_run.test_procedure_name,
             read_only=False
         )
-        self.test_execution_store = metrics.test_execution_store(self.cfg)
+        self.test_run_store = metrics.test_run_store(self.cfg)
 
     def on_preparation_complete(self, distribution_flavor, distribution_version, revision):
-        self.test_execution.distribution_flavor = distribution_flavor
-        self.test_execution.distribution_version = distribution_version
-        self.test_execution.revision = revision
-        # store test_execution initially (without any results) so other components can retrieve full metadata
-        self.test_execution_store.store_test_execution(self.test_execution)
-        if self.test_execution.test_procedure.auto_generated:
+        self.test_run.distribution_flavor = distribution_flavor
+        self.test_run.distribution_version = distribution_version
+        self.test_run.revision = revision
+        # store test_run initially (without any results) so other components can retrieve full metadata
+        self.test_run_store.store_test_run(self.test_run)
+        if self.test_run.test_procedure.auto_generated:
             console.info("Executing test with workload [{}] and provision_config_instance {} with version [{}].\n"
-                         .format(self.test_execution.workload_name,
-                         self.test_execution.provision_config_instance,
-                         self.test_execution.distribution_version))
+                         .format(self.test_run.workload_name,
+                         self.test_run.provision_config_instance,
+                         self.test_run.distribution_version))
         else:
             console.info("Executing test with workload [{}], test_procedure [{}] and provision_config_instance {} with version [{}].\n"
                          .format(
-                             self.test_execution.workload_name,
-                             self.test_execution.test_procedure_name,
-                             self.test_execution.provision_config_instance,
-                             self.test_execution.distribution_version
+                             self.test_run.workload_name,
+                             self.test_run.test_procedure_name,
+                             self.test_run.provision_config_instance,
+                             self.test_run.distribution_version
                              ))
 
     def on_task_finished(self, new_metrics):
@@ -246,10 +246,10 @@ class BenchmarkCoordinator:
         self.metrics_store.bulk_add(new_metrics)
         self.metrics_store.flush()
         if not self.cancelled and not self.error:
-            final_results = metrics.calculate_results(self.metrics_store, self.test_execution)
-            self.test_execution.add_results(final_results)
-            self.test_execution_store.store_test_execution(self.test_execution)
-            metrics.results_store(self.cfg).store_results(self.test_execution)
+            final_results = metrics.calculate_results(self.metrics_store, self.test_run)
+            self.test_run.add_results(final_results)
+            self.test_run_store.store_test_run(self.test_run)
+            metrics.results_store(self.cfg).store_results(self.test_run)
             publisher.summarize(final_results, self.cfg)
         else:
             self.logger.info("Suppressing output of summary results. Cancelled = [%r], Error = [%r].", self.cancelled, self.error)
@@ -274,7 +274,7 @@ def run_test(cfg, sources=False, distribution=False, external=False, docker=Fals
         else:
             raise exceptions.BenchmarkError("Got an unexpected result during benchmarking: [%s]." % str(result))
     except KeyboardInterrupt:
-        logger.info("User has cancelled the benchmark (detected by test execution orchestrator).")
+        logger.info("User has cancelled the benchmark (detected by test run orchestrator).")
         # notify the coordinator so it can properly handle this state. Do it blocking so we don't have a test execution between this message
         # and the actor exit request.
         actor_system.ask(benchmark_actor, actor.BenchmarkCancelled())
@@ -344,9 +344,9 @@ def list_pipelines():
 
 def run(cfg):
     logger = logging.getLogger(__name__)
-    name = cfg.opts("test_execution", "pipeline")
-    test_execution_id = cfg.opts("system", "test_execution.id")
-    logger.info("Test Execution id [%s]", test_execution_id)
+    name = cfg.opts("test_run", "pipeline")
+    test_run_id = cfg.opts("system", "test_run.id")
+    logger.info("Test Execution id [%s]", test_run_id)
     if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("builder", "distribution.version"):
@@ -354,7 +354,7 @@ def run(cfg):
         else:
             name = "from-sources"
         logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
-        cfg.add(config.Scope.applicationOverride, "test_execution", "pipeline", name)
+        cfg.add(config.Scope.applicationOverride, "test_run", "pipeline", name)
     else:
         logger.info("User specified pipeline [%s].", name)
 
@@ -381,4 +381,4 @@ def run(cfg):
         logger.info("User has cancelled the benchmark.")
     except BaseException:
         tb = sys.exc_info()[2]
-        raise exceptions.BenchmarkError("This test_execution ended with a fatal crash.").with_traceback(tb)
+        raise exceptions.BenchmarkError("This test_run ended with a fatal crash.").with_traceback(tb)

--- a/osbenchmark/test_run_orchestrator.py
+++ b/osbenchmark/test_run_orchestrator.py
@@ -275,7 +275,7 @@ def run_test(cfg, sources=False, distribution=False, external=False, docker=Fals
             raise exceptions.BenchmarkError("Got an unexpected result during benchmarking: [%s]." % str(result))
     except KeyboardInterrupt:
         logger.info("User has cancelled the benchmark (detected by test run orchestrator).")
-        # notify the coordinator so it can properly handle this state. Do it blocking so we don't have a test execution between this message
+        # notify the coordinator so it can properly handle this state. Do it blocking so we don't have a test run between this message
         # and the actor exit request.
         actor_system.ask(benchmark_actor, actor.BenchmarkCancelled())
     finally:
@@ -346,7 +346,7 @@ def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("test_run", "pipeline")
     test_run_id = cfg.opts("system", "test_run.id")
-    logger.info("Test Execution id [%s]", test_run_id)
+    logger.info("test run id [%s]", test_run_id)
     if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("builder", "distribution.version"):

--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -145,7 +145,7 @@ class ConnectOptions:
 
     def __getitem__(self, key):
         """
-        TestExecution expects the cfg object to be subscriptable
+        TestRun expects the cfg object to be subscriptable
         Just return 'default'
         """
         return self.default

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -564,7 +564,7 @@ class WorkerCoordinator:
     def prepare_telemetry(self, opensearch, enable):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
-        log_root = paths.test_execution_root(self.config)
+        log_root = paths.test_run_root(self.config)
 
         os_default = opensearch["default"]
 

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -147,4 +147,4 @@ EOF
 
 
 # Start OpenSearch Benchmark
-opensearch-benchmark execute-test --configuration-name=metricstore --workload=geonames --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --workload-params="number_of_replicas:1" --client-options=./ccr-client-options.json --kill-running-processes --telemetry="ccr-stats" --telemetry-params=./ccr-telemetry-param.json
+opensearch-benchmark run --configuration-name=metricstore --workload=geonames --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --workload-params="number_of_replicas:1" --client-options=./ccr-client-options.json --kill-running-processes --telemetry="ccr-stats" --telemetry-params=./ccr-telemetry-param.json

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -23,9 +23,9 @@
 # under the License.
 
 # Simple helper script to create graphs based on multiple
-# test_execution.json files (it's a summary of the results of
-# a single test_execution which is
-# stored in ~/.benchmark/benchmarks/test_executions/TEST_EXECUTION_TS/).
+# test_run.json files (it's a summary of the results of
+# a single test_run which is
+# stored in ~/.benchmark/benchmarks/test-runs/TEST_RUN_TS/).
 # There is no specific integration into Benchmark and it is also not
 # installed with Benchmark.
 #
@@ -33,10 +33,10 @@
 #
 #
 # Usage:
-# python3 analyze.py [--label=LABEL] /path1/to/test_execution.json /path2/to/test_execution.json
+# python3 analyze.py [--label=LABEL] /path1/to/test_run.json /path2/to/test_run.json
 #
 # Output: A bunch of .png files in the current directory.
-# Each graph shows one data series per test_execution.
+# Each graph shows one data series per test_run.
 # The label key is chosen based on the
 # command line parameter `--label`
 #
@@ -224,17 +224,17 @@ def plot(raw_data, label_key):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Turns test_execution.json files into graphs")
+    parser = argparse.ArgumentParser(description="Turns test_run.json files into graphs")
 
     parser.add_argument(
         "--label",
-        help="defines which attribute to use for labelling data series (default: test-execution-timestamp).",
-        # choices=["environment", "test-execution-timestamp", "user-tags", "test_procedure", "provision-config-instance"],
-        default="test-execution-timestamp")
+        help="defines which attribute to use for labelling data series (default: test-run-timestamp).",
+        # choices=["environment", "test-run-timestamp", "user-tags", "test_procedure", "provision-config-instance"],
+        default="test-run-timestamp")
 
     parser.add_argument("path",
                         nargs="+",
-                        help="Full path to one or more test_execution.json files")
+                        help="Full path to one or more test_run.json files")
 
     return parser.parse_args()
 

--- a/scripts/expand-data-corpus.py
+++ b/scripts/expand-data-corpus.py
@@ -30,7 +30,7 @@ TLDR: to generate a 100 GB corpus and then run a test against it:
 
 $ expand-data-corpus.py --corpus-size 100 --output-file-suffix 100gb
 
-$ opensearch-benchmark execute-test --workload http_logs \\
+$ opensearch-benchmark run --workload http_logs \\
     --workload_params=generated_corpus:t ...
 
 The script generates new documents by duplicating ones in the existing

--- a/tests/builder/installers/bare_installer_test.py
+++ b/tests/builder/installers/bare_installer_test.py
@@ -13,7 +13,7 @@ class BareInstallerTests(TestCase):
         self.binaries = {}
         self.all_node_ips = ["10.17.22.22", "10.17.22.23"]
 
-        self.test_execution_root = "fake_root"
+        self.test_run_root = "fake_root"
         self.node_id = "abdefg"
         self.cluster_name = "my-cluster"
 
@@ -26,7 +26,7 @@ class BareInstallerTests(TestCase):
             root_path="fake",
             config_paths=["/tmp"],
             variables={
-                "test_execution_root": self.test_execution_root,
+                "test_run_root": self.test_run_root,
                 "cluster_name": self.cluster_name,
                 "node": {
                     "port": "9200"

--- a/tests/builder/installers/docker_installer_test.py
+++ b/tests/builder/installers/docker_installer_test.py
@@ -16,8 +16,8 @@ class DockerProvisionerTests(TestCase):
         self.node_name = "9dbc682e-d32a-4669-8fbe-56fb77120dd4"
         self.cluster_name = "my-cluster"
         self.port = "39200"
-        self.test_execution_root = tempfile.gettempdir()
-        self.node_root_dir = os.path.join(self.test_execution_root, self.node_name)
+        self.test_run_root = tempfile.gettempdir()
+        self.node_root_dir = os.path.join(self.test_run_root, self.node_name)
         self.node_data_dir = os.path.join(self.node_root_dir, "data", self.node_name)
         self.node_log_dir = os.path.join(self.node_root_dir, "logs", "server")
         self.node_heap_dump_dir = os.path.join(self.node_root_dir, "heapdump")
@@ -29,7 +29,7 @@ class DockerProvisionerTests(TestCase):
             config_paths="/tmp",
             variables={
                 "cluster_name": self.cluster_name,
-                "test_execution_root": self.test_execution_root,
+                "test_run_root": self.test_run_root,
                 "node": {
                     "port": self.port
                 },

--- a/tests/builder/installers/preparers/opensearch_preparer_test.py
+++ b/tests/builder/installers/preparers/opensearch_preparer_test.py
@@ -19,7 +19,7 @@ class OpenSearchPreparerTests(TestCase):
         self.binaries = {BinaryKeys.OPENSEARCH: "/data/builds/distributions"}
         self.all_node_ips = ["10.17.22.22", "10.17.22.23"]
 
-        self.test_execution_root = "fake_root"
+        self.test_run_root = "fake_root"
         self.cluster_name = "my-cluster"
 
         self.executor = Mock()
@@ -30,7 +30,7 @@ class OpenSearchPreparerTests(TestCase):
             root_path="fake",
             config_paths=["/tmp"],
             variables={
-                "test_execution_root": self.test_execution_root,
+                "test_run_root": self.test_run_root,
                 "cluster_name": self.cluster_name,
                 "node": {
                     "port": "9200"
@@ -47,10 +47,10 @@ class OpenSearchPreparerTests(TestCase):
         uuid.return_value = self.node_id
 
         node = self.preparer.prepare(self.host, self.binaries)
-        self.assertEqual(node.binary_path, os.path.join(self.test_execution_root, self.node_id, "install/opensearch*"))
-        self.assertEqual(node.data_paths, [os.path.join(self.test_execution_root, self.node_id, "install/opensearch*/data")])
+        self.assertEqual(node.binary_path, os.path.join(self.test_run_root, self.node_id, "install/opensearch*"))
+        self.assertEqual(node.data_paths, [os.path.join(self.test_run_root, self.node_id, "install/opensearch*/data")])
         self.assertEqual(node.port, 9200)
-        self.assertEqual(node.root_dir, os.path.join(self.test_execution_root, self.node_id))
+        self.assertEqual(node.root_dir, os.path.join(self.test_run_root, self.node_id))
         self.assertEqual(node.name, self.node_id)
 
     def test_config_vars(self):
@@ -70,5 +70,5 @@ class OpenSearchPreparerTests(TestCase):
             "minimum_master_nodes": 2,
             "install_root_path": "/fake_binary_path",
             "node": {"port": "9200"},
-            "test_execution_root": self.test_execution_root
+            "test_run_root": self.test_run_root
         }, config_vars)

--- a/tests/builder/launcher_test.py
+++ b/tests/builder/launcher_test.py
@@ -295,7 +295,7 @@ class ProcessLauncherTests(TestCase):
         self.assertEqual(os.environ["OPENSEARCH_JAVA_OPTS"], env["OPENSEARCH_JAVA_OPTS"])
 
     @mock.patch("osbenchmark.time.sleep")
-    def test_pidfile_wait_test_execution(self, sleep):
+    def test_pidfile_wait_test_run(self, sleep):
         mo = mock_open()
         with self.assertRaises(exceptions.LaunchError):
             mo.side_effect = FileNotFoundError

--- a/tests/builder/mechanic_test.py
+++ b/tests/builder/mechanic_test.py
@@ -113,10 +113,10 @@ class BuilderTests(TestCase):
 
     # We stub irrelevant methods for the test
     class TestBuilder(builder.Builder):
-        def _current_test_execution(self):
-            return "test_execution 17"
+        def _current_test_run(self):
+            return "test_run 17"
 
-        def _add_results(self, current_test_execution, node):
+        def _add_results(self, current_test_run, node):
             pass
 
     @mock.patch("osbenchmark.builder.provisioner.cleanup")
@@ -125,7 +125,7 @@ class BuilderTests(TestCase):
         provisioners = [mock.Mock(), mock.Mock()]
         launcher = BuilderTests.TestLauncher()
         cfg = config.Config()
-        cfg.add(config.Scope.application, "system", "test_execution.id", "17")
+        cfg.add(config.Scope.application, "system", "test_run.id", "17")
         cfg.add(config.Scope.application, "builder", "preserve.install", False)
         metrics_store = mock.Mock()
         m = BuilderTests.TestBuilder(cfg, metrics_store, supplier, provisioners, launcher)

--- a/tests/builder/provisioner_test.py
+++ b/tests/builder/provisioner_test.py
@@ -53,7 +53,7 @@ class BareProvisionerTests(TestCase):
             variables={"heap": "4g", "runtime.jdk": "8", "runtime.jdk.bundled": "true"}),
             java_home="/usr/local/javas/java8",
             node_name="benchmark-node-0",
-            node_root_dir=HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest",
+            node_root_dir=HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest",
             all_node_ips=["10.17.22.22", "10.17.22.23"],
             all_node_names=["benchmark-node-0", "benchmark-node-1"],
             ip="10.17.22.23",
@@ -82,8 +82,8 @@ class BareProvisionerTests(TestCase):
             "cluster_name": "benchmark-provisioned-cluster",
             "node_name": "benchmark-node-0",
             "data_paths": ["/opt/opensearch-1.0.0/data"],
-            "log_path": HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest/heapdump",
+            "log_path": HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest/logs/server",
+            "heap_dump_path": HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest/heapdump",
             "node_ip": "10.17.22.23",
             "network_host": "10.17.22.23",
             "http_port": "9200",
@@ -137,7 +137,7 @@ class OpenSearchInstallerTests(TestCase):
                                                        all_node_names=["benchmark-node-0", "benchmark-node-1"],
                                                        ip="10.17.22.23",
                                                        http_port=9200,
-                                                       node_root_dir=HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest")
+                                                       node_root_dir=HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest")
 
         installer.install("/data/builds/distributions")
         self.assertEqual(installer.os_home_path, "/install/opensearch-5.0.0-SNAPSHOT")
@@ -146,8 +146,8 @@ class OpenSearchInstallerTests(TestCase):
             "cluster_name": "benchmark-provisioned-cluster",
             "node_name": "benchmark-node-0",
             "data_paths": ["/install/opensearch-5.0.0-SNAPSHOT/data"],
-            "log_path": HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.benchmark/benchmarks/test_executions/unittest/heapdump",
+            "log_path": HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest/logs/server",
+            "heap_dump_path": HOME_DIR + "/.benchmark/benchmarks/test-runs/unittest/heapdump",
             "node_ip": "10.17.22.23",
             "network_host": "10.17.22.23",
             "http_port": "9200",
@@ -175,7 +175,7 @@ class OpenSearchInstallerTests(TestCase):
                                                        all_node_names=["benchmark-node-0", "benchmark-node-1"],
                                                        ip="10.17.22.23",
                                                        http_port=9200,
-                                                       node_root_dir="~/.benchmark/benchmarks/test_executions/unittest")
+                                                       node_root_dir="~/.benchmark/benchmarks/test-runs/unittest")
 
         installer.install("/data/builds/distributions")
         self.assertEqual(installer.os_home_path, "/install/opensearch-5.0.0-SNAPSHOT")
@@ -184,8 +184,8 @@ class OpenSearchInstallerTests(TestCase):
             "cluster_name": "benchmark-provisioned-cluster",
             "node_name": "benchmark-node-0",
             "data_paths": ["/tmp/some/data-path-dir"],
-            "log_path": "~/.benchmark/benchmarks/test_executions/unittest/logs/server",
-            "heap_dump_path": "~/.benchmark/benchmarks/test_executions/unittest/heapdump",
+            "log_path": "~/.benchmark/benchmarks/test-runs/unittest/logs/server",
+            "heap_dump_path": "~/.benchmark/benchmarks/test-runs/unittest/heapdump",
             "node_ip": "10.17.22.23",
             "network_host": "10.17.22.23",
             "http_port": "9200",
@@ -209,7 +209,7 @@ class OpenSearchInstallerTests(TestCase):
                                                        all_node_names=["benchmark-node-0", "benchmark-node-1"],
                                                        ip="10.17.22.23",
                                                        http_port=9200,
-                                                       node_root_dir="~/.benchmark/benchmarks/test_executions/unittest",
+                                                       node_root_dir="~/.benchmark/benchmarks/test-runs/unittest",
                                                        hook_handler_class=NoopHookHandler)
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
@@ -230,7 +230,7 @@ class OpenSearchInstallerTests(TestCase):
                                                        all_node_names=["benchmark-node-0", "benchmark-node-1"],
                                                        ip="10.17.22.23",
                                                        http_port=9200,
-                                                       node_root_dir="~/.benchmark/benchmarks/test_executions/unittest",
+                                                       node_root_dir="~/.benchmark/benchmarks/test-runs/unittest",
                                                        hook_handler_class=NoopHookHandler)
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
@@ -547,8 +547,8 @@ class CleanupTests(TestCase):
 
         provisioner.cleanup(
             preserve=True,
-            install_dir="./benchmark/test_executions/install",
-            data_paths=["./benchmark/test_executions/data"])
+            install_dir="./benchmark/test-runs/install",
+            data_paths=["./benchmark/test-runs/data"])
 
         self.assertEqual(mock_path_exists.call_count, 0)
         self.assertEqual(mock_rm.call_count, 0)
@@ -560,8 +560,8 @@ class CleanupTests(TestCase):
 
         provisioner.cleanup(
             preserve=False,
-            install_dir="./benchmark/test_executions/install",
-            data_paths=["./benchmark/test_executions/data"])
+            install_dir="./benchmark/test-runs/install",
+            data_paths=["./benchmark/test-runs/data"])
 
         expected_dir_calls = [mock.call("/tmp/some/data-path-dir"), mock.call("/benchmark-root/workload/test_procedure/es-bin")]
         mock_path_exists.mock_calls = expected_dir_calls

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1723,7 +1723,7 @@ class FileTestRunStoreTests(TestCase):
         self.test_run_store = metrics.FileTestRunStore(self.cfg)
 
     def test_test_run_not_found(self):
-        with self.assertRaisesRegex(exceptions.NotFound, r"No test execution with test execution id \[.*\]"):
+        with self.assertRaisesRegex(exceptions.NotFound, r"No test run with test run id \[.*\]"):
             # did not store anything yet
             self.test_run_store.find_by_test_run_id(FileTestRunStoreTests.TEST_RUN_ID)
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1050,7 +1050,7 @@ class OsTestRunStoreTests(TestCase):
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "time.start", OsTestRunStoreTests.TEST_RUN_TIMESTAMP)
         self.cfg.add(config.Scope.application, "system", "test_run.id", FileTestRunStoreTests.TEST_RUN_ID)
-        self.test_run_store = metrics.EsTestRunStore(self.cfg,
+        self.test_run_store = metrics.OsTestRunStore(self.cfg,
                                               client_factory_class=MockClientFactory,
                                               index_template_provider_class=DummyIndexTemplateProvider,
                                               )

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2362,7 +2362,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_executions_template(),
+            _index_template_provider.test_runs_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2382,7 +2382,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_executions_template(),
+            _index_template_provider.test_runs_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2404,7 +2404,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_executions_template(),
+            _index_template_provider.test_runs_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2427,7 +2427,7 @@ class TestIndexTemplateProvider:
             # pylint: disable=unused-variable
             templates = [
                 _index_template_provider.metrics_template(),
-                _index_template_provider.test_executions_template(),
+                _index_template_provider.test_runs_template(),
                 _index_template_provider.results_template(),
             ]
         assert ctx.value.args[0] == (
@@ -2448,7 +2448,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_executions_template(),
+            _index_template_provider.test_runs_template(),
             _index_template_provider.results_template(),
         ]
 

--- a/tests/test_run_orchestrator_test.py
+++ b/tests/test_run_orchestrator_test.py
@@ -28,7 +28,7 @@ import unittest.mock as mock
 
 import pytest
 
-from osbenchmark import config, exceptions, test_execution_orchestrator
+from osbenchmark import config, exceptions, test_run_orchestrator
 
 
 @pytest.fixture
@@ -42,18 +42,18 @@ def running_in_docker():
 @pytest.fixture
 def benchmark_only_pipeline():
     test_pipeline_name = "benchmark-only"
-    original = test_execution_orchestrator.pipelines[test_pipeline_name]
-    pipeline = test_execution_orchestrator.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock.Mock())
+    original = test_run_orchestrator.pipelines[test_pipeline_name]
+    pipeline = test_run_orchestrator.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock.Mock())
     yield pipeline
     # restore prior pipeline!
-    test_execution_orchestrator.pipelines[test_pipeline_name] = original
+    test_run_orchestrator.pipelines[test_pipeline_name] = original
 
 
 @pytest.fixture
 def unittest_pipeline():
-    pipeline = test_execution_orchestrator.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock.Mock())
+    pipeline = test_run_orchestrator.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock.Mock())
     yield pipeline
-    del test_execution_orchestrator.pipelines[pipeline.name]
+    del test_run_orchestrator.pipelines[pipeline.name]
 
 
 def test_finds_available_pipelines():
@@ -64,35 +64,35 @@ def test_finds_available_pipelines():
         ["benchmark-only", "Assumes an already running OpenSearch instance, runs a benchmark and publishes results"],
     ]
 
-    assert expected == test_execution_orchestrator.available_pipelines()
+    assert expected == test_run_orchestrator.available_pipelines()
 
 
 def test_prevents_running_an_unknown_pipeline():
     cfg = config.Config()
-    cfg.add(config.Scope.benchmark, "system", "test_execution.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
-    cfg.add(config.Scope.benchmark, "test_execution", "pipeline", "invalid")
+    cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+    cfg.add(config.Scope.benchmark, "test_run", "pipeline", "invalid")
     cfg.add(config.Scope.benchmark, "builder", "distribution.version", "5.0.0")
 
     with pytest.raises(
             exceptions.SystemSetupError,
             match=r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines."):
-        test_execution_orchestrator.run(cfg)
+        test_run_orchestrator.run(cfg)
 
 
 def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_only_pipeline):
     cfg = config.Config()
-    cfg.add(config.Scope.benchmark, "system", "test_execution.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
-    cfg.add(config.Scope.benchmark, "test_execution", "pipeline", "benchmark-only")
+    cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+    cfg.add(config.Scope.benchmark, "test_run", "pipeline", "benchmark-only")
 
-    test_execution_orchestrator.run(cfg)
+    test_run_orchestrator.run(cfg)
 
     benchmark_only_pipeline.target.assert_called_once_with(cfg)
 
 
 def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unittest_pipeline):
     cfg = config.Config()
-    cfg.add(config.Scope.benchmark, "system", "test_execution.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
-    cfg.add(config.Scope.benchmark, "test_execution", "pipeline", "unit-test-pipeline")
+    cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+    cfg.add(config.Scope.benchmark, "test_run", "pipeline", "unit-test-pipeline")
 
     with pytest.raises(
             exceptions.SystemSetupError,
@@ -102,15 +102,15 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
                 "For more details read the docs for the benchmark-only pipeline in "
                 "https://opensearch.org/docs\n"
             )):
-        test_execution_orchestrator.run(cfg)
+        test_run_orchestrator.run(cfg)
 
 
 def test_runs_a_known_pipeline(unittest_pipeline):
     cfg = config.Config()
-    cfg.add(config.Scope.benchmark, "system", "test_execution.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
-    cfg.add(config.Scope.benchmark, "test_execution", "pipeline", "unit-test-pipeline")
+    cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+    cfg.add(config.Scope.benchmark, "test_run", "pipeline", "unit-test-pipeline")
     cfg.add(config.Scope.benchmark, "builder", "distribution.version", "")
 
-    test_execution_orchestrator.run(cfg)
+    test_run_orchestrator.run(cfg)
 
     unittest_pipeline.target.assert_called_once_with(cfg)

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -97,7 +97,7 @@ class WorkerCoordinatorTests(TestCase):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "system", "time.start", datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
-        self.cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
+        self.cfg.add(config.Scope.application, "system", "test_run.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         self.cfg.add(config.Scope.application, "system", "available.cores", 8)
         self.cfg.add(config.Scope.application, "node", "root.dir", "/tmp")
         self.cfg.add(config.Scope.application, "workload", "test_procedure.name", "default")


### PR DESCRIPTION
### Description
This PR introduces the next set of changes to improve OSB terminology and make it more inclusive. The subcommand `execute-test` is now replaced with `run`. All terms associated with the subcommand have the word execution replaced with `run`. For example, the terms `test-execution-id`, `test-execution-timestamp`, `test_executions`, `TestExecutions` are now `test-run-id`, `test-run-timestamp`, `test_runs`, `TestRuns` respectively.

These changes will be issued in the next major release. 

### Issues Resolved
#238 #288 

### Testing
- [x] New functionality includes testing
- [x] Ran tests with new subcommands
- [x] Checked external datastore and found new index patterns and fields with new naming convention

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
