### PR TITLE
Add vector search bulk param and runner

### DIFF
--- a/osbenchmark/utils/parse.py
+++ b/osbenchmark/utils/parse.py
@@ -7,7 +7,7 @@ from osbenchmark.exceptions import ConfigurationError
 
 
 def parse_string_parameter(key: str, params: dict, default: str = None) -> str:
-    if key not in params:
+    if key not in params or not params[key]:
         if default is not None:
             return default
         raise ConfigurationError(

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -585,6 +585,7 @@ class OperationType(Enum):
     DeletePointInTime = 15
     ListAllPointInTime = 16
     VectorSearch = 17
+    BulkVectorDataSet = 18
 
     # administrative actions
     ForceMerge = 1001
@@ -644,6 +645,8 @@ class OperationType(Enum):
             return OperationType.PaginatedSearch
         elif v == "vector-search":
             return OperationType.VectorSearch
+        elif v == "bulk-vector-data-set":
+            return OperationType.BulkVectorDataSet
         elif v == "cluster-health":
             return OperationType.ClusterHealth
         elif v == "bulk":


### PR DESCRIPTION
### Description
Added params and runner to support vector search
bulk operations. This custom bulk vector search
support partitioning files like bigann and hdf5
into multiple bulk request based on bulk size.

### Issues Resolved
Part of #103 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
```
make test

================= 1211 passed, 5 skipped, 3 warnings in 17.23s =================

```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
