### PR TITLE
Changes for serverless implementations which may not support the full complement of OpenSearch APIs

### DIFF
--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -265,7 +265,12 @@ def cluster_distribution_version(cfg, client_factory=client.OsClientFactory):
     opensearch = client_factory(hosts, client_options).create()
     # unconditionally wait for the REST layer - if it's not up by then, we'll intentionally raise the original error
     client.wait_for_rest_layer(opensearch)
-    return opensearch.info()["version"]["number"]
+    try:
+        distribution_version = opensearch.info()["version"]["number"]
+    except Exception:
+        console.warn("Could not determine distribution version from endpoint, use --distribution-version to specify")
+        distribution_version = None
+    return distribution_version
 
 
 def to_ip_port(hosts):


### PR DESCRIPTION
### Description
Serverless OpenSearch implementations don't support the full complement of OpenSearch APIs, since details of the internals such as node counts, allocation, shard locations, etc. are abstracted away.  For instance, the cluster-health API may not be available.  The changes here ensure that OSB will work for such systems.  There may be more changes required to ensure that flags like telemetry continue to function, but those issues will be handled in a subsequent change.

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/354

### Testing
- Added a test to exercise the bypassing of the cluster health API call
- Ran unit and integ tests


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
