### PR TITLE
Change to support benchmarking of ES-7.10 domains

### DIFF
--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -626,7 +626,10 @@ class NodeStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         default_client = self.clients["default"]
-        distribution_name = default_client.info()["version"]["distribution"]
+        if not default_client.info()["version"]["distribution"] is None:
+            distribution_name = default_client.info()["version"]["distribution"]
+        else:
+            distribution_name = ""
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]
 

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -626,10 +626,7 @@ class NodeStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         default_client = self.clients["default"]
-        if not default_client.info()["version"]["distribution"] is None:
-            distribution_name = default_client.info()["version"]["distribution"]
-        else:
-            distribution_name = ""
+        distribution_name = default_client.info()["version"].get("distribution", "")
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]
 

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -626,6 +626,7 @@ class NodeStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         default_client = self.clients["default"]
+        # ElasticSearch does not supply a value for the distribution field
         distribution_name = default_client.info()["version"].get("distribution", "")
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]


### PR DESCRIPTION
### Description
OpenSearch Benchmark-1.0.0 cannot test ElasticSearch-7.10 and older versions due to change introduced in PR https://github.com/opensearch-project/opensearch-benchmark/pull/248. 
Upon hitting OpenSearch domain's endpoint, we get attribute "distribution" but this attribute is not defined for ElasticSeaech domains causing error in execute-test : 
`File "/home/ec2-user/.pyenv/versions/3.8.0/lib/python3.8/site-packages/osbenchmark/telemetry.py", line 629, in on_benchmark_start
    distribution_name = default_client.info()["version"]["distribution"]

KeyError: 'distribution'`

This PR resolves adds a check to set variable **distribution_name** to empty string in case of ES domains and bypassing the error without impacting the existing functionality.


### Testing
**execute-test** command now successfully benchmarks ES domains.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
