### PR TITLE
Rename parameters for Distributed Workload Generation - Issue 258 

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -470,7 +470,7 @@ def create_arg_parser():
              "(default: localhost:9200).",
         default="")  # actually the default is pipeline specific and it is set later
     test_execution_parser.add_argument(
-        "--load-worker-coordinator-hosts",
+        "--worker-ips",
         help="Define a comma-separated list of hosts which should generate load (default: localhost).",
         default="localhost")
     test_execution_parser.add_argument(
@@ -859,8 +859,8 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(
                 config.Scope.applicationOverride,
                 "worker_coordinator",
-                "load_worker_coordinator_hosts",
-                opts.csv_to_list(args.load_worker_coordinator_hosts))
+                "worker_ips",
+                opts.csv_to_list(args.worker_ips))
             cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -528,7 +528,7 @@ class WorkerCoordinator:
         self.workload = None
         self.test_procedure = None
         self.metrics_store = None
-        self.load_worker_coordinator_hosts = []
+        self.worker_ips = []
         self.workers = []
         # which client ids are assigned to which workers?
         self.clients_per_worker = {}
@@ -636,7 +636,7 @@ class WorkerCoordinator:
         # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.
         self.prepare_telemetry(os_clients, enable=not uses_static_responses)
 
-        for host in self.config.opts("worker_coordinator", "load_worker_coordinator_hosts"):
+        for host in self.config.opts("worker_coordinator", "worker_ips"):
             host_config = {
                 # for simplicity we assume that all benchmark machines have the same specs
                 "cores": num_cores(self.config)
@@ -646,9 +646,9 @@ class WorkerCoordinator:
             else:
                 host_config["host"] = host
 
-            self.load_worker_coordinator_hosts.append(host_config)
+            self.worker_ips.append(host_config)
 
-        self.target.prepare_workload([h["host"] for h in self.load_worker_coordinator_hosts], self.config, self.workload)
+        self.target.prepare_workload([h["host"] for h in self.worker_ips], self.config, self.workload)
 
     def start_benchmark(self):
         self.logger.info("Benchmark is about to start.")
@@ -669,7 +669,7 @@ class WorkerCoordinator:
         if allocator.clients < 128:
             self.logger.info("Allocation matrix:\n%s", "\n".join([str(a) for a in self.allocations]))
 
-        worker_assignments = calculate_worker_assignments(self.load_worker_coordinator_hosts, allocator.clients)
+        worker_assignments = calculate_worker_assignments(self.worker_ips, allocator.clients)
         worker_id = 0
         for assignment in worker_assignments:
             host = assignment["host"]

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -110,7 +110,7 @@ class WorkerCoordinatorTests(TestCase):
         self.cfg.add(config.Scope.application, "client", "hosts",
                      WorkerCoordinatorTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
-        self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
+        self.cfg.add(config.Scope.application, "worker_coordinator", "worker_ips", ["localhost"])
         self.cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
@@ -135,7 +135,7 @@ class WorkerCoordinatorTests(TestCase):
     @mock.patch("osbenchmark.utils.net.resolve")
     def test_start_benchmark_and_prepare_workload(self, resolve):
         # override load worker_coordinator host
-        self.cfg.add(config.Scope.applicationOverride, "worker_coordinator", "load_worker_coordinator_hosts", ["10.5.5.1", "10.5.5.2"])
+        self.cfg.add(config.Scope.applicationOverride, "worker_coordinator", "worker_ips", ["10.5.5.1", "10.5.5.2"])
         resolve.side_effect = ["10.5.5.1", "10.5.5.2"]
 
         target = self.create_test_worker_coordinator_target()


### PR DESCRIPTION
### Description
The terminology used in Distributed Workload Generation is updated. 
Once all the hosts have had the daemon successfully start on them, we run the following command on the host we designated as --coordinator-ip.

# Run test command on coordinator
opensearch-benchmark execute_test --pipeline=benchmark-only --workload=<workload> --load-worker-coordinator-hosts=<IP2,IP3> --target-hosts=<endpoint>

The parameter **"--load-worker-coordinator-hosts"** is renamed to **"worker-ips"** to be consistent with --node-ip and --coordinator-ip.

### Issues Resolved
[258]

### Testing

To use Distributed Workload Generation, users have to first start the opensearch-benchmark daemon on all hosts they plan to distribute load from. One of the hosts --referred to as the load coordinator host -- coordinates requests while the others -- referred to as worker-ips -- will drive the requests / load. For example, if we have three hosts -- denoted by IP1, IP2, and IP3 --, we would do run the corresponding command on each host:

#### Run on IP1 Host
`opensearch-benchmarkd start --node-ip=<IP1> --coordinator-ip=<IP1>`

#### Run on IP2 Host
`opensearch-benchmarkd start --node-ip=<IP2> --coordinator-ip=<IP1>`

#### Run on IP3 Host
`opensearch-benchmarkd start --node-ip=<IP3> --coordinator-ip=<IP1>`

Once all the hosts have had the daemon successfully start on them, run the following command on the host we designated as --coordinator-ip in the commands above (in this case, IP1):

#### Run test command on IP1 Host
`opensearch-benchmark execute-test --pipeline=benchmark-only --workload=<workload> --worker-ips=<IP2,IP3> --target-hosts=<endpoint>
`

This starts the test. IP1 is the coordinator and delegates a portion of ingestion and search requests for IP2 and IP3 to send to the target cluster.

It is expected to run the tests successfully. The following screenshot is an output from a test.

![DWG_success](https://github.com/opensearch-project/opensearch-benchmark/assets/3635674/cc9490dc-e8da-4214-a030-017d4172619b)





---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
