### PR TITLE
Revert renaming commits from main

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -470,7 +470,7 @@ def create_arg_parser():
              "(default: localhost:9200).",
         default="")  # actually the default is pipeline specific and it is set later
     test_execution_parser.add_argument(
-        "--worker-ips",
+        "--load-worker-coordinator-hosts",
         help="Define a comma-separated list of hosts which should generate load (default: localhost).",
         default="localhost")
     test_execution_parser.add_argument(
@@ -859,8 +859,8 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(
                 config.Scope.applicationOverride,
                 "worker_coordinator",
-                "worker_ips",
-                opts.csv_to_list(args.worker_ips))
+                "load_worker_coordinator_hosts",
+                opts.csv_to_list(args.load_worker_coordinator_hosts))
             cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -77,7 +77,7 @@ def register_default_runners():
     register_runner(workload.OperationType.RestoreSnapshot, RestoreSnapshot(), async_runner=True)
     # We treat the following as administrative commands and thus already start to wrap them in a retry.
     register_runner(workload.OperationType.ClusterHealth, Retry(ClusterHealth()), async_runner=True)
-    register_runner(workload.OperationType.CreateIngestPipeline, Retry(CreateIngestPipeline()), async_runner=True)
+    register_runner(workload.OperationType.PutPipeline, Retry(PutPipeline()), async_runner=True)
     register_runner(workload.OperationType.Refresh, Retry(Refresh()), async_runner=True)
     register_runner(workload.OperationType.CreateIndex, Retry(CreateIndex()), async_runner=True)
     register_runner(workload.OperationType.DeleteIndex, Retry(DeleteIndex()), async_runner=True)
@@ -1231,7 +1231,7 @@ class ClusterHealth(Runner):
         return "cluster-health"
 
 
-class CreateIngestPipeline(Runner):
+class PutPipeline(Runner):
     async def __call__(self, opensearch, params):
         await opensearch.ingest.put_pipeline(id=mandatory(params, "id", self),
                                      body=mandatory(params, "body", self),
@@ -1240,7 +1240,7 @@ class CreateIngestPipeline(Runner):
                                      )
 
     def __repr__(self, *args, **kwargs):
-        return "create-ingest-pipeline"
+        return "put-pipeline"
 
 # TODO: refactor it after python client support search pipeline https://github.com/opensearch-project/opensearch-py/issues/474
 class CreateSearchPipeline(Runner):

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -529,7 +529,7 @@ class WorkerCoordinator:
         self.workload = None
         self.test_procedure = None
         self.metrics_store = None
-        self.worker_ips = []
+        self.load_worker_coordinator_hosts = []
         self.workers = []
         # which client ids are assigned to which workers?
         self.clients_per_worker = {}
@@ -637,7 +637,7 @@ class WorkerCoordinator:
         # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.
         self.prepare_telemetry(os_clients, enable=not uses_static_responses)
 
-        for host in self.config.opts("worker_coordinator", "worker_ips"):
+        for host in self.config.opts("worker_coordinator", "load_worker_coordinator_hosts"):
             host_config = {
                 # for simplicity we assume that all benchmark machines have the same specs
                 "cores": num_cores(self.config)
@@ -647,9 +647,9 @@ class WorkerCoordinator:
             else:
                 host_config["host"] = host
 
-            self.worker_ips.append(host_config)
+            self.load_worker_coordinator_hosts.append(host_config)
 
-        self.target.prepare_workload([h["host"] for h in self.worker_ips], self.config, self.workload)
+        self.target.prepare_workload([h["host"] for h in self.load_worker_coordinator_hosts], self.config, self.workload)
 
     def start_benchmark(self):
         self.logger.info("Benchmark is about to start.")
@@ -670,7 +670,7 @@ class WorkerCoordinator:
         if allocator.clients < 128:
             self.logger.info("Allocation matrix:\n%s", "\n".join([str(a) for a in self.allocations]))
 
-        worker_assignments = calculate_worker_assignments(self.worker_ips, allocator.clients)
+        worker_assignments = calculate_worker_assignments(self.load_worker_coordinator_hosts, allocator.clients)
         worker_id = 0
         for assignment in worker_assignments:
             host = assignment["host"]

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -590,7 +590,7 @@ class OperationType(Enum):
     # administrative actions
     ForceMerge = 1001
     ClusterHealth = 1002
-    CreateIngestPipeline = 1003
+    PutPipeline = 1003
     Refresh = 1004
     CreateIndex = 1005
     DeleteIndex = 1006
@@ -653,8 +653,8 @@ class OperationType(Enum):
             return OperationType.Bulk
         elif v == "raw-request":
             return OperationType.RawRequest
-        elif v == "create-ingest-pipeline":
-            return OperationType.CreateIngestPipeline
+        elif v == "put-pipeline":
+            return OperationType.PutPipeline
         elif v == "refresh":
             return OperationType.Refresh
         elif v == "create-index":

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -2737,13 +2737,13 @@ class VectorSearchQueryRunnerTests(TestCase):
         )
 
 
-class CreateIngestPipelineRunnerTests(TestCase):
+class PutPipelineRunnerTests(TestCase):
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
     async def test_create_pipeline(self, opensearch):
         opensearch.ingest.put_pipeline.return_value = as_future()
 
-        r = runner.CreateIngestPipeline()
+        r = runner.PutPipeline()
 
         params = {
             "id": "rename",
@@ -2769,16 +2769,13 @@ class CreateIngestPipelineRunnerTests(TestCase):
     async def test_param_body_mandatory(self, opensearch):
         opensearch.ingest.put_pipeline.return_value = as_future()
 
-        r = runner.CreateIngestPipeline()
+        r = runner.PutPipeline()
 
         params = {
             "id": "rename"
         }
         with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source "
-                                    "for operation 'create-ingest-pipeline' "
-                                    "did not provide the "
-                                    "mandatory parameter 'body'. "
+                                    "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'body'. "
                                     "Add it to your parameter source and try again."):
             await r(opensearch, params)
 
@@ -2789,15 +2786,13 @@ class CreateIngestPipelineRunnerTests(TestCase):
     async def test_param_id_mandatory(self, opensearch):
         opensearch.ingest.put_pipeline.return_value = as_future()
 
-        r = runner.CreateIngestPipeline()
+        r = runner.PutPipeline()
 
         params = {
             "body": {}
         }
         with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for "
-                                    "operation 'create-ingest-pipeline' did"
-                                    " not provide the mandatory parameter 'id'. "
+                                    "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'id'. "
                                     "Add it to your parameter source and try again."):
             await r(opensearch, params)
 

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -110,7 +110,7 @@ class WorkerCoordinatorTests(TestCase):
         self.cfg.add(config.Scope.application, "client", "hosts",
                      WorkerCoordinatorTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
-        self.cfg.add(config.Scope.application, "worker_coordinator", "worker_ips", ["localhost"])
+        self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
         self.cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
@@ -135,7 +135,7 @@ class WorkerCoordinatorTests(TestCase):
     @mock.patch("osbenchmark.utils.net.resolve")
     def test_start_benchmark_and_prepare_workload(self, resolve):
         # override load worker_coordinator host
-        self.cfg.add(config.Scope.applicationOverride, "worker_coordinator", "worker_ips", ["10.5.5.1", "10.5.5.2"])
+        self.cfg.add(config.Scope.applicationOverride, "worker_coordinator", "load_worker_coordinator_hosts", ["10.5.5.1", "10.5.5.2"])
         resolve.side_effect = ["10.5.5.1", "10.5.5.2"]
 
         target = self.create_test_worker_coordinator_target()


### PR DESCRIPTION
### Description
OSCI program introduced some commits that rename components into main. However, these commits should be reverted to prevent breaking changes from entering OSB 1.2.0. These changes should only be included in the next major release, OSB 2.0.0. These changes are already cherry-picked into `renaming-components` branch.
- 3adacc0a9383cf7f81dbe0cba4c4f6c0b206cab2 Rename parameters for Distributed Workload Generation - Issue 258  (#407)
- e73664af95218a1ff1afb8fa05bc9d0c7766ec33 renamed put pipeline to create ingest pipeline (#399)


### Issues Resolved
N/A

### Testing
- [x] New functionality includes testing

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
