### PR TITLE
set default pipeline to benchmark-only

### DIFF
--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -28,7 +28,8 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.execute_test(cfg, f"--pipeline=from-sources --revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+    assert it.execute_test(cfg, f"--pipeline=from-sources --revision=latest \
+                           --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts --provision-config-instance=4gheap "
                         f"--opensearch-plugins=analysis-icu") == 0
 

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -28,7 +28,7 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.execute_test(cfg, f"--revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+    assert it.execute_test(cfg, f"--pipeline=from-sources --revision=latest --workload=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
                         f"--test-procedure=append-no-conflicts --provision-config-instance=4gheap "
                         f"--opensearch-plugins=analysis-icu") == 0
 

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -344,16 +344,18 @@ def list_pipelines():
 
 def run(cfg):
     logger = logging.getLogger(__name__)
-    name = cfg.opts("test_execution", "pipeline")
+    # pipeline is no more mandatory, will default to benchmark-only
+    name = cfg.opts("test_execution", "pipeline", mandatory=False)
     test_execution_id = cfg.opts("system", "test_execution.id")
     logger.info("Test Execution id [%s]", test_execution_id)
-    if len(name) == 0:
-        # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
+    if not name:
+        # assume from-distribution pipeline if distribution.version has been specified
         if cfg.exists("builder", "distribution.version"):
             name = "from-distribution"
         else:
-            name = "from-sources"
-        logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
+            name = "benchmark-only"
+            logger.info("User did not specify distribution.version or pipeline. Using default pipeline [%s].", name)
+
         cfg.add(config.Scope.applicationOverride, "test_execution", "pipeline", name)
     else:
         logger.info("User specified pipeline [%s].", name)

--- a/tests/test_execution_orchestrator_test.py
+++ b/tests/test_execution_orchestrator_test.py
@@ -114,3 +114,12 @@ def test_runs_a_known_pipeline(unittest_pipeline):
     test_execution_orchestrator.run(cfg)
 
     unittest_pipeline.target.assert_called_once_with(cfg)
+
+def test_runs_a_default_pipeline(benchmark_only_pipeline):
+    # with no pipeline specified, should default to benchmark-only
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "system", "test_execution.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+
+    test_execution_orchestrator.run(cfg)
+
+    benchmark_only_pipeline.target.assert_called_once_with(cfg)


### PR DESCRIPTION
### Description
If no pipeline is specified then by default 'benchmark-only' will be used

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/326

### Testing
- [X] New functionality includes testing

[Describe how this change was tested]
Tested against already running cluster without specifying pipeline. default 'benchmark-only' will be used
```
python3 benchmark.py execute-test --workload=http_logs --target-hosts=https://localhost:9200 --distribution-version=2.10.0 --client-options="basic_auth_user:'admin',basic_auth_password:'admin',verify_certs:false,use_ssl:false" --test-mode --kill-running-processes

Output logs

2023-10-10 03:17:48,323 -not-actor-/PID:52566 osbenchmark.test_execution_orchestrator INFO Test Execution id [452bd58d-31ee-4da5-86ed-b77339cfb411]
2023-10-10 03:17:48,324 -not-actor-/PID:52566 osbenchmark.test_execution_orchestrator INFO User specified no pipeline. Using default pipeline [benchmark-only].
```

validated by running
```
make test

..

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 1186 passed, 5 skipped, 3 warnings in 6.43s ==================
```
Added new UT

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
