### PR TITLE
Remove references to default admin creds

### DIFF
--- a/docs/api/execute-test.md
+++ b/docs/api/execute-test.md
@@ -50,7 +50,7 @@ Execute the `http_logs` workload against an existing OpenSearch cluster but only
 *Example 3*
 
 ```
-opensearch-benchmark execute-test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
+opensearch-benchmark execute-test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:<admin password>"
 ```
 
 Execute the `nyc_taxis` workload against an existing OpenSearch cluster with the security plugin enabled.

--- a/osbenchmark/resources/docker-compose.yml.j2
+++ b/osbenchmark/resources/docker-compose.yml.j2
@@ -39,7 +39,7 @@ services:
     networks:
       - opensearch-net
     healthcheck:
-          test: curl -f http://localhost:{{http_port}} -u admin:admin --insecure
+          test: curl -f http://localhost:{{http_port}} -u admin:myStrongPassword123! --insecure
           interval: 5s
           timeout: 2s
           retries: 10

--- a/osbenchmark/resources/docker-compose.yml.j2
+++ b/osbenchmark/resources/docker-compose.yml.j2
@@ -40,7 +40,12 @@ services:
     networks:
       - opensearch-net
     healthcheck:
-          test: curl -f http://localhost:{{http_port}} -u admin:myStrongPassword123! --insecure
+          {%- set version_numbers = os_version.split('.') | map('int') %}
+          {%- if version_numbers[0] > 2 or (version_numbers[0] == 2 and version_numbers[1] >= 12) %}
+            test: curl -f http://localhost:{{http_port}} -u admin:myStrongPassword123! --insecure
+          {%- else %}
+            test: curl -f http://localhost:{{http_port}} -u admin:admin --insecure
+          {%- endif %}
           interval: 5s
           timeout: 2s
           retries: 10

--- a/osbenchmark/resources/docker-compose.yml.j2
+++ b/osbenchmark/resources/docker-compose.yml.j2
@@ -18,6 +18,7 @@ services:
       - DISABLE_INSTALL_DEMO_CONFIG=true
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" # starting with 2.12.0 a strong initial admin password must be set
     ulimits:
       memlock:
         soft: -1

--- a/samples/ccr/docker-compose-metricstore.yml
+++ b/samples/ccr/docker-compose-metricstore.yml
@@ -11,6 +11,7 @@ services:
       - cluster.initial_master_nodes=metricstore-node
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!"
     ulimits:
       memlock:
         soft: -1

--- a/samples/ccr/docker-compose-metricstore.yml
+++ b/samples/ccr/docker-compose-metricstore.yml
@@ -11,7 +11,7 @@ services:
       - cluster.initial_master_nodes=metricstore-node
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
-      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!"
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" # starting with 2.12.0 a strong initial admin password must be set
     ulimits:
       memlock:
         soft: -1

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -25,7 +25,7 @@ printf "Waiting for clusters to get ready "
 ALL_CLUSTERS_READY=false
 
 while ! $ALL_CLUSTERS_READY; do
-    (curl -ks -u admin:admin https://localhost:9200 -o /dev/null && curl -ks -u admin:admin https://localhost:9201 -o /dev/null && ALL_CLUSTERS_READY=true) || (printf "." && sleep 5)
+    (curl -ks -u admin:myStrongPassword123! https://localhost:9200 -o /dev/null && curl -ks -u admin:admin https://localhost:9201 -o /dev/null && ALL_CLUSTERS_READY=true) || (printf "." && sleep 5)
 done
 
 echo
@@ -50,7 +50,7 @@ curl -o /dev/null -H 'Content-Type: application/json' -k -u admin:admin -X PUT h
 EOF
 
 echo "Set auto-follow pattern on follower for every index on leader"
-curl -H 'Content-Type: application/json' -k -u admin:admin https://localhost:9201/_plugins/_replication/_autofollow -d @- <<-EOF
+curl -H 'Content-Type: application/json' -k -u admin:myStrongPassword123! https://localhost:9201/_plugins/_replication/_autofollow -d @- <<-EOF
 {
   "leader_alias": "source",
   "name": "all",
@@ -90,7 +90,7 @@ cat >ccr-client-options.json <<'EOF'
   "default": {
     "use_ssl":"true",
     "basic_auth_user":"admin",
-    "basic_auth_password":"admin",
+    "basic_auth_password":"myStrongPassword123!",
     "verify_certs":"false"
   },
   "follower": {


### PR DESCRIPTION
### Description
With 2.12.0 release, the security plugin is making a change that requires an initial admin password to be set via an environment variable. This PR makes this change in CI/code/documentation. 

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
