### PR TITLE
Add vector search as new operation type to search

### DIFF
--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -584,6 +584,7 @@ class OperationType(Enum):
     CreatePointInTime = 14
     DeletePointInTime = 15
     ListAllPointInTime = 16
+    VectorSearch = 17
 
     # administrative actions
     ForceMerge = 1001
@@ -641,6 +642,8 @@ class OperationType(Enum):
             return OperationType.ScrollSearch
         elif v == "paginated-search":
             return OperationType.PaginatedSearch
+        elif v == "vector-search":
+            return OperationType.VectorSearch
         elif v == "cluster-health":
             return OperationType.ClusterHealth
         elif v == "bulk":


### PR DESCRIPTION
### Description
For Vector search, we have to compare actual response's hits with expected neighbors to estimate recall for search. However, there is no provision to return recall similar to throughput. Hence, we will publish recall metrics like recall@k, recall@r as part of meta object. We also time those recall calculation and publish in ms to meta object.

Added tests to verify results are as expected.

### Issues Resolved
Part of  https://github.com/opensearch-project/opensearch-benchmark/issues/103 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
```
make test 

.venv/lib/python3.8/site-packages/pkg_resources/__init__.py:2868
.venv/lib/python3.8/site-packages/pkg_resources/__init__.py:2868
  /Users/balasvij/PycharmProjects/knn/opensearch-benchmark/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 1191 passed, 5 skipped, 3 warnings in 16.93s =================


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
