### PR TITLE
Extend Sigv4 to Role based Access

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -188,6 +188,7 @@ class OsClientFactory:
                                                       default_value=None, mandatory=False)
         metrics_aws_access_key_id = None
         metrics_aws_secret_access_key = None
+        metrics_aws_session_token = None
         metrics_aws_region = None
         metrics_aws_service = None
 
@@ -196,6 +197,8 @@ class OsClientFactory:
                                                           default_value=None, mandatory=False)
             metrics_aws_secret_access_key = self._config.opts("results_publishing", "datastore.aws_secret_access_key",
                                                               default_value=None, mandatory=False)
+            metrics_aws_session_token = self._config.opts("results_publishing", "datastore.aws_session_token",
+                                                          default_value=None, mandatory=False)
             metrics_aws_region = self._config.opts("results_publishing", "datastore.region",
                                                    default_value=None, mandatory=False)
             metrics_aws_service = self._config.opts("results_publishing", "datastore.service",
@@ -203,6 +206,7 @@ class OsClientFactory:
         elif metrics_amazon_aws_log_in == 'environment':
             metrics_aws_access_key_id = os.getenv("OSB_DATASTORE_AWS_ACCESS_KEY_ID", default=None)
             metrics_aws_secret_access_key = os.getenv("OSB_DATASTORE_AWS_SECRET_ACCESS_KEY", default=None)
+            metrics_aws_session_token = os.getenv("OSB_DATASTORE_AWS_SESSION_TOKEN", default=None)
             metrics_aws_region = os.getenv("OSB_DATASTORE_REGION", default=None)
             metrics_aws_service = os.getenv("OSB_DATASTORE_SERVICE", default=None)
 
@@ -254,13 +258,17 @@ class OsClientFactory:
             client_options["basic_auth_user"] = user
             client_options["basic_auth_password"] = password
 
-        #add options for aws user login: pass in aws access key id, aws secret access key, service and region on command
+        # add options for aws user login:
+        # pass in aws access key id, aws secret access key, aws session token, service and region on command
         if metrics_amazon_aws_log_in is not None:
             client_options["amazon_aws_log_in"] = 'client_option'
             client_options["aws_access_key_id"] = metrics_aws_access_key_id
             client_options["aws_secret_access_key"] = metrics_aws_secret_access_key
             client_options["service"] = metrics_aws_service
             client_options["region"] = metrics_aws_region
+
+            if metrics_aws_session_token:
+                client_options["aws_session_token"] = metrics_aws_session_token
 
         factory = client.OsClientFactory(hosts=[{"host": host, "port": port}], client_options=client_options)
         self._client = factory.create()

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -249,7 +249,7 @@ class OsClientFactoryTests(TestCase):
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_with_aws_creds(self, mocked_load_cert_chain):
         hosts = [{"host": "localhost", "port": 9200}]
-        client_options = {
+        user_based_client_options = {
             "use_ssl": True,
             "timeout": 120,
             "amazon_aws_log_in": 'client_option',
@@ -259,34 +259,50 @@ class OsClientFactoryTests(TestCase):
             "region": "us-east-1",
             "verify_certs": True
         }
-        # make a copy so we can verify later that the factory did not modify it
-        original_client_options = dict(client_options)
+
+        role_based_client_options = dict(user_based_client_options)
+        role_based_client_options["aws_session_token"] = "dummy_token"
+
+        client_options_list = [
+            user_based_client_options,
+            role_based_client_options
+        ]
 
         logger = logging.getLogger("osbenchmark.client")
-        with mock.patch.object(logger, "info") as mocked_info_logger:
-            f = client.OsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL support: on"),
-            mock.call("SSL certificate verification: on"),
-            mock.call("SSL client authentication: off")
-        ])
 
-        assert not mocked_load_cert_chain.called, "ssl_context.load_cert_chain should not have been called as we have not supplied " \
-                                                  "client certs"
+        for client_options in client_options_list:
+            # make a copy so we can verify later that the factory did not modify it
+            original_client_options = dict(client_options)
 
-        self.assertEqual(hosts, f.hosts)
-        self.assertTrue(f.ssl_context.check_hostname)
-        self.assertEqual(ssl.CERT_REQUIRED, f.ssl_context.verify_mode)
+            with mock.patch.object(logger, "info") as mocked_info_logger:
+                f = client.OsClientFactory(hosts, client_options)
 
-        self.assertEqual("https", f.client_options["scheme"])
-        self.assertIn("timeout", f.client_options)
-        self.assertIn("aws_access_key_id", f.client_options)
-        self.assertIn("aws_secret_access_key", f.client_options)
-        self.assertIn("amazon_aws_log_in", f.client_options)
-        self.assertIn("service", f.client_options)
-        self.assertIn("region", f.client_options)
+            mocked_info_logger.assert_has_calls([
+                mock.call("SSL support: on"),
+                mock.call("SSL certificate verification: on"),
+                mock.call("SSL client authentication: off")
+            ])
 
-        self.assertDictEqual(original_client_options, client_options)
+            assert not mocked_load_cert_chain.called, "ssl_context.load_cert_chain should not have been called as we have not supplied " \
+                                                    "client certs"
+
+            self.assertEqual(hosts, f.hosts)
+            self.assertTrue(f.ssl_context.check_hostname)
+            self.assertEqual(ssl.CERT_REQUIRED, f.ssl_context.verify_mode)
+
+            self.assertEqual("https", f.client_options["scheme"])
+            self.assertIn("timeout", f.client_options)
+            self.assertIn("aws_access_key_id", f.client_options)
+            self.assertIn("aws_secret_access_key", f.client_options)
+            self.assertIn("amazon_aws_log_in", f.client_options)
+            self.assertIn("service", f.client_options)
+            self.assertIn("region", f.client_options)
+
+            if "aws_session_token" in original_client_options:
+                self.assertIn("aws_session_token", f.client_options)
+
+            self.assertDictEqual(original_client_options, client_options)
+
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_unverified_certificate_present_client_certificates(self, mocked_load_cert_chain):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -327,12 +327,14 @@ class OsClientTests(TestCase):
         _datastore_verify_certs = random.choice([True, False])
         _datastore_amazon_aws_log_in = configuration_source
         _datastore_aws_access_key_id = "".join([random.choice(string.digits) for _ in range(AWS_ACCESS_KEY_ID_LENGTH)])
-        _datastore_aws_secret_access_key = "".join([random.choice(string.ascii_letters + string.digits) for _ in range(AWS_SECRET_ACCESS_KEY_LENGTH)])
+        _datastore_aws_secret_access_key = "".join([random.choice(string.ascii_letters + string.digits) \
+                                                    for _ in range(AWS_SECRET_ACCESS_KEY_LENGTH)])
         _datastore_aws_service = random.choice(['es', 'aoss'])
         _datastore_aws_region = random.choice(['us-east-1', 'eu-west-1'])
 
         # optional
-        _datastore_aws_session_token = "".join([random.choice(string.ascii_letters + string.digits) for _ in range(AWS_SESSION_TOKEN_LENGTH)])
+        _datastore_aws_session_token = "".join([random.choice(string.ascii_letters + string.digits) \
+                                                for _ in range(AWS_SESSION_TOKEN_LENGTH)])
 
         cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.host", _datastore_host)
         cfg.add(config.Scope.applicationOverride, "results_publishing", "datastore.port", _datastore_port)


### PR DESCRIPTION
### Description
extend sigv4 support to role-based access

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/377

### Testing
- [X] New functionality includes testing

[Describe how this change was tested]
Added new UT
Updated existing UT
validated by running `make test`
validated by provisioning a managed cluster and verifying access with session-token
validated by running benchmark test using http_logs

**Note**
Scroll API request in OSB becnhmark test is failing and is currently being investigated

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
