### PR TITLE
Move data set loading outside constructor

### DIFF
--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -89,11 +89,18 @@ class HDF5DataSet(DataSet):
     FORMAT_NAME = "hdf5"
 
     def __init__(self, dataset_path: str, context: Context):
-        file = h5py.File(dataset_path)
-        self.data = cast(h5py.Dataset, file[self.parse_context(context)])
+        self.dataset_path = dataset_path
+        self.context = self.parse_context(context)
         self.current = self.BEGINNING
+        self.data = None
+
+    def _load(self):
+        if self.data is None:
+            file = h5py.File(self.dataset_path)
+            self.data = cast(h5py.Dataset, file[self.context])
 
     def read(self, chunk_size: int):
+        self._load()
         if self.current >= self.size():
             return None
 
@@ -106,7 +113,7 @@ class HDF5DataSet(DataSet):
         return vectors
 
     def seek(self, offset: int):
-
+        # load file first before seek
         if offset < self.BEGINNING:
             raise Exception("Offset must be greater than or equal to 0")
 
@@ -116,6 +123,8 @@ class HDF5DataSet(DataSet):
         self.current = offset
 
     def size(self):
+        # load file first before return size
+        self._load()
         return self.data.len()
 
     def reset(self):
@@ -152,7 +161,15 @@ class BigANNVectorDataSet(DataSet):
     BYTES_PER_FLOAT = 4
 
     def __init__(self, dataset_path: str):
-        self.file = open(dataset_path, 'rb')
+        self.dataset_path = dataset_path
+        self.file = None
+        self.current = BigANNVectorDataSet.BEGINNING
+        self.num_points = 0
+        self.dimension = 0
+        self.bytes_per_num = 0
+
+    def _init_internal_params(self):
+        self.file = open(self.dataset_path, 'rb')
         self.file.seek(BigANNVectorDataSet.BEGINNING, os.SEEK_END)
         num_bytes = self.file.tell()
         self.file.seek(BigANNVectorDataSet.BEGINNING)
@@ -163,17 +180,23 @@ class BigANNVectorDataSet(DataSet):
 
         self.num_points = int.from_bytes(self.file.read(4), "little")
         self.dimension = int.from_bytes(self.file.read(4), "little")
-        self.bytes_per_num = self._get_data_size(dataset_path)
+        self.bytes_per_num = self._get_data_size(self.dataset_path)
 
         if (num_bytes - BigANNVectorDataSet.DATA_SET_HEADER_LENGTH) != (
                 self.num_points * self.dimension * self.bytes_per_num):
             raise Exception("Invalid file. File size is not matching with expected estimated "
                             "value based on number of points, dimension and bytes per point")
 
-        self.reader = self._value_reader(dataset_path)
-        self.current = BigANNVectorDataSet.BEGINNING
+        self.reader = self._value_reader(self.dataset_path)
+
+    def _load(self):
+        # load file if it is not loaded yet
+        if self.file is None:
+            self._init_internal_params()
 
     def read(self, chunk_size: int):
+        # load file first before read
+        self._load()
         if self.current >= self.size():
             return None
 
@@ -188,15 +211,16 @@ class BigANNVectorDataSet(DataSet):
         return vectors
 
     def seek(self, offset: int):
-
+        # load file first before seek
+        self._load()
         if offset < self.BEGINNING:
             raise Exception("Offset must be greater than or equal to 0")
 
         if offset >= self.size():
             raise Exception("Offset must be less than the data set size")
 
-        bytes_offset = BigANNVectorDataSet.DATA_SET_HEADER_LENGTH + \
-                       self.dimension * self.bytes_per_num * offset
+        bytes_offset = BigANNVectorDataSet.DATA_SET_HEADER_LENGTH + (
+                self.dimension * self.bytes_per_num * offset)
         self.file.seek(bytes_offset)
         self.current = offset
 
@@ -205,14 +229,18 @@ class BigANNVectorDataSet(DataSet):
                            range(self.dimension)])
 
     def size(self):
+        # load file first before return size
+        self._load()
         return self.num_points
 
     def reset(self):
-        self.file.seek(BigANNVectorDataSet.DATA_SET_HEADER_LENGTH)
+        if self.file:
+            self.file.seek(BigANNVectorDataSet.DATA_SET_HEADER_LENGTH)
         self.current = BigANNVectorDataSet.BEGINNING
 
     def __del__(self):
-        self.file.close()
+        if self.file:
+            self.file.close()
 
     @staticmethod
     def _get_extension(file_name):

--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -100,6 +100,7 @@ class HDF5DataSet(DataSet):
             self.data = cast(h5py.Dataset, file[self.context])
 
     def read(self, chunk_size: int):
+        # load file first before read
         self._load()
         if self.current >= self.size():
             return None
@@ -113,7 +114,6 @@ class HDF5DataSet(DataSet):
         return vectors
 
     def seek(self, offset: int):
-        # load file first before seek
         if offset < self.BEGINNING:
             raise Exception("Offset must be greater than or equal to 0")
 

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -825,7 +825,8 @@ class VectorDataSetPartitionParamSource(ParamSource):
         data_set_path: Path to data set
         context: Context the data set will be used in.
         data_set: Structure containing meta data about data and ability to read
-        num_vectors: Number of vectors to use from the data set
+        total_num_vectors: Number of vectors to use from the data set
+        num_vectors: Number of vectors to use for given partition
         total: Number of vectors for the partition
         current: Current vector offset in data set
         infinite: Property of param source signalling that it can be exhausted
@@ -840,7 +841,8 @@ class VectorDataSetPartitionParamSource(ParamSource):
         self.context = context
         self.data_set_format = parse_string_parameter("data_set_format", params)
         self.data_set_path = parse_string_parameter("data_set_path", params)
-        self.num_vectors: int = parse_int_parameter("num_vectors", params, -1)
+        self.total_num_vectors: int = parse_int_parameter("num_vectors", params, -1)
+        self.num_vectors = 0
         self.total = 1
         self.current = 0
         self.percent_completed = 0
@@ -869,20 +871,21 @@ class VectorDataSetPartitionParamSource(ParamSource):
             self.data_set: DataSet = get_data_set(
                 self.data_set_format, self.data_set_path, self.context)
         # if value is -1 or greater than dataset size, use dataset size as num_vectors
-        if self.num_vectors < 0 or self.num_vectors > self.data_set.size():
-            self.num_vectors = self.data_set.size()
-            self.total = self.num_vectors
+        if self.total_num_vectors < 0 or self.total_num_vectors > self.data_set.size():
+            self.total_num_vectors = self.data_set.size()
+        self.total = self.total_num_vectors
 
         partition_x = copy.copy(self)
 
-        num_vectors = int(self.num_vectors / total_partitions)
+        min_num_vectors_per_partition = int(self.total_num_vectors / total_partitions)
+        partition_x.offset = int(partition_index * min_num_vectors_per_partition)
+        partition_x.num_vectors = min_num_vectors_per_partition
 
         # if partition is not divided equally, add extra docs to the last partition
-        if self.num_vectors % total_partitions != 0 and self._is_last_partition(partition_index, total_partitions):
-            num_vectors += self.num_vectors - (num_vectors * total_partitions)
+        if self.total_num_vectors % total_partitions != 0 and self._is_last_partition(partition_index, total_partitions):
+            remaining_vectors = self.total_num_vectors - (min_num_vectors_per_partition * total_partitions)
+            partition_x.num_vectors += remaining_vectors
 
-        partition_x.num_vectors = num_vectors
-        partition_x.offset = int(partition_index * partition_x.num_vectors)
         # We need to create a new instance of the data set for each client
         partition_x.data_set = get_data_set(
             self.data_set_format,
@@ -936,6 +939,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.neighbors_data_set_format = parse_string_parameter(
             self.PARAMS_NAME_NEIGHBORS_DATA_SET_FORMAT, params, self.data_set_format)
         self.neighbors_data_set_path = params.get(self.PARAMS_NAME_NEIGHBORS_DATA_SET_PATH)
+        self.neighbors_data_set = None
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
         self.query_params = query_params
@@ -972,6 +976,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         # add neighbor instance to partition
         partition.neighbors_data_set = get_data_set(
             self.neighbors_data_set_format, self.neighbors_data_set_path, Context.NEIGHBORS)
+        partition.neighbors_data_set.seek(partition.offset)
         return partition
 
     def params(self):
@@ -982,6 +987,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         if is_dataset_exhausted and self.current_rep < self.repetitions:
             self.data_set.seek(self.offset)
+            self.neighbors_data_set.seek(self.offset)
             self.current = self.offset
             self.current_rep += 1
         elif is_dataset_exhausted:
@@ -1066,7 +1072,6 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
         """
         Returns: A bulk index parameter with vectors from a data set.
         """
-        # TODO: Fix below logic to make sure we index only total number of documents as mentioned in the params.
         if self.current >= self.num_vectors + self.offset:
             raise StopIteration
 
@@ -1081,7 +1086,10 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
                 metadata.update({id_field_name: doc_id})
             return {bulk_action: metadata}
 
-        partition = self.data_set.read(self.bulk_size)
+        remaining_vectors_in_partition = self.num_vectors + self.offset - self.current
+        # update bulk size if number of vectors to read is less than actual bulk size
+        bulk_size = min(self.bulk_size, remaining_vectors_in_partition)
+        partition = self.data_set.read(bulk_size)
         body = self.bulk_transform(partition, action)
         size = len(body) // 2
         self.current += size

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -2536,7 +2536,7 @@ class VectorSearchParamSourceTests(TestCase):
                 workload.Workload(name="unit-test"),
                 test_param_source_params,
                 self.DEFAULT_CONTEXT
-            )
+            ).partition(0, 1)
         )
 
     def test_invalid_data_set_path(self):
@@ -2553,11 +2553,12 @@ class VectorSearchParamSourceTests(TestCase):
                 workload.Workload(name="unit-test"),
                 test_param_source_params,
                 self.DEFAULT_CONTEXT
-            )
+            ).partition(0, 1)
         )
 
     def test_partition_hdf5(self):
         num_vectors = 100
+        num_partitions = 10
 
         hdf5_data_set_path = create_data_set(
             num_vectors,
@@ -2579,8 +2580,7 @@ class VectorSearchParamSourceTests(TestCase):
             self.DEFAULT_CONTEXT
         )
 
-        num_partitions = 10
-        vectors_per_partition = test_param_source.num_vectors // num_partitions
+        vectors_per_partition = num_vectors // num_partitions
 
         self._test_partition(
             test_param_source,
@@ -2590,6 +2590,7 @@ class VectorSearchParamSourceTests(TestCase):
 
     def test_partition_bigann(self):
         num_vectors = 100
+        num_partitions = 10
         float_extension = "fbin"
 
         bigann_data_set_path = create_data_set(
@@ -2611,14 +2612,11 @@ class VectorSearchParamSourceTests(TestCase):
             test_param_source_params,
             self.DEFAULT_CONTEXT
         )
-
-        num_partitions = 10
-        vecs_per_partition = test_param_source.num_vectors // num_partitions
-
+        vectors_per_partition = num_vectors // num_partitions
         self._test_partition(
             test_param_source,
             num_partitions,
-            vecs_per_partition
+            vectors_per_partition
         )
 
     def _test_partition(
@@ -2691,11 +2689,12 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
                 "request-params": {},
             }
         )
+        query_param_source_partition = query_param_source.partition(0, 1)
 
         # Check each
         for _ in range(DEFAULT_NUM_VECTORS):
             self._check_params(
-                query_param_source.params(),
+                query_param_source_partition.params(),
                 self.DEFAULT_FIELD_NAME,
                 self.DEFAULT_DIMENSION,
                 k,
@@ -2703,7 +2702,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
 
         # Assert last call creates stop iteration
         with self.assertRaises(StopIteration):
-            query_param_source.params()
+            query_param_source_partition.params()
 
     def test_params_custom_body(self):
         # Create a data set
@@ -2741,11 +2740,12 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
                 }
             }
         )
+        query_param_source_partition = query_param_source.partition(0, 1)
 
         # Check each
         for _ in range(DEFAULT_NUM_VECTORS):
             self._check_params(
-                query_param_source.params(),
+                query_param_source_partition.params(),
                 self.DEFAULT_FIELD_NAME,
                 self.DEFAULT_DIMENSION,
                 k,
@@ -2754,7 +2754,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
 
         # Assert last call creates stop iteration
         with self.assertRaises(StopIteration):
-            query_param_source.params()
+            query_param_source_partition.params()
 
     def _check_params(
             self,
@@ -2822,12 +2822,12 @@ class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
         }
         bulk_param_source = BulkVectorsFromDataSetParamSource(
             workload.Workload(name="unit-test"), test_param_source_params)
-
+        bulk_param_source_partition = bulk_param_source.partition(0, 1)
         # Check each payload returned
         vectors_consumed = 0
         while vectors_consumed < num_vectors:
             expected_num_vectors = min(num_vectors - vectors_consumed, bulk_size)
-            actual_params = bulk_param_source.params()
+            actual_params = bulk_param_source_partition.params()
             self._check_params(
                 actual_params,
                 self.DEFAULT_INDEX_NAME,
@@ -2840,7 +2840,7 @@ class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
 
         # Assert last call creates stop iteration
         with self.assertRaises(StopIteration):
-            bulk_param_source.params()
+            bulk_param_source_partition.params()
 
     def test_params_custom(self):
         num_vectors = 49
@@ -2863,12 +2863,12 @@ class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
         }
         bulk_param_source = BulkVectorsFromDataSetParamSource(
             workload.Workload(name="unit-test"), test_param_source_params)
-
+        bulk_param_source_partition = bulk_param_source.partition(0, 1)
         # Check each payload returned
         vectors_consumed = 0
         while vectors_consumed < num_vectors:
             expected_num_vectors = min(num_vectors - vectors_consumed, bulk_size)
-            actual_params = bulk_param_source.params()
+            actual_params = bulk_param_source_partition.params()
             self._check_params(
                 actual_params,
                 self.DEFAULT_INDEX_NAME,
@@ -2881,7 +2881,7 @@ class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
 
         # Assert last call creates stop iteration
         with self.assertRaises(StopIteration):
-            bulk_param_source.params()
+            bulk_param_source_partition.params()
 
     def _check_params(
             self,


### PR DESCRIPTION
### Description
Param sources will be instatiated before corpora loading. Hence, set data set parameters to initial value during initialization and load data set during partition stage.

### Issues Resolved

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
