### PR TITLE
Switching to the default connection class to address slower connection with RequestsHttpConnection

### DIFF
--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -294,7 +294,7 @@ class OsClientFactory:
         aws_auth = opensearchpy.AWSV4SignerAuth(credentials, self.aws_log_in_dict["region"],
                                                 self.aws_log_in_dict["service"])
         return opensearchpy.OpenSearch(hosts=self.hosts, use_ssl=True, verify_certs=True, http_auth=aws_auth,
-                                       connection_class=opensearchpy.RequestsHttpConnection)
+                                       connection_class=opensearchpy.Urllib3HttpConnection)
 
     def create_async(self):
         # pylint: disable=import-outside-toplevel

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -291,7 +291,7 @@ class OsClientFactory:
         credentials = Credentials(access_key=self.aws_log_in_dict["aws_access_key_id"],
                                   secret_key=self.aws_log_in_dict["aws_secret_access_key"],
                                   token=self.aws_log_in_dict["aws_session_token"])
-        aws_auth = opensearchpy.AWSV4SignerAuth(credentials, self.aws_log_in_dict["region"],
+        aws_auth = opensearchpy.Urllib3AWSV4SignerAuth(credentials, self.aws_log_in_dict["region"],
                                                 self.aws_log_in_dict["service"])
         return opensearchpy.OpenSearch(hosts=self.hosts, use_ssl=True, verify_certs=True, http_auth=aws_auth,
                                        connection_class=opensearchpy.Urllib3HttpConnection)

--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -179,7 +179,7 @@ class TargetHosts(ConnectOptions):
             defined as a json string or file.
             """
             # pylint: disable=import-outside-toplevel
-            from opensearchpy.client import _normalize_hosts
+            from opensearchpy.client.utils import _normalize_hosts
             return {TargetHosts.DEFAULT: _normalize_hosts(arg)}
 
         self.parsed_options = to_dict(self.argvalue, default_parser=normalize_to_dict)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "opensearch-py[async]==2.3.2",
+    "opensearch-py[async]==2.4.1",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT


### PR DESCRIPTION
### Description
This PR implements the default Urllib3HttpConnection to replace RequestsHttpConnection to address the slower connection issue, as recommended by the opensearch-py guide for connection classes. Upon checking the code, I discovered this was the only place RequestsHttpConnection was used. Please do point out if I was wrong here.

### Issues Resolved
#408 

### Testing
- [ ] New functionality includes testing


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
