### PR TITLE
Surface Workload and Jinja Template Errors to Console and Provide Common Solutions

### DIFF
--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -946,8 +946,8 @@ class WorkloadFileReader:
     COMMON_WORKLOAD_FORMAT_ERRORS = """
     ---------------------------------------------------------------------------------------------------------------------------
     [Common workload formatting errors:] \n
-    - Jinja2 expressions missing parameters (e.g. got {{search_clients}} but need {{search_clients | default(8)}})\n
-    - Jinja2 expressions missing \"tojson\" parameter when needed(e.g. got {{index_settings | default({})}} but need{{index_settings | default({}) | tojson}})\n
+    - Jinja2 expression missing parameters (e.g. got {{search_clients}} but needs {{search_clients | default(8)}})\n
+    - Jinja2 expression missing \"tojson\" parameter when needed(e.g. got {{index_settings | default({})}} but needs {{index_settings | default({}) | tojson}})\n
     - JSON file might not be correctly formatted after rendering Jinja2 (e.g. additional brackets (}, ]) or missing commas (,))
     ---------------------------------------------------------------------------------------------------------------------------
     """
@@ -1000,7 +1000,7 @@ class WorkloadFileReader:
             exception_message = f"Jinja2 Exception TemplateSyntaxError: {e}\n"
             if 'endif' in exception_message:
                 exception_message = exception_message + \
-                    "There is an extra Jinja2 \"endif\" somewhere in workload's files. " + \
+                    "There is an extra Jinja2 \"endif\" somewhere in the workload's files. " + \
                     "Please remove it so that the workload can be rendered and run.\n"
             if 'Missing end of raw directive' in exception_message:
                 exception_message += \

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -943,6 +943,15 @@ class CompleteWorkloadParams:
 class WorkloadFileReader:
     MINIMUM_SUPPORTED_TRACK_VERSION = 2
     MAXIMUM_SUPPORTED_TRACK_VERSION = 2
+    COMMON_WORKLOAD_FORMAT_ERRORS = """
+    ---------------------------------------------------------------------------------------------------------------------------
+    [Common workload formatting errors:] \n
+    - Jinja2 expressions missing parameters (e.g. got {{search_clients}} but need {{search_clients | default(8)}})\n
+    - Jinja2 expressions missing \"tojson\" parameter when needed(e.g. got {{index_settings | default({})}} but need{{index_settings | default({}) | tojson}})\n
+    - JSON file might not be correctly formatted after rendering Jinja2 (e.g. additional brackets (}, ]) or missing commas (,))
+    ---------------------------------------------------------------------------------------------------------------------------
+    """
+
     """
     Creates a workload from a workload file.
     """
@@ -997,11 +1006,20 @@ class WorkloadFileReader:
                 erroneous_lines = lines[ctx_start:ctx_end]
                 erroneous_lines.insert(line_idx - ctx_start + 1, "-" * (e.colno - 1) + "^ Error is here")
                 msg += " Lines containing the error:\n\n{}\n\n".format("\n".join(erroneous_lines))
-            msg += "The complete workload has been written to '{}' for diagnosis.".format(tmp.name)
+            msg += "The complete workload has been written to '{}' for diagnosis. \n\n".format(tmp.name)
+            console_message = f"Suggestion: Verify that [{workload_name}] workload has correctly formatted JSON files and " + \
+                f"Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
+                f"See common workload formatting errors:{WorkloadFileReader.COMMON_WORKLOAD_FORMAT_ERRORS}"
+            msg += console_message
             raise WorkloadSyntaxError(msg)
         except Exception as e:
+            # TypeErrors get logged here
             self.logger.exception("Could not load [%s].", workload_spec_file)
-            msg = "Could not load '{}'. The complete workload has been written to '{}' for diagnosis.".format(workload_spec_file, tmp.name)
+            msg = "Could not load '{}'. The complete workload has been written to '{}' for diagnosis. \n\n".format(workload_spec_file, tmp.name)
+            console_message = f"Suggestion: Verify that [{workload_name}] workload has correctly formatted JSON files and " + \
+                f"Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
+                f"See common workload formatting errors:{WorkloadFileReader.COMMON_WORKLOAD_FORMAT_ERRORS}"
+            msg += console_message
             # Convert to string early on to avoid serialization errors with Jinja exceptions.
             raise WorkloadSyntaxError(msg, str(e))
         # check the workload version before even attempting to validate the JSON format to avoid bogus errors.

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -999,8 +999,9 @@ class WorkloadFileReader:
         except jinja2.exceptions.TemplateSyntaxError as e:
             exception_message = f"Jinja2 Exception TemplateSyntaxError: {e}\n"
             if 'endif' in exception_message:
-                exception_message += \
-                    "There is an extra Jinja2 \"endif\" somewhere in workload's files. Please remove it so that the workload can be rendered and run.\n"
+                exception_message = exception_message + \
+                    "There is an extra Jinja2 \"endif\" somewhere in workload's files. " + \
+                    "Please remove it so that the workload can be rendered and run.\n"
             if 'Missing end of raw directive' in exception_message:
                 exception_message += \
                     "In the workload files, \"{% raw -%}\" was provided but is missing it's associated \"{% endraw -%}\" tag.\n"

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1022,7 +1022,7 @@ class WorkloadFileReader:
                 msg += " Lines containing the error:\n\n{}\n\n".format("\n".join(erroneous_lines))
             msg += "The complete workload has been written to '{}' for diagnosis. \n\n".format(tmp.name)
             console_message = f"Suggestion: Verify that [{workload_name}] workload has correctly formatted JSON files and " + \
-                f"Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
+                "Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
                 f"See common workload formatting errors:{WorkloadFileReader.COMMON_WORKLOAD_FORMAT_ERRORS}"
             msg += console_message
             raise WorkloadSyntaxError(msg)
@@ -1030,9 +1030,10 @@ class WorkloadFileReader:
         except Exception as e:
             # TypeErrors get logged here
             self.logger.exception("Could not load [%s].", workload_spec_file)
-            msg = "Could not load '{}'. The complete workload has been written to '{}' for diagnosis. \n\n".format(workload_spec_file, tmp.name)
+            msg = "Could not load '{}'. The complete workload has been written to '{}' for diagnosis. \n\n".format(
+                workload_spec_file, tmp.name)
             console_message = f"Suggestion: Verify that [{workload_name}] workload has correctly formatted JSON files and " + \
-                f"Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
+                "Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. " + \
                 f"See common workload formatting errors:{WorkloadFileReader.COMMON_WORKLOAD_FORMAT_ERRORS}"
             msg += console_message
             # Convert to string early on to avoid serialization errors with Jinja exceptions.


### PR DESCRIPTION
### Description
Users have often made changes to OSB workloads and come across vague and unclear errors. Instead of showing them what the error is or providing them common issues and suggestions on how to fix them, the console wouuld show the following:
```
The complete workload has been written to '/var/folders/yh/89c2pcg10szgzwc6qj2h04gst115h_/T/tmptoxqvjsr.json' for diagnosis
```
These files are usually empty and not useful.

This PR adds better error handling when OSB attempts to render workload files and Jinja templates. Users do not have to dig into the OSB logs anymore for workload and jinja template errors or guess as to what went wrong. These changes now surface the error to the console and highlight common issues and solutions. 

### Issues Resolved
#447 

### Testing
- [x] New functionality includes testing

Recreated common errors in `workload.json`, `operations/default.json`, and `test_procedures/default.json`. Ran the tests and encountered more descriptive error handling that either provides the place to fix or recommendations of common issues and solutions. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
