### PR TITLE
Changing execute-test progress bar

### DIFF
--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -13,7 +13,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -36,15 +36,29 @@ from osbenchmark.metrics import MetaInfoScope
 from osbenchmark.utils import io, sysstats, console, opts, process
 from osbenchmark.utils.versions import components
 
+
 def list_telemetry():
     console.println("Available telemetry devices:\n")
-    devices = [[device.command, device.human_name, device.help] for device in [JitCompiler, Gc, FlightRecorder,
-                                                                               Heapdump, NodeStats, RecoveryStats,
-                                                                               CcrStats, SegmentStats, TransformStats,
-                                                                               SearchableSnapshotsStats,
-                                                                               SegmentReplicationStats]]
+    devices = [
+        [device.command, device.human_name, device.help]
+        for device in [
+            JitCompiler,
+            Gc,
+            FlightRecorder,
+            Heapdump,
+            NodeStats,
+            RecoveryStats,
+            CcrStats,
+            SegmentStats,
+            TransformStats,
+            SearchableSnapshotsStats,
+            SegmentReplicationStats,
+        ]
+    ]
     console.println(tabulate.tabulate(devices, ["Command", "Name", "Description"]))
-    console.println("\nKeep in mind that each telemetry device may incur a runtime overhead which can skew results.")
+    console.println(
+        "\nKeep in mind that each telemetry device may incur a runtime overhead which can skew results."
+    )
 
 
 class Telemetry:
@@ -105,6 +119,7 @@ class Telemetry:
 #
 ########################################################################################
 
+
 class TelemetryDevice:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
@@ -161,7 +176,9 @@ class SamplerThread(threading.Thread):
                 self.recorder.record()
                 time.sleep(self.recorder.sample_interval)
         except BaseException:
-            logging.getLogger(__name__).exception("Could not determine %s", self.recorder)
+            logging.getLogger(__name__).exception(
+                "Could not determine %s", self.recorder
+            )
 
 
 class FlightRecorder(TelemetryDevice):
@@ -182,17 +199,36 @@ class FlightRecorder(TelemetryDevice):
 
         # JFR was integrated into OpenJDK 11 and is not a commercial feature anymore.
         if self.java_major_version < 11:
-            console.println("\n***************************************************************************\n")
-            console.println("[WARNING] Java flight recorder is a commercial feature of the Oracle JDK.\n")
-            console.println("You are using Java flight recorder which requires that you comply with\nthe licensing terms stated in:\n")
-            console.println(console.format.link("http://www.oracle.com/technetwork/java/javase/terms/license/index.html"))
-            console.println("\nBy using this feature you confirm that you comply with these license terms.\n")
-            console.println("Otherwise, please abort and rerun Benchmark without the \"jfr\" telemetry device.")
-            console.println("\n***************************************************************************\n")
+            console.println(
+                "\n***************************************************************************\n"
+            )
+            console.println(
+                "[WARNING] Java flight recorder is a commercial feature of the Oracle JDK.\n"
+            )
+            console.println(
+                "You are using Java flight recorder which requires that you comply with\nthe licensing terms stated in:\n"
+            )
+            console.println(
+                console.format.link(
+                    "http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+                )
+            )
+            console.println(
+                "\nBy using this feature you confirm that you comply with these license terms.\n"
+            )
+            console.println(
+                'Otherwise, please abort and rerun Benchmark without the "jfr" telemetry device.'
+            )
+            console.println(
+                "\n***************************************************************************\n"
+            )
 
             time.sleep(3)
 
-        console.info("%s: Writing flight recording to [%s]" % (self.human_name, log_file), logger=self.logger)
+        console.info(
+            "%s: Writing flight recording to [%s]" % (self.human_name, log_file),
+            logger=self.logger,
+        )
 
         java_opts = self.java_opts(log_file)
 
@@ -208,17 +244,27 @@ class FlightRecorder(TelemetryDevice):
 
         if self.java_major_version < 9:
             java_opts.append("-XX:+FlightRecorder")
-            java_opts.append("-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={}".format(log_file))
+            java_opts.append(
+                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={}".format(
+                    log_file
+                )
+            )
             jfr_cmd = "-XX:StartFlightRecording=defaultrecording=true"
             if recording_template:
-                self.logger.info("jfr: Using recording template [%s].", recording_template)
+                self.logger.info(
+                    "jfr: Using recording template [%s].", recording_template
+                )
                 jfr_cmd += ",settings={}".format(recording_template)
             else:
                 self.logger.info("jfr: Using default recording template.")
         else:
-            jfr_cmd += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(log_file)
+            jfr_cmd += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(
+                log_file
+            )
             if recording_template:
-                self.logger.info("jfr: Using recording template [%s].", recording_template)
+                self.logger.info(
+                    "jfr: Using recording template [%s].", recording_template
+                )
                 jfr_cmd += ",settings={}".format(recording_template)
             else:
                 self.logger.info("jfr: Using default recording template.")
@@ -239,9 +285,17 @@ class JitCompiler(TelemetryDevice):
     def instrument_java_opts(self):
         io.ensure_dir(self.log_root)
         log_file = os.path.join(self.log_root, "jit.log")
-        console.info("%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file), logger=self.logger)
-        return ["-XX:+UnlockDiagnosticVMOptions", "-XX:+TraceClassLoading", "-XX:+LogCompilation",
-                "-XX:LogFile={}".format(log_file), "-XX:+PrintAssembly"]
+        console.info(
+            "%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file),
+            logger=self.logger,
+        )
+        return [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+TraceClassLoading",
+            "-XX:+LogCompilation",
+            "-XX:LogFile={}".format(log_file),
+            "-XX:+PrintAssembly",
+        ]
 
 
 class Gc(TelemetryDevice):
@@ -259,18 +313,31 @@ class Gc(TelemetryDevice):
     def instrument_java_opts(self):
         io.ensure_dir(self.log_root)
         log_file = os.path.join(self.log_root, "gc.log")
-        console.info("%s: Writing GC log to [%s]" % (self.human_name, log_file), logger=self.logger)
+        console.info(
+            "%s: Writing GC log to [%s]" % (self.human_name, log_file),
+            logger=self.logger,
+        )
         return self.java_opts(log_file)
 
     def java_opts(self, log_file):
         if self.java_major_version < 9:
-            return ["-Xloggc:{}".format(log_file), "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-XX:+PrintGCTimeStamps",
-                    "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
-                    "-XX:+PrintTenuringDistribution"]
+            return [
+                "-Xloggc:{}".format(log_file),
+                "-XX:+PrintGCDetails",
+                "-XX:+PrintGCDateStamps",
+                "-XX:+PrintGCTimeStamps",
+                "-XX:+PrintGCApplicationStoppedTime",
+                "-XX:+PrintGCApplicationConcurrentTime",
+                "-XX:+PrintTenuringDistribution",
+            ]
         else:
-            log_config = self.telemetry_params.get("gc-log-config", "gc*=info,safepoint=info,age*=trace")
+            log_config = self.telemetry_params.get(
+                "gc-log-config", "gc*=info,safepoint=info,age*=trace"
+            )
             # see https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5
-            return [f"-Xlog:{log_config}:file={log_file}:utctime,uptimemillis,level,tags:filecount=0"]
+            return [
+                f"-Xlog:{log_config}:file={log_file}:utctime,uptimemillis,level,tags:filecount=0"
+            ]
 
 
 class Heapdump(TelemetryDevice):
@@ -285,8 +352,13 @@ class Heapdump(TelemetryDevice):
 
     def detach_from_node(self, node, running):
         if running:
-            heap_dump_file = os.path.join(self.log_root, "heap_at_exit_{}.hprof".format(node.pid))
-            console.info("{}: Writing heap dump to [{}]".format(self.human_name, heap_dump_file), logger=self.logger)
+            heap_dump_file = os.path.join(
+                self.log_root, "heap_at_exit_{}.hprof".format(node.pid)
+            )
+            console.info(
+                "{}: Writing heap dump to [{}]".format(self.human_name, heap_dump_file),
+                logger=self.logger,
+            )
             cmd = "jmap -dump:format=b,file={} {}".format(heap_dump_file, node.pid)
             if process.run_subprocess_with_logging(cmd):
                 self.logger.warning("Could not write heap dump to [%s]", heap_dump_file)
@@ -308,7 +380,10 @@ class SegmentStats(TelemetryDevice):
         try:
             segment_stats = self.client.cat.segments(index="_all", v=True)
             stats_file = os.path.join(self.log_root, "segment_stats.log")
-            console.info(f"{self.human_name}: Writing segment stats to [{stats_file}]", logger=self.logger)
+            console.info(
+                f"{self.human_name}: Writing segment stats to [{stats_file}]",
+                logger=self.logger,
+            )
             with open(stats_file, "wt") as f:
                 f.write(segment_stats)
         except BaseException:
@@ -319,12 +394,15 @@ class CcrStats(TelemetryDevice):
     internal = False
     command = "ccr-stats"
     human_name = "CCR Stats"
-    help = ("Regularly samples Cross Cluster Replication (CCR) leader and follower(s) checkpoint at index level"
-            "and calculates replication lag")
+    help = (
+        "Regularly samples Cross Cluster Replication (CCR) leader and follower(s) checkpoint at index level"
+        "and calculates replication lag"
+    )
 
     """
     Gathers CCR stats on a cluster level
     """
+
     def __init__(self, telemetry_params, clients, metrics_store):
         """
         :param telemetry_params: The configuration object for telemetry_params.
@@ -343,17 +421,25 @@ class CcrStats(TelemetryDevice):
         self.sample_interval = telemetry_params.get("ccr-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was {}.".format(self.sample_interval))
+                "The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was {}.".format(
+                    self.sample_interval
+                )
+            )
         self.specified_cluster_names = self.clients.keys()
         self.indices_per_cluster = self.telemetry_params.get("ccr-stats-indices", False)
-        self.max_replication_lag_seconds = self.telemetry_params.get("ccr-max-replication-lag-seconds", 60*60*60)
+        self.max_replication_lag_seconds = self.telemetry_params.get(
+            "ccr-max-replication-lag-seconds", 60 * 60 * 60
+        )
         if self.indices_per_cluster:
             for cluster_name in self.indices_per_cluster.keys():
                 if cluster_name not in clients:
                     raise exceptions.SystemSetupError(
                         "The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
                         "the cluster names [{}] specified in --target-hosts "
-                        "but it had [{}].".format(",".join(sorted(clients.keys())), cluster_name))
+                        "but it had [{}].".format(
+                            ",".join(sorted(clients.keys())), cluster_name
+                        )
+                    )
             self.specified_cluster_names = self.indices_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -362,9 +448,16 @@ class CcrStats(TelemetryDevice):
     def on_benchmark_start(self):
         recorder = []
         for cluster_name in self.specified_cluster_names:
-            recorder = CcrStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store, self.sample_interval,
-                                        self.max_replication_lag_seconds,
-                                        self.indices_per_cluster[cluster_name] if self.indices_per_cluster else None)
+            recorder = CcrStatsRecorder(
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+                self.sample_interval,
+                self.max_replication_lag_seconds,
+                self.indices_per_cluster[cluster_name]
+                if self.indices_per_cluster
+                else None,
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -382,7 +475,15 @@ class CcrStatsRecorder:
     Collects and pushes CCR stats for the specified cluster to the metric store.
     """
 
-    def __init__(self, cluster_name, client, metrics_store, sample_interval, max_replication_lag_seconds, indices=None):
+    def __init__(
+        self,
+        cluster_name,
+        client,
+        metrics_store,
+        sample_interval,
+        max_replication_lag_seconds,
+        indices=None,
+    ):
         """
         :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
         :param client: The OpenSearch client for this cluster.
@@ -394,12 +495,14 @@ class CcrStatsRecorder:
         self.cluster_name = cluster_name
         self.client = client
         self.metrics_store = metrics_store
-        self.sample_interval= sample_interval
+        self.sample_interval = sample_interval
         self.indices = indices
         self.logger = logging.getLogger(__name__)
         self.leader_checkpoints = dict()
         for index in self.indices:
-            self.leader_checkpoints[index] = deque(maxlen = int(max_replication_lag_seconds/sample_interval))
+            self.leader_checkpoints[index] = deque(
+                maxlen=int(max_replication_lag_seconds / sample_interval)
+            )
 
     def __str__(self):
         return "ccr stats"
@@ -416,7 +519,9 @@ class CcrStatsRecorder:
 
     def log_leader_stats(self):
         try:
-            stats = self.client.transport.perform_request("GET", "/_plugins/_replication/leader_stats")
+            stats = self.client.transport.perform_request(
+                "GET", "/_plugins/_replication/leader_stats"
+            )
             self.record_cluster_level_stats(stats)
         except opensearchpy.TransportError:
             msg = "A transport error occurred while collecting CCR leader stats"
@@ -425,24 +530,31 @@ class CcrStatsRecorder:
 
     def log_follower_stats(self):
         try:
-            stats = self.client.transport.perform_request("GET", "/_plugins/_replication/follower_stats")
+            stats = self.client.transport.perform_request(
+                "GET", "/_plugins/_replication/follower_stats"
+            )
             self.record_cluster_level_stats(stats)
         except opensearchpy.TransportError:
-            msg = "A transport error occurred while collecting follower stats for remote cluster: {}".format(self.cluster_name)
+            msg = "A transport error occurred while collecting follower stats for remote cluster: {}".format(
+                self.cluster_name
+            )
             self.logger.exception(msg)
             raise exceptions.BenchmarkError(msg)
-
 
     def log_ccr_lag_per_index(self):
         for index in self.indices:
             try:
-                stats = self.client.transport.perform_request("GET", "/_plugins/_replication/" + index + "/_status")
+                stats = self.client.transport.perform_request(
+                    "GET", "/_plugins/_replication/" + index + "/_status"
+                )
                 if stats["status"] == "SYNCING":
                     self.record_stats_per_index(index, stats)
                 else:
                     self.logger.info("CCR Status is not syncing. Ignoring for now!")
             except opensearchpy.TransportError:
-                msg = "A transport error occurred while collecting CCR stats for remote cluster: {}".format(self.cluster_name)
+                msg = "A transport error occurred while collecting CCR stats for remote cluster: {}".format(
+                    self.cluster_name
+                )
                 self.logger.exception(msg)
                 raise exceptions.BenchmarkError(msg)
 
@@ -456,32 +568,37 @@ class CcrStatsRecorder:
             "index": name,
             "leader_checkpoint": stats["syncing_details"]["leader_checkpoint"],
             "follower_checkpoint": stats["syncing_details"]["follower_checkpoint"],
-            "replication_lag": self.calculate_lag(name, stats["syncing_details"]["leader_checkpoint"],
-                                    stats["syncing_details"]["follower_checkpoint"])
+            "replication_lag": self.calculate_lag(
+                name,
+                stats["syncing_details"]["leader_checkpoint"],
+                stats["syncing_details"]["follower_checkpoint"],
+            ),
         }
-        index_metadata = {
-            "cluster": self.cluster_name,
-            "index": name
-        }
-        self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=index_metadata)
+        index_metadata = {"cluster": self.cluster_name, "index": name}
+        self.metrics_store.put_doc(
+            doc, level=MetaInfoScope.cluster, meta_data=index_metadata
+        )
 
     def record_cluster_level_stats(self, data):
         metadata = {
             "cluster": self.cluster_name,
         }
-        self.metrics_store.put_doc(data, level=MetaInfoScope.cluster, meta_data=metadata)
+        self.metrics_store.put_doc(
+            data, level=MetaInfoScope.cluster, meta_data=metadata
+        )
 
     def calculate_lag(self, index, leader_checkpoint, follower_checkpoint):
         leader_checkpoint_queue = self.leader_checkpoints[index]
 
-        while(leader_checkpoint_queue and leader_checkpoint_queue[0] <= follower_checkpoint):
+        while (
+            leader_checkpoint_queue
+            and leader_checkpoint_queue[0] <= follower_checkpoint
+        ):
             leader_checkpoint_queue.popleft()
 
         if leader_checkpoint > follower_checkpoint:
             leader_checkpoint_queue.append(leader_checkpoint)
         return len(leader_checkpoint_queue) * self.sample_interval
-
-
 
 
 class RecoveryStats(TelemetryDevice):
@@ -515,8 +632,10 @@ class RecoveryStats(TelemetryDevice):
         self.sample_interval = telemetry_params.get("recovery-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'recovery-stats-sample-interval' must be greater than zero but was {}."
-                    .format(self.sample_interval))
+                "The telemetry parameter 'recovery-stats-sample-interval' must be greater than zero but was {}.".format(
+                    self.sample_interval
+                )
+            )
         self.specified_cluster_names = self.clients.keys()
         indices_per_cluster = self.telemetry_params.get("recovery-stats-indices", False)
         # allow the user to specify either an index pattern as string or as a JSON object
@@ -531,7 +650,10 @@ class RecoveryStats(TelemetryDevice):
                     raise exceptions.SystemSetupError(
                         "The telemetry parameter 'recovery-stats-indices' must be a JSON Object with keys matching "
                         "the cluster names [{}] specified in --target-hosts "
-                        "but it had [{}].".format(",".join(sorted(clients.keys())), cluster_name))
+                        "but it had [{}].".format(
+                            ",".join(sorted(clients.keys())), cluster_name
+                        )
+                    )
             self.specified_cluster_names = self.indices_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -539,9 +661,15 @@ class RecoveryStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         for cluster_name in self.specified_cluster_names:
-            recorder = RecoveryStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store,
-                                             self.sample_interval,
-                                             self.indices_per_cluster[cluster_name] if self.indices_per_cluster else "")
+            recorder = RecoveryStatsRecorder(
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+                self.sample_interval,
+                self.indices_per_cluster[cluster_name]
+                if self.indices_per_cluster
+                else "",
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -559,7 +687,9 @@ class RecoveryStatsRecorder:
     Collects and pushes recovery stats for the specified cluster to the metric store.
     """
 
-    def __init__(self, cluster_name, client, metrics_store, sample_interval, indices=None):
+    def __init__(
+        self, cluster_name, client, metrics_store, sample_interval, indices=None
+    ):
         """
         :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
         :param client: The OpenSearch client for this cluster.
@@ -583,24 +713,27 @@ class RecoveryStatsRecorder:
         Collect recovery stats for indexes (optionally) specified in telemetry parameters and push to metrics store.
         """
         try:
-            stats = self.client.indices.recovery(index=self.indices, active_only=True, detailed=False)
+            stats = self.client.indices.recovery(
+                index=self.indices, active_only=True, detailed=False
+            )
         except opensearchpy.TransportError:
-            msg = "A transport error occurred while collecting recovery stats on cluster [{}]".format(self.cluster_name)
+            msg = "A transport error occurred while collecting recovery stats on cluster [{}]".format(
+                self.cluster_name
+            )
             self.logger.exception(msg)
             raise exceptions.BenchmarkError(msg)
 
         for idx, idx_stats in stats.items():
             for shard in idx_stats["shards"]:
-                doc = {
-                    "name": "recovery-stats",
-                    "shard": shard
-                }
+                doc = {"name": "recovery-stats", "shard": shard}
                 shard_metadata = {
                     "cluster": self.cluster_name,
                     "index": idx,
-                    "shard": shard["id"]
+                    "shard": shard["id"],
                 }
-                self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=shard_metadata)
+                self.metrics_store.put_doc(
+                    doc, level=MetaInfoScope.cluster, meta_data=shard_metadata
+                )
 
 
 class NodeStats(TelemetryDevice):
@@ -632,11 +765,18 @@ class NodeStats(TelemetryDevice):
         distribution_version = default_client.info()["version"]["number"]
         major, minor = components(distribution_version)[:2]
 
-        if distribution_name != NodeStats.opensearch_distribution_name and (major < 7 or (major == 7 and minor < 2)):
+        if distribution_name != NodeStats.opensearch_distribution_name and (
+            major < 7 or (major == 7 and minor < 2)
+        ):
             console.warn(NodeStats.warning, logger=self.logger)
 
         for cluster_name in self.specified_cluster_names:
-            recorder = NodeStatsRecorder(self.telemetry_params, cluster_name, self.clients[cluster_name], self.metrics_store)
+            recorder = NodeStatsRecorder(
+                self.telemetry_params,
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -654,32 +794,58 @@ class NodeStatsRecorder:
         self.sample_interval = telemetry_params.get("node-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was {}.".format(self.sample_interval))
+                "The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was {}.".format(
+                    self.sample_interval
+                )
+            )
 
         self.include_indices = telemetry_params.get("node-stats-include-indices", False)
-        self.include_indices_metrics = telemetry_params.get("node-stats-include-indices-metrics", False)
+        self.include_indices_metrics = telemetry_params.get(
+            "node-stats-include-indices-metrics", False
+        )
 
         if self.include_indices_metrics:
             if isinstance(self.include_indices_metrics, str):
-                self.include_indices_metrics_list = opts.csv_to_list(self.include_indices_metrics)
+                self.include_indices_metrics_list = opts.csv_to_list(
+                    self.include_indices_metrics
+                )
             else:
                 # we don't validate the allowable metrics as they may change across ES versions
                 raise exceptions.SystemSetupError(
                     "The telemetry parameter 'node-stats-include-indices-metrics' must be a comma-separated string but was {}".format(
-                        type(self.include_indices_metrics))
+                        type(self.include_indices_metrics)
                     )
+                )
         else:
-            self.include_indices_metrics_list = ["docs", "store", "indexing", "search", "merges", "query_cache",
-                                                 "fielddata", "segments", "translog", "request_cache"]
+            self.include_indices_metrics_list = [
+                "docs",
+                "store",
+                "indexing",
+                "search",
+                "merges",
+                "query_cache",
+                "fielddata",
+                "segments",
+                "translog",
+                "request_cache",
+            ]
 
-        self.include_thread_pools = telemetry_params.get("node-stats-include-thread-pools", True)
-        self.include_buffer_pools = telemetry_params.get("node-stats-include-buffer-pools", True)
-        self.include_breakers = telemetry_params.get("node-stats-include-breakers", True)
+        self.include_thread_pools = telemetry_params.get(
+            "node-stats-include-thread-pools", True
+        )
+        self.include_buffer_pools = telemetry_params.get(
+            "node-stats-include-buffer-pools", True
+        )
+        self.include_breakers = telemetry_params.get(
+            "node-stats-include-breakers", True
+        )
         self.include_network = telemetry_params.get("node-stats-include-network", True)
         self.include_process = telemetry_params.get("node-stats-include-process", True)
         self.include_mem_stats = telemetry_params.get("node-stats-include-mem", True)
         self.include_gc_stats = telemetry_params.get("node-stats-include-gc", True)
-        self.include_indexing_pressure = telemetry_params.get("node-stats-include-indexing-pressure", True)
+        self.include_indexing_pressure = telemetry_params.get(
+            "node-stats-include-indexing-pressure", True
+        )
         self.client = client
         self.metrics_store = metrics_store
         self.cluster_name = cluster_name
@@ -693,20 +859,29 @@ class NodeStatsRecorder:
             node_name = node_stats["name"]
             metrics_store_meta_data = {
                 "cluster": self.cluster_name,
-                "node_name": node_name
+                "node_name": node_name,
             }
             collected_node_stats = collections.OrderedDict()
             collected_node_stats["name"] = "node-stats"
 
             if self.include_indices or self.include_indices_metrics:
                 collected_node_stats.update(
-                    self.indices_stats(node_name, node_stats, include=self.include_indices_metrics_list))
+                    self.indices_stats(
+                        node_name, node_stats, include=self.include_indices_metrics_list
+                    )
+                )
             if self.include_thread_pools:
-                collected_node_stats.update(self.thread_pool_stats(node_name, node_stats))
+                collected_node_stats.update(
+                    self.thread_pool_stats(node_name, node_stats)
+                )
             if self.include_breakers:
-                collected_node_stats.update(self.circuit_breaker_stats(node_name, node_stats))
+                collected_node_stats.update(
+                    self.circuit_breaker_stats(node_name, node_stats)
+                )
             if self.include_buffer_pools:
-                collected_node_stats.update(self.jvm_buffer_pool_stats(node_name, node_stats))
+                collected_node_stats.update(
+                    self.jvm_buffer_pool_stats(node_name, node_stats)
+                )
             if self.include_mem_stats:
                 collected_node_stats.update(self.jvm_mem_stats(node_name, node_stats))
             if self.include_gc_stats:
@@ -716,12 +891,16 @@ class NodeStatsRecorder:
             if self.include_process:
                 collected_node_stats.update(self.process_stats(node_name, node_stats))
             if self.include_indexing_pressure:
-                collected_node_stats.update(self.indexing_pressure(node_name, node_stats))
+                collected_node_stats.update(
+                    self.indexing_pressure(node_name, node_stats)
+                )
 
-            self.metrics_store.put_doc(dict(collected_node_stats),
-                                       level=MetaInfoScope.node,
-                                       node_name=node_name,
-                                       meta_data=metrics_store_meta_data)
+            self.metrics_store.put_doc(
+                dict(collected_node_stats),
+                level=MetaInfoScope.node,
+                node_name=node_name,
+                meta_data=metrics_store_meta_data,
+            )
 
     def flatten_stats_fields(self, prefix=None, stats=None):
         """
@@ -737,11 +916,17 @@ class NodeStatsRecorder:
                 if isinstance(section_value, dict):
                     new_prefix = "{}_{}".format(prefix, section_name)
                     # https://www.python.org/dev/peps/pep-0380/
-                    yield from self.flatten_stats_fields(prefix=new_prefix, stats=section_value).items()
+                    yield from self.flatten_stats_fields(
+                        prefix=new_prefix, stats=section_value
+                    ).items()
                 # Avoid duplication for metric fields that have unit embedded in value as they are also recorded elsewhere
                 # example: `breakers_parent_limit_size_in_bytes` vs `breakers_parent_limit_size`
-                elif isinstance(section_value, (int, float)) and not isinstance(section_value, bool):
-                    yield "{}{}".format(prefix + "_" if prefix else "", section_name), section_value
+                elif isinstance(section_value, (int, float)) and not isinstance(
+                    section_value, bool
+                ):
+                    yield "{}{}".format(
+                        prefix + "_" if prefix else "", section_name
+                    ), section_value
 
         if stats:
             return dict(iterate())
@@ -753,33 +938,51 @@ class NodeStatsRecorder:
         ordered_results = collections.OrderedDict()
         for section in include:
             if section in idx_stats:
-                ordered_results.update(self.flatten_stats_fields(prefix="indices_" + section, stats=idx_stats[section]))
+                ordered_results.update(
+                    self.flatten_stats_fields(
+                        prefix="indices_" + section, stats=idx_stats[section]
+                    )
+                )
 
         return ordered_results
 
     def thread_pool_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="thread_pool", stats=node_stats["thread_pool"])
+        return self.flatten_stats_fields(
+            prefix="thread_pool", stats=node_stats["thread_pool"]
+        )
 
     def circuit_breaker_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="breakers", stats=node_stats["breakers"])
+        return self.flatten_stats_fields(
+            prefix="breakers", stats=node_stats["breakers"]
+        )
 
     def jvm_buffer_pool_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="jvm_buffer_pools", stats=node_stats["jvm"]["buffer_pools"])
+        return self.flatten_stats_fields(
+            prefix="jvm_buffer_pools", stats=node_stats["jvm"]["buffer_pools"]
+        )
 
     def jvm_mem_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="jvm_mem", stats=node_stats["jvm"]["mem"])
+        return self.flatten_stats_fields(
+            prefix="jvm_mem", stats=node_stats["jvm"]["mem"]
+        )
 
     def jvm_gc_stats(self, node_name, node_stats):
         return self.flatten_stats_fields(prefix="jvm_gc", stats=node_stats["jvm"]["gc"])
 
     def network_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="transport", stats=node_stats.get("transport"))
+        return self.flatten_stats_fields(
+            prefix="transport", stats=node_stats.get("transport")
+        )
 
     def process_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="process_cpu", stats=node_stats["process"]["cpu"])
+        return self.flatten_stats_fields(
+            prefix="process_cpu", stats=node_stats["process"]["cpu"]
+        )
 
     def indexing_pressure(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="indexing_pressure", stats=node_stats["indexing_pressure"])
+        return self.flatten_stats_fields(
+            prefix="indexing_pressure", stats=node_stats["indexing_pressure"]
+        )
 
     def sample(self):
         try:
@@ -810,20 +1013,26 @@ class TransformStats(TelemetryDevice):
 
         self.telemetry_params = telemetry_params
         self.clients = clients
-        self.sample_interval = telemetry_params.get("transform-stats-sample-interval", 1)
+        self.sample_interval = telemetry_params.get(
+            "transform-stats-sample-interval", 1
+        )
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
                 f"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero "
-                f"but was [{self.sample_interval}].")
+                f"but was [{self.sample_interval}]."
+            )
         self.specified_cluster_names = self.clients.keys()
-        self.transforms_per_cluster = self.telemetry_params.get("transform-stats-transforms", False)
+        self.transforms_per_cluster = self.telemetry_params.get(
+            "transform-stats-transforms", False
+        )
         if self.transforms_per_cluster:
             for cluster_name in self.transforms_per_cluster.keys():
                 if cluster_name not in clients:
                     raise exceptions.SystemSetupError(
                         f"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys "
                         f"matching the cluster names [{','.join(sorted(clients.keys()))}] specified in --target-hosts "
-                        f"but it had [{cluster_name}].")
+                        f"but it had [{cluster_name}]."
+                    )
             self.specified_cluster_names = self.transforms_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -831,10 +1040,15 @@ class TransformStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         for cluster_name in self.specified_cluster_names:
-            recorder = TransformStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store,
-                                              self.sample_interval,
-                                              self.transforms_per_cluster[
-                                                  cluster_name] if self.transforms_per_cluster else None)
+            recorder = TransformStatsRecorder(
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+                self.sample_interval,
+                self.transforms_per_cluster[cluster_name]
+                if self.transforms_per_cluster
+                else None,
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -854,7 +1068,9 @@ class TransformStatsRecorder:
     Collects and pushes Transform stats for the specified cluster to the metric store.
     """
 
-    def __init__(self, cluster_name, client, metrics_store, sample_interval, transforms=None):
+    def __init__(
+        self, cluster_name, client, metrics_store, sample_interval, transforms=None
+    ):
         """
         :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
         :param client: The OpenSearch client for this cluster.
@@ -895,8 +1111,10 @@ class TransformStatsRecorder:
             stats = self.client.transform.get_transform_stats("_all")
 
         except opensearchpy.TransportError:
-            msg = f"A transport error occurred while collecting transform stats on " \
-                  f"cluster [{self.cluster_name}]"
+            msg = (
+                f"A transport error occurred while collecting transform stats on "
+                f"cluster [{self.cluster_name}]"
+            )
             self.logger.exception(msg)
             raise exceptions.BenchmarkError(msg)
 
@@ -906,7 +1124,9 @@ class TransformStatsRecorder:
                     # Skip metrics for transform not part of user supplied whitelist (transform-stats-transforms)
                     # in telemetry params.
                     continue
-                self.record_stats_per_transform(transform["id"], transform["stats"], prefix)
+                self.record_stats_per_transform(
+                    transform["id"], transform["stats"], prefix
+                )
 
             except KeyError:
                 self.logger.warning(
@@ -921,41 +1141,67 @@ class TransformStatsRecorder:
         :param prefix: A prefix for the counters/values, e.g. for total runtimes
         """
 
-        meta_data = {
-            "transform_id": transform_id
-        }
+        meta_data = {"transform_id": transform_id}
 
-        self.metrics_store.put_value_cluster_level(prefix + "transform_pages_processed",
-                                                   stats.get("pages_processed", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_documents_processed",
-                                                   stats.get("documents_processed", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_documents_indexed",
-                                                   stats.get("documents_indexed", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_index_total", stats.get("index_total", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_index_failures", stats.get("index_failures", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_search_total", stats.get("search_total", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_search_failures",
-                                                   stats.get("search_failures", 0),
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_processing_total",
-                                                   stats.get("processing_total", 0),
-                                                   meta_data=meta_data)
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_pages_processed",
+            stats.get("pages_processed", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_documents_processed",
+            stats.get("documents_processed", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_documents_indexed",
+            stats.get("documents_indexed", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_index_total",
+            stats.get("index_total", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_index_failures",
+            stats.get("index_failures", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_search_total",
+            stats.get("search_total", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_search_failures",
+            stats.get("search_failures", 0),
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_processing_total",
+            stats.get("processing_total", 0),
+            meta_data=meta_data,
+        )
 
-        self.metrics_store.put_value_cluster_level(prefix + "transform_search_time",
-                                                   stats.get("search_time_in_ms", 0),
-                                                   "ms", meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_index_time",
-                                                   stats.get("index_time_in_ms", 0), "ms",
-                                                   meta_data=meta_data)
-        self.metrics_store.put_value_cluster_level(prefix + "transform_processing_time",
-                                                   stats.get("processing_time_in_ms", 0), "ms",
-                                                   meta_data=meta_data)
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_search_time",
+            stats.get("search_time_in_ms", 0),
+            "ms",
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_index_time",
+            stats.get("index_time_in_ms", 0),
+            "ms",
+            meta_data=meta_data,
+        )
+        self.metrics_store.put_value_cluster_level(
+            prefix + "transform_processing_time",
+            stats.get("processing_time_in_ms", 0),
+            "ms",
+            meta_data=meta_data,
+        )
 
         documents_processed = stats.get("documents_processed", 0)
         processing_time = stats.get("search_time_in_ms", 0)
@@ -964,8 +1210,12 @@ class TransformStatsRecorder:
 
         if processing_time > 0:
             throughput = documents_processed / processing_time * 1000
-            self.metrics_store.put_value_cluster_level(prefix + "transform_throughput", throughput,
-                                                       "docs/s", meta_data=meta_data)
+            self.metrics_store.put_value_cluster_level(
+                prefix + "transform_throughput",
+                throughput,
+                "docs/s",
+                meta_data=meta_data,
+            )
 
 
 class SearchableSnapshotsStats(TelemetryDevice):
@@ -977,6 +1227,7 @@ class SearchableSnapshotsStats(TelemetryDevice):
     """
     Gathers searchable snapshots stats on a cluster level
     """
+
     def __init__(self, telemetry_params, clients, metrics_store):
         """
         :param telemetry_params: The configuration object for telemetry_params.
@@ -1016,13 +1267,18 @@ class SearchableSnapshotsStats(TelemetryDevice):
 
         self.telemetry_params = telemetry_params
         self.clients = clients
-        self.sample_interval = telemetry_params.get("searchable-snapshots-stats-sample-interval", 1)
+        self.sample_interval = telemetry_params.get(
+            "searchable-snapshots-stats-sample-interval", 1
+        )
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
                 f"The telemetry parameter 'searchable-snapshots-stats-sample-interval' must be greater than zero "
-                f"but was {self.sample_interval}.")
+                f"but was {self.sample_interval}."
+            )
         self.specified_cluster_names = self.clients.keys()
-        indices_per_cluster = self.telemetry_params.get("searchable-snapshots-stats-indices", None)
+        indices_per_cluster = self.telemetry_params.get(
+            "searchable-snapshots-stats-indices", None
+        )
         # allow the user to specify either an index pattern as string or as a JSON object
         if isinstance(indices_per_cluster, str):
             self.indices_per_cluster = {opts.TargetHosts.DEFAULT: [indices_per_cluster]}
@@ -1035,7 +1291,8 @@ class SearchableSnapshotsStats(TelemetryDevice):
                     raise exceptions.SystemSetupError(
                         f"The telemetry parameter 'searchable-snapshots-stats-indices' must be a JSON Object "
                         f"with keys matching the cluster names [{','.join(sorted(clients.keys()))}] specified in "
-                        f"--target-hosts but it had [{cluster_name}].")
+                        f"--target-hosts but it had [{cluster_name}]."
+                    )
             self.specified_cluster_names = self.indices_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -1044,8 +1301,14 @@ class SearchableSnapshotsStats(TelemetryDevice):
     def on_benchmark_start(self):
         for cluster_name in self.specified_cluster_names:
             recorder = SearchableSnapshotsStatsRecorder(
-                cluster_name, self.clients[cluster_name], self.metrics_store, self.sample_interval,
-                self.indices_per_cluster[cluster_name] if self.indices_per_cluster else None)
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+                self.sample_interval,
+                self.indices_per_cluster[cluster_name]
+                if self.indices_per_cluster
+                else None,
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -1063,7 +1326,9 @@ class SearchableSnapshotsStatsRecorder:
     Collects and pushes searchable snapshots stats for the specified cluster to the metric store.
     """
 
-    def __init__(self, cluster_name, client, metrics_store, sample_interval, indices=None):
+    def __init__(
+        self, cluster_name, client, metrics_store, sample_interval, indices=None
+    ):
         """
         :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
         :param client: The OpenSearch client for this cluster.
@@ -1092,18 +1357,25 @@ class SearchableSnapshotsStatsRecorder:
             level = "indices" if self.indices else "cluster"
             # we don't use the existing client support (searchable_snapshots.stats())
             # as the API is deliberately undocumented and might change:
-            stats = self.client.transport.perform_request("GET", stats_api_endpoint, params={"level": level})
+            stats = self.client.transport.perform_request(
+                "GET", stats_api_endpoint, params={"level": level}
+            )
         except opensearchpy.NotFoundError as e:
-            if "No searchable snapshots indices found" in e.info.get("error").get("reason"):
+            if "No searchable snapshots indices found" in e.info.get("error").get(
+                "reason"
+            ):
                 self.logger.info(
                     "Unable to find valid indices while collecting searchable snapshots stats "
-                    "on cluster [%s]", self.cluster_name)
+                    "on cluster [%s]",
+                    self.cluster_name,
+                )
                 # allow collection, indices might be mounted later on
                 return
         except opensearchpy.TransportError:
             raise exceptions.BenchmarkError(
                 f"A transport error occurred while collecting searchable snapshots stats on cluster "
-                f"[{self.cluster_name}]") from None
+                f"[{self.cluster_name}]"
+            ) from None
 
         total_stats = stats.get("total", [])
         for lucene_file_stats in total_stats:
@@ -1128,12 +1400,11 @@ class SearchableSnapshotsStatsRecorder:
         if index:
             doc["index"] = index
 
-        meta_data = {
-            "cluster": self.cluster_name,
-            "level": level
-        }
+        meta_data = {"cluster": self.cluster_name, "level": level}
 
-        self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=meta_data)
+        self.metrics_store.put_doc(
+            doc, level=MetaInfoScope.cluster, meta_data=meta_data
+        )
 
     # TODO Consider moving under the utils package for broader/future use?
     # at the moment it's only useful here as this stats API is undocumented and we don't wan't to use
@@ -1150,6 +1421,7 @@ class SearchableSnapshotsStatsRecorder:
                 return True
         return False
 
+
 class StartupTime(InternalTelemetryDevice):
     def __init__(self, stopwatch=time.StopWatch):
         super().__init__()
@@ -1162,13 +1434,16 @@ class StartupTime(InternalTelemetryDevice):
         self.timer.stop()
 
     def store_system_metrics(self, node, metrics_store):
-        metrics_store.put_value_node_level(node.node_name, "node_startup_time", self.timer.total_time(), "s")
+        metrics_store.put_value_node_level(
+            node.node_name, "node_startup_time", self.timer.total_time(), "s"
+        )
 
 
 class DiskIo(InternalTelemetryDevice):
     """
     Gathers disk I/O stats.
     """
+
     def __init__(self, node_count_on_host):
         super().__init__()
         self.node_count_on_host = node_count_on_host
@@ -1188,10 +1463,14 @@ class DiskIo(InternalTelemetryDevice):
                 disk_start = sysstats.disk_io_counters()
                 self.read_bytes = disk_start.read_bytes
                 self.write_bytes = disk_start.write_bytes
-                self.logger.warning("Process I/O counters are not supported on this platform. Falling back to less "
-                                    "accurate disk I/O counters.")
+                self.logger.warning(
+                    "Process I/O counters are not supported on this platform. Falling back to less "
+                    "accurate disk I/O counters."
+                )
             except BaseException:
-                self.logger.exception("Could not determine I/O stats at benchmark start.")
+                self.logger.exception(
+                    "Could not determine I/O stats at benchmark start."
+                )
 
     def detach_from_node(self, node, running):
         if running:
@@ -1208,12 +1487,20 @@ class DiskIo(InternalTelemetryDevice):
                 else:
                     disk_end = sysstats.disk_io_counters()
                     if self.node_count_on_host > 1:
-                        self.logger.info("There are [%d] nodes on this host and Benchmark fell back to disk I/O counters. "
-                                         "Attributing [1/%d] of total I/O to [%s].",
-                                         self.node_count_on_host, self.node_count_on_host, node.node_name)
+                        self.logger.info(
+                            "There are [%d] nodes on this host and Benchmark fell back to disk I/O counters. "
+                            "Attributing [1/%d] of total I/O to [%s].",
+                            self.node_count_on_host,
+                            self.node_count_on_host,
+                            node.node_name,
+                        )
 
-                    self.read_bytes = (disk_end.read_bytes - self.read_bytes) // self.node_count_on_host
-                    self.write_bytes = (disk_end.write_bytes - self.write_bytes) // self.node_count_on_host
+                    self.read_bytes = (
+                        disk_end.read_bytes - self.read_bytes
+                    ) // self.node_count_on_host
+                    self.write_bytes = (
+                        disk_end.write_bytes - self.write_bytes
+                    ) // self.node_count_on_host
             # Catching RuntimeException is not sufficient: psutil might raise AccessDenied (derived from Exception)
             except BaseException:
                 self.logger.exception("Could not determine I/O stats at benchmark end.")
@@ -1223,9 +1510,13 @@ class DiskIo(InternalTelemetryDevice):
 
     def store_system_metrics(self, node, metrics_store):
         if self.write_bytes is not None:
-            metrics_store.put_value_node_level(node.node_name, "disk_io_write_bytes", self.write_bytes, "byte")
+            metrics_store.put_value_node_level(
+                node.node_name, "disk_io_write_bytes", self.write_bytes, "byte"
+            )
         if self.read_bytes is not None:
-            metrics_store.put_value_node_level(node.node_name, "disk_io_read_bytes", self.read_bytes, "byte")
+            metrics_store.put_value_node_level(
+                node.node_name, "disk_io_read_bytes", self.read_bytes, "byte"
+            )
 
 
 def store_node_attribute_metadata(metrics_store, nodes_info):
@@ -1235,14 +1526,18 @@ def store_node_attribute_metadata(metrics_store, nodes_info):
         if "attributes" in node:
             for k, v in node["attributes"].items():
                 attribute_key = "attribute_%s" % str(k)
-                metrics_store.add_meta_info(metrics.MetaInfoScope.node, node["name"], attribute_key, v)
+                metrics_store.add_meta_info(
+                    metrics.MetaInfoScope.node, node["name"], attribute_key, v
+                )
                 if attribute_key not in pseudo_cluster_attributes:
                     pseudo_cluster_attributes[attribute_key] = set()
                 pseudo_cluster_attributes[attribute_key].add(v)
 
     for k, v in pseudo_cluster_attributes.items():
         if len(v) == 1:
-            metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, k, next(iter(v)))
+            metrics_store.add_meta_info(
+                metrics.MetaInfoScope.cluster, None, k, next(iter(v))
+            )
 
 
 def store_plugin_metadata(metrics_store, nodes_info):
@@ -1251,7 +1546,11 @@ def store_plugin_metadata(metrics_store, nodes_info):
     all_same = False
 
     for node in nodes_info:
-        plugins = [p["name"] for p in extract_value(node, ["plugins"], fallback=[]) if "name" in p]
+        plugins = [
+            p["name"]
+            for p in extract_value(node, ["plugins"], fallback=[])
+            if "name" in p
+        ]
         if not all_nodes_plugins:
             all_nodes_plugins = plugins.copy()
             all_same = True
@@ -1260,10 +1559,14 @@ def store_plugin_metadata(metrics_store, nodes_info):
             all_same = all_same and set(all_nodes_plugins) == set(plugins)
 
         if plugins:
-            metrics_store.add_meta_info(metrics.MetaInfoScope.node, node["name"], "plugins", plugins)
+            metrics_store.add_meta_info(
+                metrics.MetaInfoScope.node, node["name"], "plugins", plugins
+            )
 
     if all_same and all_nodes_plugins:
-        metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "plugins", all_nodes_plugins)
+        metrics_store.add_meta_info(
+            metrics.MetaInfoScope.cluster, None, "plugins", all_nodes_plugins
+        )
 
 
 def extract_value(node, path, fallback="unknown"):
@@ -1280,6 +1583,7 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
     """
     Gathers static environment information on a cluster level (e.g. version numbers).
     """
+
     def __init__(self, client, metrics_store):
         super().__init__()
         self.metrics_store = metrics_store
@@ -1296,9 +1600,21 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         distribution_version = client_info["version"]["number"]
         # older versions (pre 6.3.0) don't expose a build_flavor property because the only (implicit) flavor was "oss".
         distribution_flavor = client_info["version"].get("build_flavor", "oss")
-        self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", revision)
-        self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_version", distribution_version)
-        self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_flavor", distribution_flavor)
+        self.metrics_store.add_meta_info(
+            metrics.MetaInfoScope.cluster, None, "source_revision", revision
+        )
+        self.metrics_store.add_meta_info(
+            metrics.MetaInfoScope.cluster,
+            None,
+            "distribution_version",
+            distribution_version,
+        )
+        self.metrics_store.add_meta_info(
+            metrics.MetaInfoScope.cluster,
+            None,
+            "distribution_flavor",
+            distribution_flavor,
+        )
 
         info = self.client.nodes.info(node_id="_all")
         nodes_info = info["nodes"].values()
@@ -1307,8 +1623,18 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
             # while we could determine this for bare-metal nodes that are
             # provisioned by Benchmark, there are other cases (Docker, externally
             # provisioned clusters) where it's not that easy.
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_vendor", extract_value(node, ["jvm", "vm_vendor"]))
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_version", extract_value(node, ["jvm", "version"]))
+            self.metrics_store.add_meta_info(
+                metrics.MetaInfoScope.node,
+                node_name,
+                "jvm_vendor",
+                extract_value(node, ["jvm", "vm_vendor"]),
+            )
+            self.metrics_store.add_meta_info(
+                metrics.MetaInfoScope.node,
+                node_name,
+                "jvm_version",
+                extract_value(node, ["jvm", "version"]),
+            )
 
         store_plugin_metadata(self.metrics_store, nodes_info)
         store_node_attribute_metadata(self.metrics_store, nodes_info)
@@ -1318,19 +1644,40 @@ def add_metadata_for_node(metrics_store, node_name, host_name):
     """
     Gathers static environment information like OS or CPU details for benchmark-provisioned nodes.
     """
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "os_name", sysstats.os_name())
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "os_version", sysstats.os_version())
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "cpu_logical_cores", sysstats.logical_cpu_cores())
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "cpu_physical_cores", sysstats.physical_cpu_cores())
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "cpu_model", sysstats.cpu_model())
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "node_name", node_name)
-    metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "host_name", host_name)
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node, node_name, "os_name", sysstats.os_name()
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node, node_name, "os_version", sysstats.os_version()
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node,
+        node_name,
+        "cpu_logical_cores",
+        sysstats.logical_cpu_cores(),
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node,
+        node_name,
+        "cpu_physical_cores",
+        sysstats.physical_cpu_cores(),
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node, node_name, "cpu_model", sysstats.cpu_model()
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node, node_name, "node_name", node_name
+    )
+    metrics_store.add_meta_info(
+        metrics.MetaInfoScope.node, node_name, "host_name", host_name
+    )
 
 
 class ExternalEnvironmentInfo(InternalTelemetryDevice):
     """
     Gathers static environment information for externally provisioned clusters.
     """
+
     def __init__(self, client, metrics_store):
         super().__init__()
         self.metrics_store = metrics_store
@@ -1352,14 +1699,20 @@ class ExternalEnvironmentInfo(InternalTelemetryDevice):
         for node in nodes_stats:
             node_name = node["name"]
             host = node.get("host", "unknown")
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "node_name", node_name)
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "host_name", host)
+            self.metrics_store.add_meta_info(
+                metrics.MetaInfoScope.node, node_name, "node_name", node_name
+            )
+            self.metrics_store.add_meta_info(
+                metrics.MetaInfoScope.node, node_name, "host_name", host
+            )
 
         for node in nodes_info:
             node_name = node["name"]
             self.store_node_info(node_name, "os_name", node, ["os", "name"])
             self.store_node_info(node_name, "os_version", node, ["os", "version"])
-            self.store_node_info(node_name, "cpu_logical_cores", node, ["os", "available_processors"])
+            self.store_node_info(
+                node_name, "cpu_logical_cores", node, ["os", "available_processors"]
+            )
             self.store_node_info(node_name, "jvm_vendor", node, ["jvm", "vm_vendor"])
             self.store_node_info(node_name, "jvm_version", node, ["jvm", "version"])
 
@@ -1367,13 +1720,16 @@ class ExternalEnvironmentInfo(InternalTelemetryDevice):
         store_node_attribute_metadata(self.metrics_store, nodes_info)
 
     def store_node_info(self, node_name, metric_key, node, path):
-        self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, metric_key, extract_value(node, path))
+        self.metrics_store.add_meta_info(
+            metrics.MetaInfoScope.node, node_name, metric_key, extract_value(node, path)
+        )
 
 
 class JvmStatsSummary(InternalTelemetryDevice):
     """
     Gathers a summary of various JVM statistics during the whole test execution.
     """
+
     def __init__(self, client, metrics_store):
         super().__init__()
         self.metrics_store = metrics_store
@@ -1394,38 +1750,66 @@ class JvmStatsSummary(InternalTelemetryDevice):
         for node_name, jvm_stats_end in jvm_stats_at_end.items():
             if node_name in self.jvm_stats_per_node:
                 jvm_stats_start = self.jvm_stats_per_node[node_name]
-                young_gc_time = max(jvm_stats_end["young_gc_time"] - jvm_stats_start["young_gc_time"], 0)
-                young_gc_count = max(jvm_stats_end["young_gc_count"] - jvm_stats_start["young_gc_count"], 0)
-                old_gc_time = max(jvm_stats_end["old_gc_time"] - jvm_stats_start["old_gc_time"], 0)
-                old_gc_count = max(jvm_stats_end["old_gc_count"] - jvm_stats_start["old_gc_count"], 0)
+                young_gc_time = max(
+                    jvm_stats_end["young_gc_time"] - jvm_stats_start["young_gc_time"], 0
+                )
+                young_gc_count = max(
+                    jvm_stats_end["young_gc_count"] - jvm_stats_start["young_gc_count"],
+                    0,
+                )
+                old_gc_time = max(
+                    jvm_stats_end["old_gc_time"] - jvm_stats_start["old_gc_time"], 0
+                )
+                old_gc_count = max(
+                    jvm_stats_end["old_gc_count"] - jvm_stats_start["old_gc_count"], 0
+                )
 
                 total_young_gen_collection_time += young_gc_time
                 total_young_gen_collection_count += young_gc_count
                 total_old_gen_collection_time += old_gc_time
                 total_old_gen_collection_count += old_gc_count
 
-                self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_time", young_gc_time, "ms")
-                self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_count", young_gc_count)
-                self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_time", old_gc_time, "ms")
-                self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_count", old_gc_count)
+                self.metrics_store.put_value_node_level(
+                    node_name, "node_young_gen_gc_time", young_gc_time, "ms"
+                )
+                self.metrics_store.put_value_node_level(
+                    node_name, "node_young_gen_gc_count", young_gc_count
+                )
+                self.metrics_store.put_value_node_level(
+                    node_name, "node_old_gen_gc_time", old_gc_time, "ms"
+                )
+                self.metrics_store.put_value_node_level(
+                    node_name, "node_old_gen_gc_count", old_gc_count
+                )
 
-                all_pool_stats = {
-                    "name": "jvm_memory_pool_stats"
-                }
+                all_pool_stats = {"name": "jvm_memory_pool_stats"}
                 for pool_name, pool_stats in jvm_stats_end["pools"].items():
                     all_pool_stats[pool_name] = {
                         "peak_usage": pool_stats["peak"],
-                        "unit": "byte"
+                        "unit": "byte",
                     }
-                self.metrics_store.put_doc(all_pool_stats, level=MetaInfoScope.node, node_name=node_name)
+                self.metrics_store.put_doc(
+                    all_pool_stats, level=MetaInfoScope.node, node_name=node_name
+                )
 
             else:
-                self.logger.warning("Cannot determine JVM stats for [%s] (not in the cluster at the start of the benchmark).", node_name)
+                self.logger.warning(
+                    "Cannot determine JVM stats for [%s] (not in the cluster at the start of the benchmark).",
+                    node_name,
+                )
 
-        self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_time", total_young_gen_collection_time, "ms")
-        self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_count", total_young_gen_collection_count)
-        self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_time", total_old_gen_collection_time, "ms")
-        self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_count", total_old_gen_collection_count)
+        self.metrics_store.put_value_cluster_level(
+            "node_total_young_gen_gc_time", total_young_gen_collection_time, "ms"
+        )
+        self.metrics_store.put_value_cluster_level(
+            "node_total_young_gen_gc_count", total_young_gen_collection_count
+        )
+        self.metrics_store.put_value_cluster_level(
+            "node_total_old_gen_gc_time", total_old_gen_collection_time, "ms"
+        )
+        self.metrics_store.put_value_cluster_level(
+            "node_total_old_gen_gc_count", total_old_gen_collection_count
+        )
 
         self.jvm_stats_per_node = None
 
@@ -1450,7 +1834,7 @@ class JvmStatsSummary(InternalTelemetryDevice):
                 "young_gc_count": young_gen_collection_count,
                 "old_gc_time": old_gen_collection_time,
                 "old_gc_count": old_gen_collection_count,
-                "pools": {}
+                "pools": {},
             }
             pool_usage = node["jvm"]["mem"]["pools"]
             for pool_name, pool_stats in pool_usage.items():
@@ -1464,6 +1848,7 @@ class IndexStats(InternalTelemetryDevice):
     """
     Gathers statistics via the OpenSearch index stats API
     """
+
     def __init__(self, client, metrics_store):
         super().__init__()
         self.client = client
@@ -1479,9 +1864,14 @@ class IndexStats(InternalTelemetryDevice):
                 n = t["name"]
                 v = t["value"]
                 if t["value"] > 0:
-                    console.warn("%s is %d ms indicating that the cluster is not in a defined clean state. Recorded index time "
-                                 "metrics may be misleading." % (n, v), logger=self.logger)
+                    console.warn(
+                        "%s is %d ms indicating that the cluster is not in a defined clean state. Recorded index time "
+                        "metrics may be misleading." % (n, v),
+                        logger=self.logger,
+                    )
             self.first_time = False
+        console.println("")
+        
 
     def on_benchmark_stop(self):
         self.logger.info("Gathering indices stats for all primaries on benchmark stop.")
@@ -1493,7 +1883,11 @@ class IndexStats(InternalTelemetryDevice):
         p = index_stats["_all"]["primaries"]
         # actually this is add_count
         self.add_metrics(self.extract_value(p, ["segments", "count"]), "segments_count")
-        self.add_metrics(self.extract_value(p, ["segments", "memory_in_bytes"]), "segments_memory_in_bytes", "byte")
+        self.add_metrics(
+            self.extract_value(p, ["segments", "memory_in_bytes"]),
+            "segments_memory_in_bytes",
+            "byte",
+        )
 
         for t in self.index_times(index_stats):
             self.metrics_store.put_doc(doc=t, level=metrics.MetaInfoScope.cluster)
@@ -1501,14 +1895,45 @@ class IndexStats(InternalTelemetryDevice):
         for ct in self.index_counts(index_stats):
             self.metrics_store.put_doc(doc=ct, level=metrics.MetaInfoScope.cluster)
 
-        self.add_metrics(self.extract_value(p, ["segments", "doc_values_memory_in_bytes"]), "segments_doc_values_memory_in_bytes", "byte")
-        self.add_metrics(self.extract_value(p, ["segments", "stored_fields_memory_in_bytes"]), "segments_stored_fields_memory_in_bytes",
-                                            "byte")
-        self.add_metrics(self.extract_value(p, ["segments", "terms_memory_in_bytes"]), "segments_terms_memory_in_bytes", "byte")
-        self.add_metrics(self.extract_value(p, ["segments", "norms_memory_in_bytes"]), "segments_norms_memory_in_bytes", "byte")
-        self.add_metrics(self.extract_value(p, ["segments", "points_memory_in_bytes"]), "segments_points_memory_in_bytes", "byte")
-        self.add_metrics(self.extract_value(index_stats, ["_all", "total", "store", "size_in_bytes"]), "store_size_in_bytes", "byte")
-        self.add_metrics(self.extract_value(index_stats, ["_all", "total", "translog", "size_in_bytes"]), "translog_size_in_bytes", "byte")
+        self.add_metrics(
+            self.extract_value(p, ["segments", "doc_values_memory_in_bytes"]),
+            "segments_doc_values_memory_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(p, ["segments", "stored_fields_memory_in_bytes"]),
+            "segments_stored_fields_memory_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(p, ["segments", "terms_memory_in_bytes"]),
+            "segments_terms_memory_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(p, ["segments", "norms_memory_in_bytes"]),
+            "segments_norms_memory_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(p, ["segments", "points_memory_in_bytes"]),
+            "segments_points_memory_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(
+                index_stats, ["_all", "total", "store", "size_in_bytes"]
+            ),
+            "store_size_in_bytes",
+            "byte",
+        )
+        self.add_metrics(
+            self.extract_value(
+                index_stats, ["_all", "total", "translog", "size_in_bytes"]
+            ),
+            "translog_size_in_bytes",
+            "byte",
+        )
 
     def index_stats(self):
         # noinspection PyBroadException
@@ -1520,16 +1945,54 @@ class IndexStats(InternalTelemetryDevice):
 
     def index_times(self, stats, per_shard_stats=True):
         times = []
-        self.index_time(times, stats, "merges_total_time", ["merges", "total_time_in_millis"], per_shard_stats)
-        self.index_time(times, stats, "merges_total_throttled_time", ["merges", "total_throttled_time_in_millis"], per_shard_stats)
-        self.index_time(times, stats, "indexing_total_time", ["indexing", "index_time_in_millis"], per_shard_stats)
-        self.index_time(times, stats, "indexing_throttle_time", ["indexing", "throttle_time_in_millis"], per_shard_stats)
-        self.index_time(times, stats, "refresh_total_time", ["refresh", "total_time_in_millis"], per_shard_stats)
-        self.index_time(times, stats, "flush_total_time", ["flush", "total_time_in_millis"], per_shard_stats)
+        self.index_time(
+            times,
+            stats,
+            "merges_total_time",
+            ["merges", "total_time_in_millis"],
+            per_shard_stats,
+        )
+        self.index_time(
+            times,
+            stats,
+            "merges_total_throttled_time",
+            ["merges", "total_throttled_time_in_millis"],
+            per_shard_stats,
+        )
+        self.index_time(
+            times,
+            stats,
+            "indexing_total_time",
+            ["indexing", "index_time_in_millis"],
+            per_shard_stats,
+        )
+        self.index_time(
+            times,
+            stats,
+            "indexing_throttle_time",
+            ["indexing", "throttle_time_in_millis"],
+            per_shard_stats,
+        )
+        self.index_time(
+            times,
+            stats,
+            "refresh_total_time",
+            ["refresh", "total_time_in_millis"],
+            per_shard_stats,
+        )
+        self.index_time(
+            times,
+            stats,
+            "flush_total_time",
+            ["flush", "total_time_in_millis"],
+            per_shard_stats,
+        )
         return times
 
     def index_time(self, values, stats, name, path, per_shard_stats):
-        primary_total_stats = self.extract_value(stats, ["_all", "primaries"], default_value={})
+        primary_total_stats = self.extract_value(
+            stats, ["_all", "primaries"], default_value={}
+        )
         value = self.extract_value(primary_total_stats, path)
         if value is not None:
             doc = {
@@ -1549,13 +2012,12 @@ class IndexStats(InternalTelemetryDevice):
         return counts
 
     def index_count(self, values, stats, name, path):
-        primary_total_stats = self.extract_value(stats, ["_all", "primaries"], default_value={})
+        primary_total_stats = self.extract_value(
+            stats, ["_all", "primaries"], default_value={}
+        )
         value = self.extract_value(primary_total_stats, path)
         if value is not None:
-            doc = {
-                "name": name,
-                "value": value
-            }
+            doc = {"name": name, "value": value}
             values.append(doc)
 
     def primary_shard_stats(self, stats, path):
@@ -1565,9 +2027,13 @@ class IndexStats(InternalTelemetryDevice):
                 for shard in shards["shards"].values():
                     for shard_metrics in shard:
                         if shard_metrics["routing"]["primary"]:
-                            shard_stats.append(self.extract_value(shard_metrics, path, default_value=0))
+                            shard_stats.append(
+                                self.extract_value(shard_metrics, path, default_value=0)
+                            )
         except KeyError:
-            self.logger.warning("Could not determine primary shard stats at path [%s].", ",".join(path))
+            self.logger.warning(
+                "Could not determine primary shard stats at path [%s].", ",".join(path)
+            )
         return shard_stats
 
     def add_metrics(self, value, metric_key, unit=None):
@@ -1584,7 +2050,11 @@ class IndexStats(InternalTelemetryDevice):
                 value = value[k]
             return value
         except KeyError:
-            self.logger.warning("Could not determine value at path [%s]. Returning default value [%s]", ",".join(path), str(default_value))
+            self.logger.warning(
+                "Could not determine value at path [%s]. Returning default value [%s]",
+                ",".join(path),
+                str(default_value),
+            )
             return default_value
 
 
@@ -1596,37 +2066,29 @@ class MlBucketProcessingTime(InternalTelemetryDevice):
 
     def on_benchmark_stop(self):
         try:
-            results = self.client.search(index=".ml-anomalies-*", body={
-                "size": 0,
-                "query": {
-                    "bool": {
-                        "must": [
-                            {"term": {"result_type": "bucket"}}
-                        ]
-                    }
-                },
-                "aggs": {
-                    "jobs": {
-                        "terms": {
-                            "field": "job_id"
-                        },
-                        "aggs": {
-                            "min_pt": {
-                                "min": {"field": "processing_time_ms"}
+            results = self.client.search(
+                index=".ml-anomalies-*",
+                body={
+                    "size": 0,
+                    "query": {"bool": {"must": [{"term": {"result_type": "bucket"}}]}},
+                    "aggs": {
+                        "jobs": {
+                            "terms": {"field": "job_id"},
+                            "aggs": {
+                                "min_pt": {"min": {"field": "processing_time_ms"}},
+                                "max_pt": {"max": {"field": "processing_time_ms"}},
+                                "mean_pt": {"avg": {"field": "processing_time_ms"}},
+                                "median_pt": {
+                                    "percentiles": {
+                                        "field": "processing_time_ms",
+                                        "percents": [50],
+                                    }
+                                },
                             },
-                            "max_pt": {
-                                "max": {"field": "processing_time_ms"}
-                            },
-                            "mean_pt": {
-                                "avg": {"field": "processing_time_ms"}
-                            },
-                            "median_pt": {
-                                "percentiles": {"field": "processing_time_ms", "percents": [50]}
-                            }
                         }
-                    }
-                }
-            })
+                    },
+                },
+            )
         except opensearchpy.TransportError:
             self.logger.exception("Could not retrieve ML bucket processing time.")
             return
@@ -1640,7 +2102,9 @@ class MlBucketProcessingTime(InternalTelemetryDevice):
                 ml_job_stats["median"] = job["median_pt"]["values"]["50.0"]
                 ml_job_stats["max"] = job["max_pt"]["value"]
                 ml_job_stats["unit"] = "ms"
-                self.metrics_store.put_doc(doc=dict(ml_job_stats), level=MetaInfoScope.cluster)
+                self.metrics_store.put_doc(
+                    doc=dict(ml_job_stats), level=MetaInfoScope.cluster
+                )
         except KeyError:
             # no ML running
             pass
@@ -1650,6 +2114,7 @@ class IndexSize(InternalTelemetryDevice):
     """
     Measures the final size of the index
     """
+
     def __init__(self, data_paths):
         super().__init__()
         self.data_paths = data_paths
@@ -1670,7 +2135,10 @@ class IndexSize(InternalTelemetryDevice):
 
     def store_system_metrics(self, node, metrics_store):
         if self.index_size_bytes:
-            metrics_store.put_value_node_level(node.node_name, "final_index_size_bytes", self.index_size_bytes, "byte")
+            metrics_store.put_value_node_level(
+                node.node_name, "final_index_size_bytes", self.index_size_bytes, "byte"
+            )
+
 
 class SegmentReplicationStats(TelemetryDevice):
     internal = False
@@ -1712,13 +2180,18 @@ class SegmentReplicationStats(TelemetryDevice):
 
         self.telemetry_params = telemetry_params
         self.clients = clients
-        self.sample_interval = telemetry_params.get("segment-replication-stats-sample-interval", 1)
+        self.sample_interval = telemetry_params.get(
+            "segment-replication-stats-sample-interval", 1
+        )
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
                 f"The telemetry parameter 'segment-replication-stats-sample-interval' must be greater than zero "
-                f"but was [{self.sample_interval}].")
+                f"but was [{self.sample_interval}]."
+            )
         self.specified_cluster_names = self.clients.keys()
-        indices_per_cluster = self.telemetry_params.get("segment-replication-stats-indices", None)
+        indices_per_cluster = self.telemetry_params.get(
+            "segment-replication-stats-indices", None
+        )
         # allow the user to specify either an index pattern as string or as a JSON object
         if isinstance(indices_per_cluster, str):
             self.indices_per_cluster = {opts.TargetHosts.DEFAULT: [indices_per_cluster]}
@@ -1731,7 +2204,8 @@ class SegmentReplicationStats(TelemetryDevice):
                     raise exceptions.SystemSetupError(
                         f"The telemetry parameter 'segment-replication-stats-indices' must be a JSON Object with keys "
                         f"matching the cluster names [{','.join(sorted(clients.keys()))}] specified in --target-hosts "
-                        f"but it had [{cluster_name}].")
+                        f"but it had [{cluster_name}]."
+                    )
             self.specified_cluster_names = self.indices_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -1740,8 +2214,14 @@ class SegmentReplicationStats(TelemetryDevice):
     def on_benchmark_start(self):
         for cluster_name in self.specified_cluster_names:
             recorder = SegmentReplicationStatsRecorder(
-                cluster_name, self.clients[cluster_name], self.metrics_store, self.sample_interval,
-                self.indices_per_cluster[cluster_name] if self.indices_per_cluster else None)
+                cluster_name,
+                self.clients[cluster_name],
+                self.metrics_store,
+                self.sample_interval,
+                self.indices_per_cluster[cluster_name]
+                if self.indices_per_cluster
+                else None,
+            )
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.setDaemon(True)
@@ -1753,12 +2233,15 @@ class SegmentReplicationStats(TelemetryDevice):
             for sampler in self.samplers:
                 sampler.finish()
 
+
 class SegmentReplicationStatsRecorder:
     """
     Collects and pushes segment replication stats for the specified cluster to the metric store.
     """
 
-    def __init__(self, cluster_name, client, metrics_store, sample_interval, indices=None):
+    def __init__(
+        self, cluster_name, client, metrics_store, sample_interval, indices=None
+    ):
         """
         :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
         :param client: The OpenSearch client for this cluster.
@@ -1789,18 +2272,21 @@ class SegmentReplicationStatsRecorder:
             try:
                 stats_api_endpoint = "/_cat/segment_replication/"
                 stats = self.client.transport.perform_request(
-                    "GET", stats_api_endpoint + index, params={"time": "ms", "bytes": "b", "format": "JSON"})
+                    "GET",
+                    stats_api_endpoint + index,
+                    params={"time": "ms", "bytes": "b", "format": "JSON"},
+                )
             except opensearchpy.TransportError:
                 raise exceptions.BenchmarkError(
                     f"A transport error occurred while collecting segment replication stats on cluster "
-                    f"[{self.cluster_name}]") from None
+                    f"[{self.cluster_name}]"
+                ) from None
 
             # parse the REST API response, each element in the list is a shard
             for shard_stats in stats:
                 self._push_stats(stats=shard_stats, index=index)
 
     def _push_stats(self, stats, index=None):
-
         doc = {
             "name": "segment-replication-stats",
             "shard_id": stats["shardId"],
@@ -1810,12 +2296,11 @@ class SegmentReplicationStatsRecorder:
             "bytes_behind": int(stats["bytes_behind"]),
             "current_lag_in_millis": int(stats["current_lag"]),
             "last_completed_lag_in_millis": int(stats["last_completed_lag"]),
-            "rejected_requests": int(stats["rejected_requests"])
+            "rejected_requests": int(stats["rejected_requests"]),
         }
 
-        meta_data = {
-            "cluster": self.cluster_name,
-            "index": index
-        }
+        meta_data = {"cluster": self.cluster_name, "index": index}
 
-        self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=meta_data)
+        self.metrics_store.put_doc(
+            doc, level=MetaInfoScope.cluster, meta_data=meta_data
+        )

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -13,7 +13,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -41,6 +41,7 @@ class FileSource:
     """
     FileSource is a wrapper around a plain file which simplifies testing of file I/O calls.
     """
+
     def __init__(self, file_name, mode, encoding="utf-8"):
         self.file_name = file_name
         self.mode = mode
@@ -91,6 +92,7 @@ class MmapSource:
     """
     MmapSource is a wrapper around a memory-mapped file which simplifies testing of file I/O calls.
     """
+
     def __init__(self, file_name, mode, encoding="utf-8"):
         self.file_name = file_name
         self.mode = mode
@@ -151,6 +153,7 @@ class DictStringFileSourceFactory:
 
     It is intended for scenarios where multiple files may be read by client code.
     """
+
     def __init__(self, name_to_contents):
         self.name_to_contents = name_to_contents
 
@@ -163,6 +166,7 @@ class StringAsFileSource:
     Implementation of ``FileSource`` intended for tests. It's kept close to ``FileSource`` to simplify maintenance but it is not meant to
      be used in production code.
     """
+
     def __init__(self, contents, mode, encoding="utf-8"):
         """
         :param contents: The file contents as an array of strings. Each item in the array should correspond to one line.
@@ -240,7 +244,10 @@ def _zipdir(source_directory, archive):
         for file in files:
             archive.write(
                 filename=os.path.join(root, file),
-                arcname=os.path.relpath(os.path.join(root, file), os.path.join(source_directory, "..")))
+                arcname=os.path.relpath(
+                    os.path.join(root, file), os.path.join(source_directory, "..")
+                ),
+            )
 
 
 def is_archive(name):
@@ -296,38 +303,66 @@ def decompress(zip_name, target_directory):
     elif extension == ".bz2":
         decompressor_args = ["pbzip2", "-d", "-k", "-m10000", "-c"]
         decompressor_lib = bz2.open
-        _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
+        _do_decompress_manually(
+            target_directory, zip_name, decompressor_args, decompressor_lib
+        )
     elif extension == ".gz":
         decompressor_args = ["pigz", "-d", "-k", "-c"]
         decompressor_lib = gzip.open
-        _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
+        _do_decompress_manually(
+            target_directory, zip_name, decompressor_args, decompressor_lib
+        )
     elif extension in [".tar", ".tar.gz", ".tgz", ".tar.bz2"]:
         _do_decompress(target_directory, tarfile.open(zip_name))
     else:
-        raise RuntimeError("Unsupported file extension [%s]. Cannot decompress [%s]" % (extension, zip_name))
+        raise RuntimeError(
+            "Unsupported file extension [%s]. Cannot decompress [%s]"
+            % (extension, zip_name)
+        )
 
 
-def _do_decompress_manually(target_directory, filename, decompressor_args, decompressor_lib):
+def _do_decompress_manually(
+    target_directory, filename, decompressor_args, decompressor_lib
+):
     decompressor_bin = decompressor_args[0]
     base_path_without_extension = basename(splitext(filename)[0])
 
     if is_executable(decompressor_bin):
-        if _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
+        if _do_decompress_manually_external(
+            target_directory, filename, base_path_without_extension, decompressor_args
+        ):
             return
     else:
-        logging.getLogger(__name__).warning("%s not found in PATH. Using standard library, decompression will take longer.",
-                                            decompressor_bin)
+        logging.getLogger(__name__).warning(
+            "%s not found in PATH. Using standard library, decompression will take longer.",
+            decompressor_bin,
+        )
 
-    _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
+    _do_decompress_manually_with_lib(
+        target_directory, filename, decompressor_lib(filename)
+    )
 
 
-def _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
-    with open(os.path.join(target_directory, base_path_without_extension), "wb") as new_file:
+def _do_decompress_manually_external(
+    target_directory, filename, base_path_without_extension, decompressor_args
+):
+    with open(
+        os.path.join(target_directory, base_path_without_extension), "wb"
+    ) as new_file:
         try:
-            subprocess.run(decompressor_args + [filename], stdout=new_file, stderr=subprocess.PIPE, check=True)
+            subprocess.run(
+                decompressor_args + [filename],
+                stdout=new_file,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
         except subprocess.CalledProcessError as err:
-            logging.getLogger(__name__).warning("Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library.",
-                                                filename, err.cmd, err.stderr)
+            logging.getLogger(__name__).warning(
+                "Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library.",
+                filename,
+                err.cmd,
+                err.stderr,
+            )
             return False
     return True
 
@@ -337,7 +372,9 @@ def _do_decompress_manually_with_lib(target_directory, filename, compressed_file
 
     ensure_dir(target_directory)
     try:
-        with open(os.path.join(target_directory, path_without_extension), "wb") as new_file:
+        with open(
+            os.path.join(target_directory, path_without_extension), "wb"
+        ) as new_file:
             for data in iter(lambda: compressed_file.read(100 * 1024), b""):
                 new_file.write(data)
     finally:
@@ -348,7 +385,9 @@ def _do_decompress(target_directory, compressed_file):
     try:
         compressed_file.extractall(path=target_directory)
     except BaseException:
-        raise RuntimeError("Could not decompress provided archive [%s]" % compressed_file.filename)
+        raise RuntimeError(
+            "Could not decompress provided archive [%s]" % compressed_file.filename
+        )
     finally:
         compressed_file.close()
 
@@ -422,6 +461,7 @@ class FileOffsetTable:
     The FileOffsetTable represents a persistent mapping from lines in a data file to their offset in bytes in the
     data file. This helps bulk-indexing clients to advance quickly to a certain position in a large data file.
     """
+
     def __init__(self, data_file_path, offset_table_path, mode):
         """
         Creates a new FileOffsetTable instance. The constructor should not be called directly but instead the
@@ -447,7 +487,9 @@ class FileOffsetTable:
         """
         :return: True iff the file offset table exists and it is up-to-date.
         """
-        return self.exists() and os.path.getmtime(self.offset_table_path) >= os.path.getmtime(self.data_file_path)
+        return self.exists() and os.path.getmtime(
+            self.offset_table_path
+        ) >= os.path.getmtime(self.data_file_path)
 
     def __enter__(self):
         self.offset_file = open(self.offset_table_path, self.mode)
@@ -530,7 +572,11 @@ def prepare_file_offset_table(data_file_path):
     """
     file_offset_table = FileOffsetTable.create_for_data_file(data_file_path)
     if not file_offset_table.is_valid():
-        console.info("Preparing file offset table for [%s] ... " % data_file_path, end="", flush=True)
+        console.info(
+            "Preparing file offset table for [%s] ... " % data_file_path,
+            end="\n",
+            flush=True,
+        )
         line_number = 0
         with file_offset_table:
             with open(data_file_path, mode="rt", encoding="utf-8") as data_file:
@@ -541,7 +587,7 @@ def prepare_file_offset_table(data_file_path):
                     line_number += 1
                     if line_number % 50000 == 0:
                         file_offset_table.add_offset(line_number, data_file.tell())
-        console.println("[OK]")
+        console.print("[OK]")
         return line_number
     else:
         return None
@@ -572,7 +618,9 @@ def skip_lines(data_file_path, data_file, number_of_lines_to_skip):
     # can we fast forward?
     if file_offset_table.exists():
         with file_offset_table:
-            offset, remaining_lines = file_offset_table.find_closest_offset(number_of_lines_to_skip)
+            offset, remaining_lines = file_offset_table.find_closest_offset(
+                number_of_lines_to_skip
+            )
     else:
         offset = 0
         remaining_lines = number_of_lines_to_skip

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -92,6 +92,8 @@ install_requires = [
     "google-auth==1.22.1",
     # License: MIT
     "wheel==0.38.4",
+    # License: MIT
+    "tqdm==4.66.1",
     # License: Apache 2.0
     # transitive dependencies:
     #   botocore: Apache 2.0
@@ -104,7 +106,7 @@ tests_require = [
     "ujson",
     "pytest==7.2.2",
     "pytest-benchmark==3.2.2",
-    "pytest-asyncio==0.14.0"
+    "pytest-asyncio==0.14.0",
 ]
 
 # These packages are only required when developing Benchmark
@@ -115,65 +117,71 @@ develop_require = [
     "wheel==0.38.4",
     "github3.py==1.3.0",
     "pylint==2.6.0",
-    "pylint-quotes==0.2.1"
+    "pylint-quotes==0.2.1",
 ]
 
-python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor)
-                              for major, minor in supported_python_versions]
+python_version_classifiers = [
+    "Programming Language :: Python :: {}.{}".format(major, minor)
+    for major, minor in supported_python_versions
+]
 
-first_supported_version = "{}.{}".format(supported_python_versions[0][0], supported_python_versions[0][1])
+first_supported_version = "{}.{}".format(
+    supported_python_versions[0][0], supported_python_versions[0][1]
+)
 # next minor after the latest supported version
-first_unsupported_version = "{}.{}".format(supported_python_versions[-1][0], supported_python_versions[-1][1] + 1)
+first_unsupported_version = "{}.{}".format(
+    supported_python_versions[-1][0], supported_python_versions[-1][1] + 1
+)
 
-setup(name="opensearch-benchmark",
-      maintainer="Ian Hoang, Govind Kamat",
-      maintainer_email="hoangia@amazon.com, govkamat@amazon.com",
-      version=__versionstr__,
-      description="Macrobenchmarking framework for OpenSearch",
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url="https://github.com/opensearch-project/OpenSearch-Benchmark",
-      license="Apache License, Version 2.0",
-      packages=find_packages(
-          where=".",
-          exclude=("tests*", "benchmarks*", "it*")
-      ),
-      include_package_data=True,
-      # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Benchmark on an unsupported
-      # Python version.
-      # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-      #
-      # According to https://www.python.org/dev/peps/pep-0440/#version-matching, a trailing ".*" should
-      # ignore patch versions:
-      #
-      # "additional trailing segments will be ignored when determining whether or not a version identifier matches
-      # the clause"
-      #
-      # However, with the pattern ">=3.5.*,<=3.8.*", the version "3.8.0" is not accepted. Therefore, we match
-      # the minor version after the last supported one (i.e. if 3.8 is the last supported, we'll emit "<3.9")
-      python_requires=">={},<{}".format(first_supported_version, first_unsupported_version),
-      package_data={"": ["*.json", "*.yml"]},
-      install_requires=install_requires,
-      test_suite="tests",
-      tests_require=tests_require,
-      extras_require={
-          "develop": tests_require + develop_require
-      },
-      entry_points={
-          "console_scripts": [
-              "opensearch-benchmark=osbenchmark.benchmark:main",
-              "opensearch-benchmarkd=osbenchmark.benchmarkd:main"
-          ],
-      },
-      scripts=['scripts/expand-data-corpus.py'],
-      classifiers=[
-          "Topic :: System :: Benchmark",
-          "Development Status :: 5 - Production/Stable",
-          "License :: OSI Approved :: Apache Software License",
-          "Intended Audience :: Developers",
-          "Operating System :: MacOS :: MacOS X",
-          "Operating System :: POSIX",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 3",
-      ] + python_version_classifiers,
-      zip_safe=False)
+setup(
+    name="opensearch-benchmark",
+    maintainer="Ian Hoang, Govind Kamat",
+    maintainer_email="hoangia@amazon.com, govkamat@amazon.com",
+    version=__versionstr__,
+    description="Macrobenchmarking framework for OpenSearch",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/opensearch-project/OpenSearch-Benchmark",
+    license="Apache License, Version 2.0",
+    packages=find_packages(where=".", exclude=("tests*", "benchmarks*", "it*")),
+    include_package_data=True,
+    # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Benchmark on an unsupported
+    # Python version.
+    # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    #
+    # According to https://www.python.org/dev/peps/pep-0440/#version-matching, a trailing ".*" should
+    # ignore patch versions:
+    #
+    # "additional trailing segments will be ignored when determining whether or not a version identifier matches
+    # the clause"
+    #
+    # However, with the pattern ">=3.5.*,<=3.8.*", the version "3.8.0" is not accepted. Therefore, we match
+    # the minor version after the last supported one (i.e. if 3.8 is the last supported, we'll emit "<3.9")
+    python_requires=">={},<{}".format(
+        first_supported_version, first_unsupported_version
+    ),
+    package_data={"": ["*.json", "*.yml"]},
+    install_requires=install_requires,
+    test_suite="tests",
+    tests_require=tests_require,
+    extras_require={"develop": tests_require + develop_require},
+    entry_points={
+        "console_scripts": [
+            "opensearch-benchmark=osbenchmark.benchmark:main",
+            "opensearch-benchmarkd=osbenchmark.benchmarkd:main",
+        ],
+    },
+    scripts=["scripts/expand-data-corpus.py"],
+    classifiers=[
+        "Topic :: System :: Benchmark",
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ]
+    + python_version_classifiers,
+    zip_safe=False,
+)


### PR DESCRIPTION
### Description
In #395, it was said that the progress bar present currently is restrictive. #403 revamps that to have a easily adjustable implementation using tqdm. In line with that, this PR changes the execute-test progress bar as well. Only making this PR because #403 is about create-workloads. 

### Issues Resolved
A part of #395 

Here's a sample run: 

```
╰─$ opensearch-benchmark execute-test --pipeline="benchmark-only" \
--workload-path="/home/aksha/Workbench/Workloads/flights" \
--target-host="https://127.0.0.1:9200" \
--client-options="timeout:300,use_ssl:true,verify_certs:false,basic_auth_user:'admin',basic_auth_password:'admin'"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Executing test with workload [flights] and provision_config_instance ['external'] with version [2.11.0].

[WARNING] merges_total_time is 496 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 1231 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 2687 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 881 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.

Running search: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:06<00:00, 16.58%/s]
Running create-index: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:05<00:00, 19.89%/s]
Running cluster-health: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:05<00:00, 19.90%/s]
Running bulk: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:05<00:00, 19.90%/s]
Running search: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:05<00:00, 19.90%/s]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |   Task |      Value |   Unit |
|---------------------------------------------------------------:|-------:|-----------:|-------:|
|                     Cumulative indexing time of primary shards |        |  0.0213833 |    min |
|             Min cumulative indexing time across primary shards |        |          0 |    min |
|          Median cumulative indexing time across primary shards |        |          0 |    min |
|             Max cumulative indexing time across primary shards |        | 0.00811667 |    min |
|            Cumulative indexing throttle time of primary shards |        |          0 |    min |
|    Min cumulative indexing throttle time across primary shards |        |          0 |    min |
| Median cumulative indexing throttle time across primary shards |        |          0 |    min |
|    Max cumulative indexing throttle time across primary shards |        |          0 |    min |
|                        Cumulative merge time of primary shards |        | 0.00848333 |    min |
|                       Cumulative merge count of primary shards |        |         13 |        |
|                Min cumulative merge time across primary shards |        |          0 |    min |
|             Median cumulative merge time across primary shards |        |          0 |    min |
|                Max cumulative merge time across primary shards |        | 0.00711667 |    min |
|               Cumulative merge throttle time of primary shards |        |          0 |    min |
|       Min cumulative merge throttle time across primary shards |        |          0 |    min |
|    Median cumulative merge throttle time across primary shards |        |          0 |    min |
|       Max cumulative merge throttle time across primary shards |        |          0 |    min |
|                      Cumulative refresh time of primary shards |        |     0.0459 |    min |
|                     Cumulative refresh count of primary shards |        |        283 |        |
|              Min cumulative refresh time across primary shards |        |          0 |    min |
|           Median cumulative refresh time across primary shards |        |          0 |    min |
|              Max cumulative refresh time across primary shards |        |  0.0341667 |    min |
|                        Cumulative flush time of primary shards |        |  0.0146833 |    min |
|                       Cumulative flush count of primary shards |        |         18 |        |
|                Min cumulative flush time across primary shards |        |          0 |    min |
|             Median cumulative flush time across primary shards |        |          0 |    min |
|                Max cumulative flush time across primary shards |        | 0.00993333 |    min |
|                                        Total Young Gen GC time |        |      0.024 |      s |
|                                       Total Young Gen GC count |        |          4 |        |
|                                          Total Old Gen GC time |        |          0 |      s |
|                                         Total Old Gen GC count |        |          0 |        |
|                                                     Store size |        |  0.0108699 |     GB |
|                                                  Translog size |        | 0.00910067 |     GB |
|                                         Heap used for segments |        |          0 |     MB |
|                                       Heap used for doc values |        |          0 |     MB |
|                                            Heap used for terms |        |          0 |     MB |
|                                            Heap used for norms |        |          0 |     MB |
|                                           Heap used for points |        |          0 |     MB |
|                                    Heap used for stored fields |        |          0 |     MB |
|                                                  Segment count |        |         79 |        |
|                                                 Min Throughput |   bulk |    16227.3 | docs/s |
|                                                Mean Throughput |   bulk |    16227.3 | docs/s |
|                                              Median Throughput |   bulk |    16227.3 | docs/s |
|                                                 Max Throughput |   bulk |    16227.3 | docs/s |
|                                        50th percentile latency |   bulk |    112.968 |     ms |
|                                        90th percentile latency |   bulk |    121.081 |     ms |
|                                       100th percentile latency |   bulk |    121.806 |     ms |
|                                   50th percentile service time |   bulk |    112.968 |     ms |
|                                   90th percentile service time |   bulk |    121.081 |     ms |
|                                  100th percentile service time |   bulk |    121.806 |     ms |
|                                                     error rate |   bulk |          0 |      % |
|                                                 Min Throughput | search |     203.22 |  ops/s |
|                                                Mean Throughput | search |     203.22 |  ops/s |
|                                              Median Throughput | search |     203.22 |  ops/s |
|                                                 Max Throughput | search |     203.22 |  ops/s |
|                                        50th percentile latency | search |    16.4081 |     ms |
|                                       100th percentile latency | search |    18.1487 |     ms |
|                                   50th percentile service time | search |    16.4081 |     ms |
|                                  100th percentile service time | search |    18.1487 |     ms |
|                                                     error rate | search |          0 |      % |


--------------------------------
[INFO] SUCCESS (took 39 seconds)
--------------------------------
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
