### PR TITLE
Bumping urllib3 and boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "opensearch-py[async]==2.2.0",
+    "opensearch-py[async]==2.3.2",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT
@@ -97,7 +97,7 @@ install_requires = [
     #   botocore: Apache 2.0
     #   jmespath: MIT
     #   s3transfer: Apache 2.0
-    "boto3==1.10.32",
+    "boto3==1.28.62",
 ]
 
 tests_require = [


### PR DESCRIPTION
### Description
Bumping urllib3 to 2.3.2 and boto3 to 1.28.62 to satisfy it's dependencies. 

### Issues Resolved
#378 

### Testing
- [x] Tested with running make prereq and install


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
