### PR TITLE
Fix the predicate used for the --kill-running-processes flag

### DIFF
--- a/osbenchmark/utils/process.py
+++ b/osbenchmark/utils/process.py
@@ -133,11 +133,12 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
 
 def is_benchmark_process(p):
     cmdline = p.cmdline()
+    # On Linux, /proc/PID/status truncates the command name to 15 characters.
     return p.name() == "opensearch-benchmark" or \
-           (p.name().lower().startswith("python") and
-            (len(cmdline) > 1 and
-             (cmdline[1] == "opensearch-benchmark" or
-              cmdline[1].endswith(os.path.sep + "opensearch-benchmark"))))
+        p.name() == "opensearch-benc" or \
+        (len(cmdline) > 1 and
+         os.path.basename(cmdline[0].lower()).startswith("python") and
+         os.path.basename(cmdline[1]) == "opensearch-benchmark")
 
 
 def find_all_other_benchmark_processes():

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -123,6 +123,8 @@ class ProcessTests(TestCase):
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
+        # On Linux, the process name is truncated to 15 characters.
+        benchmark_process_l = ProcessTests.Process(106, "opensearch-benc", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
         benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python",
                                                                      "~/.local/bin/opensearch-benchmark"])
@@ -139,6 +141,7 @@ class ProcessTests(TestCase):
             random_python,
             other_process,
             benchmark_process_p,
+            benchmark_process_l,
             benchmark_process_e,
             benchmark_process_mac,
             own_benchmark_process,
@@ -153,6 +156,7 @@ class ProcessTests(TestCase):
         self.assertFalse(random_python.killed)
         self.assertFalse(other_process.killed)
         self.assertTrue(benchmark_process_p.killed)
+        self.assertTrue(benchmark_process_l.killed)
         self.assertTrue(benchmark_process_e.killed)
         self.assertTrue(benchmark_process_mac.killed)
         self.assertFalse(own_benchmark_process.killed)


### PR DESCRIPTION
### Description
The -kill-running-processes flag does not work correctly on all platforms.  This change fixes the issue.

### Issues Resolved
#404 

### Testing
Ran unit and integ tests.  Updated one of the unit tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
