### PR TITLE
Add support for create search pipeline

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -94,6 +94,7 @@ def register_default_runners():
     register_runner(workload.OperationType.StartTransform, Retry(StartTransform()), async_runner=True)
     register_runner(workload.OperationType.WaitForTransform, Retry(WaitForTransform()), async_runner=True)
     register_runner(workload.OperationType.DeleteTransform, Retry(DeleteTransform()), async_runner=True)
+    register_runner(workload.OperationType.CreateSearchPipeline, Retry(CreateSearchPipeline()), async_runner=True)
 
 
 def runner_for(operation_type):
@@ -1102,6 +1103,14 @@ class PutPipeline(Runner):
     def __repr__(self, *args, **kwargs):
         return "put-pipeline"
 
+# TODO: refactor it after python client support search pipeline https://github.com/opensearch-project/opensearch-py/issues/474
+class CreateSearchPipeline(Runner):
+    async def __call__(self, opensearch, params):
+        endpoint = "/_search/pipeline/" + mandatory(params, "id", self)
+        await opensearch.transport.perform_request(method="PUT", url=endpoint, body=mandatory(params, "body", self))
+
+    def __repr__(self, *args, **kwargs):
+        return "create-search-pipeline"
 
 class Refresh(Runner):
     async def __call__(self, opensearch, params):

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -611,6 +611,7 @@ class OperationType(Enum):
     DeleteComposableTemplate = 1031
     CreateComponentTemplate = 1032
     DeleteComponentTemplate = 1033
+    CreateSearchPipeline = 1040
 
     @property
     def admin_op(self):
@@ -710,6 +711,8 @@ class OperationType(Enum):
             return OperationType.DeletePointInTime
         elif v == "list-all-point-in-time":
             return OperationType.ListAllPointInTime
+        elif v == "create-search-pipeline":
+            return OperationType.CreateSearchPipeline
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -5660,7 +5660,9 @@ class CreateSearchPipelineRunnerTests(TestCase):
 
         await r(opensearch, params)
 
-        opensearch.transport.perform_request.assert_called_once_with(method='PUT', url='/_search/pipeline/test_pipeline', body=params["body"])
+        opensearch.transport.perform_request.assert_called_once_with(method='PUT', 
+                                                                     url='/_search/pipeline/test_pipeline',
+                                                                     body=params["body"])
 
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
@@ -5672,9 +5674,10 @@ class CreateSearchPipelineRunnerTests(TestCase):
         params = {
             "id": "test_pipeline",
         }
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'body'. "
-                                    "Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'body'. "
+            "Add it to your parameter source and try again."):
             await r(opensearch, params)
 
         self.assertEqual(0, opensearch.transport.perform_request.call_count)
@@ -5689,9 +5692,10 @@ class CreateSearchPipelineRunnerTests(TestCase):
         params = {
             "body": {}
         }
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'id'. "
-                                    "Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'id'. "
+            "Add it to your parameter source and try again."):
             await r(opensearch, params)
 
         self.assertEqual(0, opensearch.transport.perform_request.call_count)

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -2147,6 +2147,65 @@ class QueryRunnerTests(TestCase):
 
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_search_pipeline_using_request_params(self, opensearch):
+        response = {
+            "timed_out": False,
+            "took": 62,
+            "hits": {
+                "total": {
+                    "value": 2,
+                    "relation": "eq"
+                },
+                "hits": [
+                    {
+                        "title": "some-doc-1"
+                    },
+                    {
+                        "title": "some-doc-2"
+                    }
+
+                ]
+            }
+        }
+        opensearch.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(response)))
+
+        query_runner = runner.Query()
+        params = {
+            "index": "_all",
+            "cache": False,
+            "detailed-results": True,
+            "body": None,
+            "request-params": {
+                "q": "user:kimchy",
+                "search-pipeline": "test-search-pipeline"
+            }
+        }
+
+        async with query_runner:
+            result = await query_runner(opensearch, params)
+
+        self.assertEqual(1, result["weight"])
+        self.assertEqual("ops", result["unit"])
+        self.assertEqual(2, result["hits"])
+        self.assertEqual("eq", result["hits_relation"])
+        self.assertFalse(result["timed_out"])
+        self.assertEqual(62, result["took"])
+        self.assertFalse("error-type" in result)
+
+        opensearch.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/_all/_search",
+            params={
+                "request_cache": "false",
+                "q": "user:kimchy",
+                'search-pipeline': 'test-search-pipeline'
+            },
+            body=params["body"],
+            headers=None
+        )
+        opensearch.clear_scroll.assert_not_called()
 
 class PutPipelineRunnerTests(TestCase):
     @mock.patch("opensearchpy.OpenSearch")
@@ -5564,3 +5623,75 @@ class RemovePrefixTests(TestCase):
         suffix = runner.remove_prefix(index_name, "unrelatedprefix")
 
         self.assertEqual(suffix, index_name)
+
+
+class CreateSearchPipelineRunnerTests(TestCase):
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_create_search_pipeline(self, opensearch):
+        opensearch.transport.perform_request.return_value = as_future()
+
+        r = runner.CreateSearchPipeline()
+
+        params = {
+            "id": "test_pipeline",
+            "body": {
+                "request_processors": [
+                    {
+                        "filter_query": {
+                            "query": {
+                                "match": {
+                                    "foo": "bar"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "response_processors": [
+                    {
+                        "rename_field": {
+                            "field": "foo",
+                            "target_field": "bar"
+                        }
+                    }
+                ]
+            }
+        }
+
+        await r(opensearch, params)
+
+        opensearch.transport.perform_request.assert_called_once_with(method='PUT', url='/_search/pipeline/test_pipeline', body=params["body"])
+
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_param_body_mandatory(self, opensearch):
+        opensearch.transport.perform_request.return_value = as_future()
+
+        r = runner.CreateSearchPipeline()
+
+        params = {
+            "id": "test_pipeline",
+        }
+        with self.assertRaisesRegex(exceptions.DataError,
+                                    "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'body'. "
+                                    "Add it to your parameter source and try again."):
+            await r(opensearch, params)
+
+        self.assertEqual(0, opensearch.transport.perform_request.call_count)
+
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_param_id_mandatory(self, opensearch):
+        opensearch.transport.perform_request.return_value = as_future()
+
+        r = runner.CreateSearchPipeline()
+
+        params = {
+            "body": {}
+        }
+        with self.assertRaisesRegex(exceptions.DataError,
+                                    "Parameter source for operation 'create-search-pipeline' did not provide the mandatory parameter 'id'. "
+                                    "Add it to your parameter source and try again."):
+            await r(opensearch, params)
+
+        self.assertEqual(0, opensearch.transport.perform_request.call_count)


### PR DESCRIPTION
### Description
Add support for create search pipeline

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/7782

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

1. Unit test passed.
```
make test

================= 1185 passed, 5 skipped, 3 warnings in 20.11s =================
```

2. Added workloads and tested

```
    {
      "name": "create-http-log-baseline-search-pipeline",
      "operation-type": "create-search-pipeline",
      "id": "http-log-baseline-search-pipeline",
      "body": {
        "description": "Process search requests with a pipeline that does nothing. Baseline for overhead of pipeline."
      }
    }
    
    
|                                                 Min Throughput |          term |       45.65 |  ops/s |
|                                                Mean Throughput |          term |       45.65 |  ops/s |
|                                              Median Throughput |          term |       45.65 |  ops/s |
|                                                 Max Throughput |          term |       45.65 |  ops/s |
|                                       100th percentile latency |          term |     34.9443 |     ms |
|                                  100th percentile service time |          term |     12.6586 |     ms |
|                                                     error rate |          term |           0 |      % |
|                                                 Min Throughput | term_pipeline |       47.75 |  ops/s |
|                                                Mean Throughput | term_pipeline |       47.75 |  ops/s |
|                                              Median Throughput | term_pipeline |       47.75 |  ops/s |
|                                                 Max Throughput | term_pipeline |       47.75 |  ops/s |
|                                       100th percentile latency | term_pipeline |     34.4138 |     ms |
|                                  100th percentile service time | term_pipeline |     12.8929 |     ms |
|                                                     error rate | term_pipeline |           0 |      % |
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
