### PR TITLE
Add vector search param source

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1041,7 +1041,7 @@ class Query(Runner):
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")
                 return result
-            id_field = params.get("id_field_name", "_id")
+            id_field = params.get("id-field-name", "_id")
             candidates = []
             for hit in response_json['hits']['hits']:
                 if id_field in hit:  # Will add to candidates if field value is present


### PR DESCRIPTION
### Description
Added new param source to partition vector dataset and
neighbors. This will be passed to runner to perform
search and compare response with neighbors for recall
calculation.

This param source extends Search ParamSource to inherit search's
other query parameters.
Vector Param Source will add additional paramter that are required
for vector serach operation type.

### Issues Resolved
Part of #103 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
```
make test

tests/workload/params_test.py::VectorSearchParamSourceTests::test_invalid_data_set_format PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_invalid_data_set_path PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_missing_params PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_partition_bigann PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_partition_hdf5 PASSED [ 96%]
tests/workload/params_test.py::VectorSearchPartitionPartitionParamSourceTestCase::test_params PASSED [ 96%]


================= 1206 passed, 5 skipped, 3 warnings in 15.59s =================
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
