### PR TITLE
Revert publisher back to results_publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ After the test execution, a summary report is written to the command line:
 
 Creating Your Own Workloads
 ---------------------------
-For more information on how users can create their own workloads, see [the Create Workload Guide](https://github.com/opensearch-project/opensearch-benchmark/blob/main/CREATE_WORKLOAD_GUIDE.md)
+For more information on how users can create their own workloads, see [the Create Workload Guide](./CREATE_WORKLOAD_GUIDE.md)
 
 Getting help
 ------------

--- a/it/resources/benchmark-in-memory-it.ini
+++ b/it/resources/benchmark-in-memory-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[reporting]
+[results_publishing]
 datastore.type = in-memory
 
 

--- a/it/resources/benchmark-os-it.ini
+++ b/it/resources/benchmark-os-it.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[reporting]
+[results_publishing]
 datastore.type = opensearch
 datastore.host = localhost
 datastore.port = 10200

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -35,7 +35,7 @@ import thespian.actors
 
 from osbenchmark import PROGRAM_NAME, BANNER, FORUM_LINK, SKULL, check_python_version, doc_link, telemetry
 from osbenchmark import version, actor, config, paths, \
-    test_execution_orchestrator, publisher, \
+    test_execution_orchestrator, results_publisher, \
         metrics, workload, chart_generator, exceptions, log
 from osbenchmark.builder import provision_config, builder
 from osbenchmark.workload_generator import workload_generator
@@ -815,11 +815,11 @@ def configure_connection_params(arg_parser, args, cfg):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 
 
-def configure_reporting_params(args, cfg):
-    cfg.add(config.Scope.applicationOverride, "reporting", "format", args.results_format)
-    cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_results)
-    cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.results_file)
-    cfg.add(config.Scope.applicationOverride, "reporting", "numbers.align", args.results_numbers_align)
+def configure_results_publishing_params(args, cfg):
+    cfg.add(config.Scope.applicationOverride, "results_publishing", "format", args.results_format)
+    cfg.add(config.Scope.applicationOverride, "results_publishing", "values", args.show_in_results)
+    cfg.add(config.Scope.applicationOverride, "results_publishing", "output.path", args.results_file)
+    cfg.add(config.Scope.applicationOverride, "results_publishing", "numbers.align", args.results_numbers_align)
 
 
 def dispatch_sub_command(arg_parser, args, cfg):
@@ -830,8 +830,8 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
     try:
         if sub_command == "compare":
-            configure_reporting_params(args, cfg)
-            publisher.compare(cfg, args.baseline, args.contender)
+            configure_results_publishing_params(args, cfg)
+            results_publisher.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
             cfg.add(config.Scope.applicationOverride, "system", "list.test_executions.max_results", args.limit)
@@ -903,7 +903,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "builder", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
 
-            configure_reporting_params(args, cfg)
+            configure_results_publishing_params(args, cfg)
 
             execute_test(cfg, args.kill_running_processes)
         elif sub_command == "generate":

--- a/osbenchmark/config.py
+++ b/osbenchmark/config.py
@@ -114,7 +114,7 @@ def auto_load_local_config(base_config, additional_sections=None, config_file_cl
     cfg.load_config(auto_upgrade=True)
     # we override our some configuration with the one from the coordinator because it may contain more entries and we should be
     # consistent across all nodes here.
-    cfg.add_all(base_config, "reporting")
+    cfg.add_all(base_config, "results_publishing")
     cfg.add_all(base_config, "workloads")
     cfg.add_all(base_config, "provision_configs")
     cfg.add_all(base_config, "distributions")

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -179,12 +179,12 @@ class OsClientFactory:
 
     def __init__(self, cfg):
         self._config = cfg
-        host = self._config.opts("reporting", "datastore.host")
-        port = self._config.opts("reporting", "datastore.port")
-        secure = convert.to_bool(self._config.opts("reporting", "datastore.secure"))
-        user = self._config.opts("reporting", "datastore.user")
+        host = self._config.opts("results_publishing", "datastore.host")
+        port = self._config.opts("results_publishing", "datastore.port")
+        secure = convert.to_bool(self._config.opts("results_publishing", "datastore.secure"))
+        user = self._config.opts("results_publishing", "datastore.user")
 
-        metrics_amazon_aws_log_in = self._config.opts("reporting", "datastore.amazon_aws_log_in",
+        metrics_amazon_aws_log_in = self._config.opts("results_publishing", "datastore.amazon_aws_log_in",
                                                       default_value=None, mandatory=False)
         metrics_aws_access_key_id = None
         metrics_aws_secret_access_key = None
@@ -192,13 +192,13 @@ class OsClientFactory:
         metrics_aws_service = None
 
         if metrics_amazon_aws_log_in == 'config':
-            metrics_aws_access_key_id = self._config.opts("reporting", "datastore.aws_access_key_id",
+            metrics_aws_access_key_id = self._config.opts("results_publishing", "datastore.aws_access_key_id",
                                                           default_value=None, mandatory=False)
-            metrics_aws_secret_access_key = self._config.opts("reporting", "datastore.aws_secret_access_key",
+            metrics_aws_secret_access_key = self._config.opts("results_publishing", "datastore.aws_secret_access_key",
                                                               default_value=None, mandatory=False)
-            metrics_aws_region = self._config.opts("reporting", "datastore.region",
+            metrics_aws_region = self._config.opts("results_publishing", "datastore.region",
                                                    default_value=None, mandatory=False)
-            metrics_aws_service = self._config.opts("reporting", "datastore.service",
+            metrics_aws_service = self._config.opts("results_publishing", "datastore.service",
                                                     default_value=None, mandatory=False)
         elif metrics_amazon_aws_log_in == 'environment':
             metrics_aws_access_key_id = os.getenv("OSB_DATASTORE_AWS_ACCESS_KEY_ID", default=None)
@@ -233,14 +233,14 @@ class OsClientFactory:
             password = os.environ["OSB_DATASTORE_PASSWORD"]
         except KeyError:
             try:
-                password = self._config.opts("reporting", "datastore.password")
+                password = self._config.opts("results_publishing", "datastore.password")
             except exceptions.ConfigError:
                 raise exceptions.ConfigError(
-                    "No password configured through [reporting] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                    "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
                 ) from None
-        verify = self._config.opts("reporting", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
-        ca_path = self._config.opts("reporting", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
-        self.probe_version = self._config.opts("reporting", "datastore.probe.cluster_version", default_value=True, mandatory=False)
+        verify = self._config.opts("results_publishing", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"
+        ca_path = self._config.opts("results_publishing", "datastore.ssl.certificate_authorities", default_value=None, mandatory=False)
+        self.probe_version = self._config.opts("results_publishing", "datastore.probe.cluster_version", default_value=True, mandatory=False)
 
         # Instead of duplicating code, we're just adapting the metrics store specific properties to match the regular client options.
         client_options = {
@@ -280,8 +280,8 @@ class IndexTemplateProvider:
     def __init__(self, cfg):
         self._config = cfg
         self.script_dir = self._config.opts("node", "benchmark.root")
-        self._number_of_shards = self._config.opts("reporting", "datastore.number_of_shards", default_value=None, mandatory=False)
-        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=None, mandatory=False)
+        self._number_of_shards = self._config.opts("results_publishing", "datastore.number_of_shards", default_value=None, mandatory=False)
+        self._number_of_replicas = self._config.opts("results_publishing", "datastore.number_of_replicas", default_value=None, mandatory=False)
 
     def metrics_template(self):
         return self._read("metrics-template")
@@ -357,7 +357,7 @@ def metrics_store(cfg, read_only=True, workload=None, test_procedure=None, provi
 
 
 def metrics_store_class(cfg):
-    if cfg.opts("reporting", "datastore.type") == "opensearch":
+    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
         return OsMetricsStore
     else:
         return InMemoryMetricsStore
@@ -1207,7 +1207,7 @@ def test_execution_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("reporting", "datastore.type") == "opensearch":
+    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
         logger.info("Creating OS test execution store")
         return CompositeTestExecutionStore(EsTestExecutionStore(cfg), FileTestExecutionStore(cfg))
     else:
@@ -1222,7 +1222,7 @@ def results_store(cfg):
     :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
-    if cfg.opts("reporting", "datastore.type") == "opensearch":
+    if cfg.opts("results_publishing", "datastore.type") == "opensearch":
         logger.info("Creating OS results store")
         return OsResultsStore(cfg)
     else:
@@ -1690,7 +1690,7 @@ class GlobalStatsCalculator:
                 op_type = task.operation.type
                 error_rate = self.error_rate(t, op_type)
                 duration = self.duration(t)
-                if task.operation.include_in_reporting or error_rate > 0:
+                if task.operation.include_in_results_publishing or error_rate > 0:
                     self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -281,7 +281,8 @@ class IndexTemplateProvider:
         self._config = cfg
         self.script_dir = self._config.opts("node", "benchmark.root")
         self._number_of_shards = self._config.opts("results_publishing", "datastore.number_of_shards", default_value=None, mandatory=False)
-        self._number_of_replicas = self._config.opts("results_publishing", "datastore.number_of_replicas", default_value=None, mandatory=False)
+        self._number_of_replicas = self._config.opts("results_publishing", "datastore.number_of_replicas",
+                                                     default_value=None, mandatory=False)
 
     def metrics_template(self):
         return self._read("metrics-template")

--- a/osbenchmark/resources/benchmark.ini
+++ b/osbenchmark/resources/benchmark.ini
@@ -15,7 +15,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
 
-[reporting]
+[results_publishing]
 datastore.type = in-memory
 datastore.host =
 datastore.port =

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -99,14 +99,14 @@ def format_as_csv(headers, data):
 class SummaryResultsPublisher:
     def __init__(self, results, config):
         self.results = results
-        self.results_file = config.opts("reporting", "output.path")
-        self.results_format = config.opts("reporting", "format")
-        self.numbers_align = config.opts("reporting", "numbers.align",
+        self.results_file = config.opts("results_publishing", "output.path")
+        self.results_format = config.opts("results_publishing", "format")
+        self.numbers_align = config.opts("results_publishing", "numbers.align",
                                          mandatory=False, default_value="right")
-        reporting_values = config.opts("reporting", "values")
-        self.publish_all_values = reporting_values == "all"
-        self.publish_all_percentile_values = reporting_values == "all-percentiles"
-        self.show_processing_time = convert.to_bool(config.opts("reporting", "output.processingtime",
+        results_publishing_values = config.opts("results_publishing", "values")
+        self.publish_all_values = results_publishing_values == "all"
+        self.publish_all_percentile_values = results_publishing_values == "all-percentiles"
+        self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.cwd = config.opts("node", "benchmark.cwd")
 
@@ -317,12 +317,12 @@ class SummaryResultsPublisher:
 
 class ComparisonResultsPublisher:
     def __init__(self, config):
-        self.results_file = config.opts("reporting", "output.path")
-        self.results_format = config.opts("reporting", "format")
-        self.numbers_align = config.opts("reporting", "numbers.align",
+        self.results_file = config.opts("results_publishing", "output.path")
+        self.results_format = config.opts("results_publishing", "format")
+        self.numbers_align = config.opts("results_publishing", "numbers.align",
                                          mandatory=False, default_value="right")
         self.cwd = config.opts("node", "benchmark.cwd")
-        self.show_processing_time = convert.to_bool(config.opts("reporting", "output.processingtime",
+        self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.plain = False
 

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -32,7 +32,7 @@ import thespian.actors
 
 from osbenchmark import actor, config, doc_link, \
     worker_coordinator, exceptions, builder, metrics, \
-        publisher, workload, version, PROGRAM_NAME
+        results_publisher, workload, version, PROGRAM_NAME
 from osbenchmark.utils import console, opts, versions
 
 
@@ -250,7 +250,7 @@ class BenchmarkCoordinator:
             self.test_execution.add_results(final_results)
             self.test_execution_store.store_test_execution(self.test_execution)
             metrics.results_store(self.cfg).store_results(self.test_execution)
-            publisher.summarize(final_results, self.cfg)
+            results_publisher.summarize(final_results, self.cfg)
         else:
             self.logger.info("Suppressing output of summary results. Cancelled = [%r], Error = [%r].", self.cancelled, self.error)
         self.metrics_store.close()

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -533,7 +533,7 @@ class WorkerCoordinator:
         # which client ids are assigned to which workers?
         self.clients_per_worker = {}
 
-        self.progress_publisher = console.progress()
+        self.progress_results_publisher = console.progress()
         self.progress_counter = 0
         self.quiet = False
         self.allocations = None
@@ -608,7 +608,7 @@ class WorkerCoordinator:
         self.test_procedure = select_test_procedure(self.config, self.workload)
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
         downsample_factor = int(self.config.opts(
-            "reporting", "metrics.request.downsample.factor",
+            "results_publishing", "metrics.request.downsample.factor",
             mandatory=False, default_value=1))
         self.metrics_store = metrics.metrics_store(cfg=self.config,
                                                    workload=self.workload.name,
@@ -792,7 +792,7 @@ class WorkerCoordinator:
         return self.current_step == self.number_of_steps
 
     def close(self):
-        self.progress_publisher.finish()
+        self.progress_results_publisher.finish()
         if self.metrics_store and self.metrics_store.opened:
             self.metrics_store.close()
 
@@ -818,9 +818,9 @@ class WorkerCoordinator:
 
                 num_clients = max(len(progress_per_client), 1)
                 total_progress = sum(progress_per_client) / num_clients
-            self.progress_publisher.print("Running %s" % tasks, "[%3d%% done]" % (round(total_progress * 100)))
+            self.progress_results_publisher.print("Running %s" % tasks, "[%3d%% done]" % (round(total_progress * 100)))
             if task_finished:
-                self.progress_publisher.finish()
+                self.progress_results_publisher.finish()
 
     def post_process_samples(self):
         # we do *not* do this here to avoid concurrent updates (actors are single-threaded) but rather to make it clear that we use
@@ -1032,7 +1032,7 @@ class Worker(actor.BenchmarkActor):
         self.worker_id = msg.worker_id
         self.config = load_local_config(msg.config)
         self.on_error = self.config.opts("worker_coordinator", "on.error")
-        self.sample_queue_size = int(self.config.opts("reporting", "sample.queue.size", mandatory=False, default_value=1 << 20))
+        self.sample_queue_size = int(self.config.opts("results_publishing", "sample.queue.size", mandatory=False, default_value=1 << 20))
         self.workload = msg.workload
         workload.set_absolute_data_path(self.config, self.workload)
         self.client_allocations = msg.client_allocations

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1365,7 +1365,7 @@ class WorkloadSpecificationReader:
                     task = self.parse_task(op, ops, name)
                 schedule.append(task)
 
-            # verify we don't have any duplicate task names (which can be confusing / misleading in reporting).
+            # verify we don't have any duplicate task names (which can be confusing / misleading in results_publishing).
             known_task_names = set()
             for task in schedule:
                 for sub_task in task:
@@ -1523,8 +1523,8 @@ class WorkloadSpecificationReader:
 
         try:
             op = workload.OperationType.from_hyphenated_string(op_type_name)
-            if "include-in-reporting" not in params:
-                params["include-in-reporting"] = not op.admin_op
+            if "include-in-results_publishing" not in params:
+                params["include-in-results_publishing"] = not op.admin_op
             self.logger.debug("Using built-in operation type [%s] for operation [%s].", op_type_name, op_name)
         except KeyError:
             self.logger.info("Using user-provided operation type [%s] for operation [%s].", op_type_name, op_name)

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -202,11 +202,11 @@ class Documents:
         :param includes_action_and_meta_data: True, if the source file already includes the action and meta-data line. False, if it only
         contains documents.
         :param number_of_documents: The number of documents
-        in the benchmark document. Needed for proper progress reporting. Only needed if
+        in the benchmark document. Needed for proper progress results_publishing. Only needed if
          a document_archive is given.
         :param compressed_size_in_bytes: The compressed size in bytes of
         the benchmark document. Needed for verification of the download and
-         user reporting. Only useful if a document_archive is given (optional but recommended to be set).
+         user results_publishing. Only useful if a document_archive is given (optional but recommended to be set).
         :param uncompressed_size_in_bytes: The size in bytes of the benchmark document after decompressing it.
         Only useful if a document_archive is given (optional but recommended to be set).
         :param target_index: The index to target for bulk operations. May be ``None`` if ``includes_action_and_meta_data`` is ``False``.
@@ -976,8 +976,8 @@ class Operation:
         self.param_source = param_source
 
     @property
-    def include_in_reporting(self):
-        return self.params.get("include-in-reporting", True)
+    def include_in_results_publishing(self):
+        return self.params.get("include-in-results_publishing", True)
 
     def __hash__(self):
         return hash(self.name)

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -122,7 +122,7 @@ opensearch.src.subdir = opensearch
 [benchmarks]
 local.dataset.cache = ${HOME}/.benchmark/benchmarks/data
 
-[reporting]
+[results_publishing]
 datastore.type = opensearch
 datastore.host = 127.0.0.1
 datastore.port = 9209

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -185,7 +185,7 @@ class AutoLoadConfigTests(TestCase):
         base_cfg = config.Config(config_name="unittest", config_file_class=InMemoryConfigStore)
         base_cfg.add(config.Scope.application, "meta", "config.version", config.Config.CURRENT_CONFIG_VERSION)
         base_cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/base-config/data-set-cache")
-        base_cfg.add(config.Scope.application, "reporting", "datastore.type", "opensearch")
+        base_cfg.add(config.Scope.application, "results_publishing", "datastore.type", "opensearch")
         base_cfg.add(config.Scope.application, "workloads", "metrics.url", "http://github.com/org/metrics")
         base_cfg.add(config.Scope.application, "provision_configs", "private.url", "http://github.com/org/provision_configs")
         base_cfg.add(config.Scope.application, "distributions", "release.cache", False)
@@ -196,7 +196,7 @@ class AutoLoadConfigTests(TestCase):
         # did not just copy base config
         self.assertNotEqual(base_cfg.opts("benchmarks", "local.dataset.cache"), cfg.opts("benchmarks", "local.dataset.cache"))
         # copied sections from base config
-        self.assert_equals_base_config(base_cfg, cfg, "reporting", "datastore.type")
+        self.assert_equals_base_config(base_cfg, cfg, "results_publishing", "datastore.type")
         self.assert_equals_base_config(base_cfg, cfg, "workloads", "metrics.url")
         self.assert_equals_base_config(base_cfg, cfg, "provision_configs", "private.url")
         self.assert_equals_base_config(base_cfg, cfg, "distributions", "release.cache")
@@ -285,8 +285,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "reporting": {
-                "results.base.dir": "/tests/benchmark/reporting",
+            "results_publishing": {
+                "results.base.dir": "/tests/benchmark/results_publishing",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {
@@ -318,8 +318,8 @@ class ConfigMigrationTests(TestCase):
             "benchmarks": {
                 "metrics.stats.disk.device": "/dev/hdd1"
             },
-            "reporting": {
-                "results.base.dir": "/tests/benchmark/reporting",
+            "results_publishing": {
+                "results.base.dir": "/tests/benchmark/results_publishing",
                 "output.html.results.filename": "index.html"
             },
             "runtime": {

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -268,19 +268,19 @@ class OsClientTests(TestCase):
         _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
         _datastore_verify_certs = random.choice([True, False])
 
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
 
         if password_configuration == "config":
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", _datastore_password)
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
         elif password_configuration == "environment":
             monkeypatch = pytest.MonkeyPatch()
             monkeypatch.setenv("OSB_DATASTORE_PASSWORD", _datastore_password)
 
         if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.verification_mode", "none")
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
 
         try:
             metrics.OsClientFactory(cfg)
@@ -290,7 +290,7 @@ class OsClientTests(TestCase):
 
             assert (
                 e.message
-                == "No password configured through [reporting] configuration or OSB_DATASTORE_PASSWORD environment variable."
+                == "No password configured through [results_publishing] configuration or OSB_DATASTORE_PASSWORD environment variable."
             )
             return
 
@@ -319,21 +319,21 @@ class OsClientTests(TestCase):
         _datastore_aws_service = random.choice(['es', 'aoss'])
         _datastore_aws_region = random.choice(['us-east-1', 'eu-west-1'])
 
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", _datastore_host)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", _datastore_port)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", _datastore_secure)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", _datastore_user)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", _datastore_password)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.amazon_aws_log_in",
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.password", _datastore_password)
+        cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.amazon_aws_log_in",
                 _datastore_amazon_aws_log_in)
 
         if _datastore_amazon_aws_log_in == 'config':
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.aws_access_key_id",
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_access_key_id",
                     _datastore_aws_access_key_id)
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.aws_secret_access_key",
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.aws_secret_access_key",
                     _datastore_aws_secret_access_key)
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.service", _datastore_aws_service)
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.region", _datastore_aws_region)
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.service", _datastore_aws_service)
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.region", _datastore_aws_region)
         elif _datastore_amazon_aws_log_in == 'environment':
             monkeypatch = pytest.MonkeyPatch()
             monkeypatch.setenv("OSB_DATASTORE_AWS_ACCESS_KEY_ID", _datastore_aws_access_key_id)
@@ -342,12 +342,12 @@ class OsClientTests(TestCase):
             monkeypatch.setenv("OSB_DATASTORE_REGION", _datastore_aws_region)
 
         if not _datastore_verify_certs:
-            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.verification_mode", "none")
+            cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.ssl.verification_mode", "none")
 
         if override_datastore:
             if _datastore_amazon_aws_log_in == 'config':
                 for k, v in override_datastore.items():
-                    cfg.add(config.Scope.applicationOverride, "reporting", k, v)
+                    cfg.add(config.Scope.applicationOverride, "results_publishing", k, v)
             elif _datastore_amazon_aws_log_in == 'environment':
                 monkeypatch = pytest.MonkeyPatch()
                 for k, v in override_datastore.items():
@@ -1933,7 +1933,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -2024,7 +2024,7 @@ class StatsCalculatorTests(TestCase):
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
         cfg.add(config.Scope.application, "system", "test_execution.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
-        cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
+        cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["unittest_provision_config_instance"])
         cfg.add(config.Scope.application, "builder", "provision_config_instance.params", {})
         cfg.add(config.Scope.application, "builder", "plugin.params", {})
@@ -2082,7 +2082,7 @@ class GlobalStatsCalculatorTests(TestCase):
         del self.cfg
 
     def test_add_administrative_task_with_error_rate_in_results(self):
-        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-reporting': False})
+        op = Operation(name='delete-index', operation_type='DeleteIndex', params={'include-in-results_publishing': False})
         task = Task('delete-index', operation=op, schedule='deterministic')
         test_procedure = TestProcedure(name='append-fast-with-conflicts', schedule=[task], meta_data={})
 
@@ -2504,9 +2504,9 @@ class TestIndexTemplateProvider:
         _datastore_number_of_shards = random.randint(1, 100)
         _datastore_number_of_replicas = random.randint(0, 100)
 
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_replicas", _datastore_number_of_replicas)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.type", _datastore_type)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_shards", _datastore_number_of_shards)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_replicas", _datastore_number_of_replicas)
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
@@ -2525,8 +2525,8 @@ class TestIndexTemplateProvider:
         _datastore_type = "opensearch"
         _datastore_number_of_shards = random.randint(1, 100)
 
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.type", _datastore_type)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_shards", _datastore_number_of_shards)
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
@@ -2547,8 +2547,8 @@ class TestIndexTemplateProvider:
         _datastore_type = "opensearch"
         _datastore_number_of_replicas = random.randint(1, 100)
 
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_replicas", _datastore_number_of_replicas)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.type", _datastore_type)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_replicas", _datastore_number_of_replicas)
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
@@ -2569,8 +2569,8 @@ class TestIndexTemplateProvider:
         _datastore_type = "opensearch"
         _datastore_number_of_shards = 0
 
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.type", _datastore_type)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_shards", _datastore_number_of_shards)
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
         with pytest.raises(exceptions.SystemSetupError) as ctx:
@@ -2590,9 +2590,9 @@ class TestIndexTemplateProvider:
         _datastore_number_of_shards = "200"
         _datastore_number_of_replicas = "1"
 
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_replicas", _datastore_number_of_replicas)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.type", _datastore_type)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_shards", _datastore_number_of_shards)
+        self.cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.number_of_replicas", _datastore_number_of_replicas)
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 

--- a/tests/results_publisher_test.py
+++ b/tests/results_publisher_test.py
@@ -24,7 +24,7 @@
 
 from unittest import TestCase
 
-from osbenchmark import publisher
+from osbenchmark import results_publisher
 
 
 class FormatterTests(TestCase):
@@ -41,19 +41,19 @@ class FormatterTests(TestCase):
         self.numbers_align = "right"
 
     def test_formats_as_markdown(self):
-        formatted = publisher.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
+        formatted = results_publisher.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
         # 1 header line, 1 separation line + 0 data lines
         self.assertEqual(1 + 1 + 0, len(formatted.splitlines()))
 
-        formatted = publisher.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
+        formatted = results_publisher.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
         # 1 header line, 1 separation line + 3 data lines
         self.assertEqual(1 + 1 + 3, len(formatted.splitlines()))
 
     def test_formats_as_csv(self):
-        formatted = publisher.format_as_csv(self.empty_header, self.empty_data)
+        formatted = results_publisher.format_as_csv(self.empty_header, self.empty_data)
         # 1 header line, no separation line + 0 data lines
         self.assertEqual(1 + 0, len(formatted.splitlines()))
 
-        formatted = publisher.format_as_csv(self.metrics_header, self.metrics_data)
+        formatted = results_publisher.format_as_csv(self.metrics_header, self.metrics_data)
         # 1 header line, no separation line + 3 data lines
         self.assertEqual(1 + 3, len(formatted.splitlines()))

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -47,13 +47,13 @@ def create_config():
     # concrete path does not matter
     cfg.add(config.Scope.application, "node", "benchmark.root", "/some/root/path")
 
-    cfg.add(config.Scope.application, "reporting", "datastore.host", "localhost")
-    cfg.add(config.Scope.application, "reporting", "datastore.port", "0")
-    cfg.add(config.Scope.application, "reporting", "datastore.secure", False)
-    cfg.add(config.Scope.application, "reporting", "datastore.user", "")
-    cfg.add(config.Scope.application, "reporting", "datastore.password", "")
+    cfg.add(config.Scope.application, "results_publishing", "datastore.host", "localhost")
+    cfg.add(config.Scope.application, "results_publishing", "datastore.port", "0")
+    cfg.add(config.Scope.application, "results_publishing", "datastore.secure", False)
+    cfg.add(config.Scope.application, "results_publishing", "datastore.user", "")
+    cfg.add(config.Scope.application, "results_publishing", "datastore.password", "")
     # disable version probing to avoid any network calls in tests
-    cfg.add(config.Scope.application, "reporting", "datastore.probe.cluster_version", False)
+    cfg.add(config.Scope.application, "results_publishing", "datastore.probe.cluster_version", False)
     # only internal devices are active
     cfg.add(config.Scope.application, "telemetry", "devices", [])
     return cfg

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -141,9 +141,9 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
 
-        progress_publisher.print(message=message, progress=".")
+        progress_results_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -157,8 +157,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.print(message=message, progress=".")
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -175,8 +175,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.print(message=message, progress=".")
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.print(message=message, progress=".")
         mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
             mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
@@ -196,8 +196,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.print(message=message, progress=".")
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.print(message=message, progress=".")
         mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
             mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
@@ -214,8 +214,8 @@ class TestCmdLineProgressResultsPublisher:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.print(message=message, progress=".")
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
 
@@ -229,8 +229,8 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.finish()
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.finish()
         mock_printer.assert_not_called()
 
     @mock.patch("sys.stdout.isatty")
@@ -244,8 +244,8 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.finish()
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.finish()
         mock_printer.assert_called_once_with("")
 
     @mock.patch("sys.stdout.isatty")
@@ -259,6 +259,6 @@ class TestCmdLineProgressResultsPublisher:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
-        progress_publisher.finish()
+        progress_results_publisher = console.CmdLineProgressResultsPublisher(width=width, printer=mock_printer)
+        progress_results_publisher.finish()
         mock_printer.assert_called_once_with("")

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -111,7 +111,7 @@ class WorkerCoordinatorTests(TestCase):
                      WorkerCoordinatorTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
-        self.cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
+        self.cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
             workload.Task(name="index", operation=workload.Operation("index", operation_type=workload.OperationType.Bulk), clients=4)


### PR DESCRIPTION
### Description
In preparation for OSB 1.1.0 release, we need to remove any breaking changes that might have been introduced upstream. Found that this commit `40ed4613f3faa353a08b0418befcb1e907366041` adds a breaking change that should be introduced later for 2.0.0 release. 

### Issues Resolved
Reverting checkbox in #351(https://github.com/opensearch-project/opensearch-benchmark/issues/351)

### Testing
- [x] New functionality includes testing

- Tested this on two workloads, percolator and geonames. Was able to get a report for both with 0% indexing errors. Also verified that the results_publishing config had no issues ingesting documents into external datastore.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
