### PR TITLE
Adds a command-line argument to specify more latency percentiles at the end of a workload. 

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -554,6 +554,11 @@ def create_arg_parser():
         default=False,
         help="If any processes is running, it is going to kill them and allow Benchmark to continue to run."
     )
+    test_execution_parser.add_argument(
+        "--latency-percentiles",
+        help="A comma-separated list of percentiles to report for latency.",
+        default="50,90,99,99.9,99.99,100"
+    )
 
     ###############################################################################
     #
@@ -862,6 +867,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
                 "load_worker_coordinator_hosts",
                 opts.csv_to_list(args.load_worker_coordinator_hosts))
             cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
+            cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)
             configure_telemetry_params(args, cfg)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -556,8 +556,9 @@ def create_arg_parser():
     )
     test_execution_parser.add_argument(
         "--latency-percentiles",
-        help="A comma-separated list of percentiles to report for latency.",
-        default="50,90,99,99.9,99.99,100"
+        help=f"A comma-separated list of percentiles to report for latency "
+             f"(default: {metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES}).",
+        default=metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES
     )
 
     ###############################################################################

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -95,6 +95,19 @@ def format_as_csv(headers, data):
             writer.writerow(metric_record)
         return out.getvalue()
 
+def comma_separated_string_to_number_list(string_list):
+    # Split a comma-separated list in a string to a list of numbers. If they are whole numbers, make them ints,
+    # so they display without decimals.
+    # If the input is None, return None.
+    if string_list is None or len(string_list) == 0:
+        return None
+    results = [float(value) for value in string_list.split(",")]
+    for i, value in enumerate(results):
+        if round(value) == value:
+            results[i] = int(value)
+    return results
+
+
 
 class SummaryResultsPublisher:
     def __init__(self, results, config):
@@ -109,6 +122,7 @@ class SummaryResultsPublisher:
         self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
         self.cwd = config.opts("node", "benchmark.cwd")
+        self.latency_percentiles = comma_separated_string_to_number_list(config.opts("workload", "latency.percentiles", mandatory=False))
 
     def publish(self):
         print_header(FINAL_SCORE)
@@ -185,7 +199,7 @@ class SummaryResultsPublisher:
     def _publish_percentiles(self, name, task, value):
         lines = []
         if value:
-            for percentile in metrics.percentiles_for_sample_size(sys.maxsize):
+            for percentile in metrics.percentiles_for_sample_size(sys.maxsize, latency_percentiles=self.latency_percentiles):
                 percentile_value = value.get(metrics.encode_float_key(percentile))
                 a_line = self._line("%sth percentile %s" % (percentile, name), task, percentile_value, "ms",
                                     force=self.publish_all_percentile_values)
@@ -324,6 +338,7 @@ class ComparisonResultsPublisher:
         self.cwd = config.opts("node", "benchmark.cwd")
         self.show_processing_time = convert.to_bool(config.opts("results_publishing", "output.processingtime",
                                                                 mandatory=False, default_value=False))
+        self.latency_percentiles = comma_separated_string_to_number_list(config.opts("workload", "latency.percentiles", mandatory=False))
         self.plain = False
 
     def publish(self, r1, r2):
@@ -421,7 +436,7 @@ class ComparisonResultsPublisher:
 
     def _publish_percentiles(self, name, task, baseline_values, contender_values):
         lines = []
-        for percentile in metrics.percentiles_for_sample_size(sys.maxsize):
+        for percentile in metrics.percentiles_for_sample_size(sys.maxsize, latency_percentiles=self.latency_percentiles):
             baseline_value = baseline_values.get(metrics.encode_float_key(percentile))
             contender_value = contender_values.get(metrics.encode_float_key(percentile))
             self._append_non_empty(lines, self._line("%sth percentile %s" % (percentile, name),


### PR DESCRIPTION
### Description
Adds a new optional argument, `--latency-percentiles`. The user specifies additional percentiles in a comma-separated list to be reported at the end of the workload, assuming the sample size is large enough for them to make sense. The existing percentiles (50, 90, 99, 99.9, 99.99, 100) are the default, but providing a value for `--latency-percentiles` overrides this.  

Example usage: 
`opensearch-benchmark execute-test --pipeline=benchmark-only --workload-path=/home/ec2-user/osb/opensearch-benchmark-workloads/modified_nyc_taxis --target-host=http://localhost:9200 --latency-percentiles=0,10,20,25,30,40,60,70,75,80,80.1,90.1,99.99`

Result: 
```| Min Throughput | cheap-dropoff | 85 | ops/s |
| Mean Throughput | cheap-dropoff | 85.01 | ops/s |
| Median Throughput | cheap-dropoff | 85.01 | ops/s |
| Max Throughput | cheap-dropoff | 85.07 | ops/s |
| 0th percentile latency | cheap-dropoff | 1.04427 | ms |
| 10th percentile latency | cheap-dropoff | 1.23004 | ms |
| 20th percentile latency | cheap-dropoff | 1.35193 | ms |
| 25th percentile latency | cheap-dropoff | 1.40766 | ms |
| 30th percentile latency | cheap-dropoff | 1.46785 | ms |
| 40th percentile latency | cheap-dropoff | 1.57731 | ms |
| 60th percentile latency | cheap-dropoff | 1.78795 | ms |
| 70th percentile latency | cheap-dropoff | 1.89244 | ms |
| 75th percentile latency | cheap-dropoff | 1.94228 | ms |
| 80th percentile latency | cheap-dropoff | 1.99657 | ms |
| 80.1th percentile latency | cheap-dropoff | 1.9981 | ms |
| 90.1th percentile latency | cheap-dropoff | 2.11699 | ms |
| 99.99th percentile latency | cheap-dropoff | 3.86577 | ms |
| 0th percentile service time | cheap-dropoff | 0.814199 | ms |
| 10th percentile service time | cheap-dropoff | 0.858729 | ms |
| 20th percentile service time | cheap-dropoff | 0.870694 | ms |
| 25th percentile service time | cheap-dropoff | 0.876321 | ms |
| 30th percentile service time | cheap-dropoff | 0.882662 | ms |
| 40th percentile service time | cheap-dropoff | 0.902266 | ms |
| 60th percentile service time | cheap-dropoff | 0.928254 | ms |
| 70th percentile service time | cheap-dropoff | 0.94132 | ms |
| 75th percentile service time | cheap-dropoff | 0.954198 | ms |
| 80th percentile service time | cheap-dropoff | 1.00435 | ms |
| 80.1th percentile service time | cheap-dropoff | 1.0062 | ms |
| 90.1th percentile service time | cheap-dropoff | 1.2032 | ms |
| 99.99th percentile service time | cheap-dropoff | 2.88157 | ms |
| error rate | cheap-dropoff | 0 | % |
```

Result with --test-mode on (only 100 shows, because of the small sample size):

```|                                                 Min Throughput | cheap-dropoff |      179.69 |  ops/s |
|                                                Mean Throughput | cheap-dropoff |      179.69 |  ops/s |
|                                              Median Throughput | cheap-dropoff |      179.69 |  ops/s |
|                                                 Max Throughput | cheap-dropoff |      179.69 |  ops/s |
|                                       100th percentile latency | cheap-dropoff |     7.01146 |     ms |
|                                  100th percentile service time | cheap-dropoff |     1.11934 |     ms |
|                                                     error rate | cheap-dropoff |           0 |      % |
```
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-benchmark/issues/435

### Testing
- [x] New functionality includes testing

Added UT for the logic to decide which percentiles to report based on sample size. Manually tested workloads using the new argument with various values, or no value, and confirmed the printout at the end was as expected. I couldn't find a good way to non-manually test it end-to-end in the way other ITs are done - please let me know how I should do this. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
