### PR TITLE
Added client processing time

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1706,6 +1706,7 @@ class GlobalStatsCalculator:
                         task.operation.name,
                         self.summary_stats("throughput", t, op_type),
                         self.single_latency(t, op_type),
+                        self.single_latency(t, op_type, metric_name="client_processing_time"),
                         self.single_latency(t, op_type, metric_name="service_time"),
                         self.single_latency(t, op_type, metric_name="processing_time"),
                         error_rate,
@@ -1949,6 +1950,8 @@ class GlobalStats:
                         all_results.append(op_metrics(item, "throughput"))
                     if "latency" in item:
                         all_results.append(op_metrics(item, "latency"))
+                    if "client_processing_time" in item:
+                        all_results.append(op_metrics(item, "client_processing_time"))
                     if "service_time" in item:
                         all_results.append(op_metrics(item, "service_time"))
                     if "processing_time" in item:
@@ -1995,12 +1998,15 @@ class GlobalStats:
     def v(self, d, k, default=None):
         return d.get(k, default) if d else default
 
-    def add_op_metrics(self, task, operation, throughput, latency, service_time, processing_time, error_rate, duration, meta):
+    def add_op_metrics(self, task, operation, throughput, latency,
+                       client_processing_time, service_time, processing_time,
+                       error_rate, duration, meta):
         doc = {
             "task": task,
             "operation": operation,
             "throughput": throughput,
             "latency": latency,
+            "client_processing_time": client_processing_time,
             "service_time": service_time,
             "processing_time": processing_time,
             "error_rate": error_rate,

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -132,6 +132,7 @@ class SummaryResultsPublisher:
             task = record["task"]
             metrics_table.extend(self._publish_throughput(record, task))
             metrics_table.extend(self._publish_latency(record, task))
+            metrics_table.extend(self._publish_client_processing_time(record, task))
             metrics_table.extend(self._publish_service_time(record, task))
             # this is mostly needed for debugging purposes but not so relevant to end users
             if self.show_processing_time:
@@ -175,6 +176,9 @@ class SummaryResultsPublisher:
 
     def _publish_latency(self, values, task):
         return self._publish_percentiles("latency", task, values["latency"])
+
+    def _publish_client_processing_time(self, values, task):
+        return self._publish_percentiles("client_processing_time", task, values["client_processing_time"])
 
     def _publish_service_time(self, values, task):
         return self._publish_percentiles("service time", task, values["service_time"])
@@ -374,6 +378,7 @@ class ComparisonResultsPublisher:
             if t in contender_stats.tasks():
                 metrics_table.extend(self._publish_throughput(baseline_stats, contender_stats, t))
                 metrics_table.extend(self._publish_latency(baseline_stats, contender_stats, t))
+                metrics_table.extend(self._publish_client_processing_time(baseline_stats, contender_stats, t))
                 metrics_table.extend(self._publish_service_time(baseline_stats, contender_stats, t))
                 if self.show_processing_time:
                     metrics_table.extend(self._publish_processing_time(baseline_stats, contender_stats, t))
@@ -408,6 +413,11 @@ class ComparisonResultsPublisher:
         baseline_latency = baseline_stats.metrics(task)["latency"]
         contender_latency = contender_stats.metrics(task)["latency"]
         return self._publish_percentiles("latency", task, baseline_latency, contender_latency)
+
+    def _publish_client_processing_time(self, baseline_stats, contender_stats, task):
+        baseline_client_processing_time = baseline_stats.metrics(task)["client_processing_time"]
+        contender_client_processing_time = contender_stats.metrics(task)["client_processing_time"]
+        return self._publish_percentiles("client_processing_time", task, baseline_client_processing_time, contender_client_processing_time)
 
     def _publish_service_time(self, baseline_stats, contender_stats, task):
         baseline_service_time = baseline_stats.metrics(task)["service_time"]

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -1368,8 +1368,10 @@ class IndicesStatsRunnerTests(TestCase):
 
 class QueryRunnerTests(TestCase):
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_match_only_request_body_defined(self, opensearch):
+    async def test_query_match_only_request_body_defined(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -1424,8 +1426,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_with_timeout_and_headers(self, opensearch):
+    async def test_query_with_timeout_and_headers(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -1483,8 +1487,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_match_using_request_params(self, opensearch):
+    async def test_query_match_using_request_params(self, opensearch, on_client_request_start, on_client_request_end):
         response = {
             "timed_out": False,
             "took": 62,
@@ -1541,8 +1547,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_no_detailed_results(self, opensearch):
+    async def test_query_no_detailed_results(self, opensearch, on_client_request_start, on_client_request_end):
         response = {
             "timed_out": False,
             "took": 62,
@@ -1595,8 +1603,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_hits_total_as_number(self, opensearch):
+    async def test_query_hits_total_as_number(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -1650,8 +1660,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_match_all(self, opensearch):
+    async def test_query_match_all(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -1706,8 +1718,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_match_all_doc_type_fallback(self, opensearch):
+    async def test_query_match_all_doc_type_fallback(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -1763,8 +1777,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_only_one_page(self, opensearch):
+    async def test_scroll_query_only_one_page(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -1825,8 +1841,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_no_request_cache(self, opensearch):
+    async def test_scroll_query_no_request_cache(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -1887,8 +1905,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_only_one_page_only_request_body_defined(self, opensearch):
+    async def test_scroll_query_only_one_page_only_request_body_defined(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -1949,8 +1969,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_with_explicit_number_of_pages(self, opensearch):
+    async def test_scroll_query_with_explicit_number_of_pages(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -2023,8 +2045,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_cannot_clear_scroll(self, opensearch):
+    async def test_scroll_query_cannot_clear_scroll(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -2074,8 +2098,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_scroll_query_request_all_pages(self, opensearch):
+    async def test_scroll_query_request_all_pages(self, opensearch, on_client_request_start, on_client_request_end):
         # page 1
         search_response = {
             "_scroll_id": "some-scroll-id",
@@ -2148,8 +2174,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_search_pipeline_using_request_params(self, opensearch):
+    async def test_search_pipeline_using_request_params(self, opensearch, on_client_request_start, on_client_request_end):
         response = {
             "timed_out": False,
             "took": 62,
@@ -2208,8 +2236,10 @@ class QueryRunnerTests(TestCase):
         opensearch.clear_scroll.assert_not_called()
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_vector_search_with_perfect_recall(self, opensearch):
+    async def test_query_vector_search_with_perfect_recall(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -2284,8 +2314,10 @@ class QueryRunnerTests(TestCase):
         )
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_vector_search_with_no_results(self, opensearch):
+    async def test_query_vector_search_with_no_results(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 1
@@ -2340,8 +2372,10 @@ class QueryRunnerTests(TestCase):
 
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_vector_search_with_imperfect_recall(self, opensearch):
+    async def test_query_vector_search_with_imperfect_recall(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -2416,8 +2450,10 @@ class QueryRunnerTests(TestCase):
         )
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_vector_search_with_few_results_than_ground_truth(self, opensearch):
+    async def test_query_vector_search_with_few_results_than_ground_truth(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -2488,8 +2524,10 @@ class QueryRunnerTests(TestCase):
         )
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @run_async
-    async def test_query_vector_search_with_zero_recall_1(self, opensearch):
+    async def test_query_vector_search_with_zero_recall_1(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -5260,8 +5298,11 @@ class CompositeTests(TestCase):
         runner.remove_runner("call-recorder")
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.new_request_context')
     @run_async
-    async def test_execute_multiple_streams(self, opensearch):
+    async def test_execute_multiple_streams(self, opensearch, on_client_request_start, on_client_request_end,new_request_context):
         opensearch.transport.perform_request.side_effect = [
             # raw-request
             as_future(),
@@ -5337,8 +5378,11 @@ class CompositeTests(TestCase):
         ])
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.new_request_context')
     @run_async
-    async def test_propagates_violated_assertions(self, opensearch):
+    async def test_propagates_violated_assertions(self, opensearch, on_client_request_start, on_client_request_end, new_request_context):
         opensearch.transport.perform_request.side_effect = [
             # search
             as_future(io.StringIO(json.dumps({
@@ -5396,8 +5440,11 @@ class CompositeTests(TestCase):
         ])
 
     @mock.patch("opensearchpy.OpenSearch")
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.new_request_context')
     @run_async
-    async def test_executes_tasks_in_specified_order(self, opensearch):
+    async def test_executes_tasks_in_specified_order(self, opensearch, on_client_request_start, on_client_request_end, new_request_context):
         opensearch.transport.perform_request.return_value = as_future()
 
         params = {


### PR DESCRIPTION
### Description

Introduced a new metric: **Client Processing Time**.

- Client Processing Time: The delta between total request time and service time.

- Total Request Time: Defined as the duration between the runner sending a request to the client OpenSearch-py and receiving the response.

- Service Time: Represents the interval from the server receiving the request to the server sending the response. Note: There was a discrepancy in the documentation regarding Service Time, and I have clarified my observations in the associated PR.