### PR TITLE
Emit a more informative error message if git is not installed at startup

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -86,7 +86,9 @@ def osbenchmark(cfg, command_line):
     This method should be used for benchmark invocations of the all commands besides test_execution.
     These commands may have different CLI options than test_execution.
     """
-    err, retcode = process.run_subprocess_with_stderr(osbenchmark_command_line_for(cfg, command_line))
+    cmd = osbenchmark_command_line_for(cfg, command_line)
+    print("\nInvoking OSB:", cmd)
+    err, retcode = process.run_subprocess_with_stderr(cmd)
     if retcode != 0:
         print(err)
     return retcode

--- a/osbenchmark/utils/git.py
+++ b/osbenchmark/utils/git.py
@@ -33,10 +33,8 @@ VERSION_REGEX = r'.* ([0-9]+)\.([0-9]+)\..*'
 
 def probed(f):
     def probe(src, *args, **kwargs):
-        # Probe for -C
         try:
-            out, _, status = process.run_subprocess_with_out_and_err(
-                "git -C {} --version".format(io.escape_path(src)))
+            out, _, status = process.run_subprocess_with_out_and_err("git --version")
         except FileNotFoundError:
             status = 1
         if status != 0:
@@ -58,6 +56,7 @@ def is_working_copy(src):
     return os.path.exists(src) and os.path.exists(os.path.join(src, ".git"))
 
 
+@probed
 def clone(src, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -44,12 +44,14 @@ class GitTests(TestCase):
             git.head_revision("/src")
         self.assertEqual("OpenSearch Benchmark requires at least version 2 of git.  You have git version 1.4.0.  Please update git.",
                          ctx.exception.args[0])
-        run_subprocess_with_out_and_err.assert_called_with("git -C /src --version")
+        run_subprocess_with_out_and_err.assert_called_with("git --version")
 
     @mock.patch("osbenchmark.utils.io.ensure_dir")
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_clone_successful(self, run_subprocess_with_logging, ensure_dir):
+    def test_clone_successful(self, run_subprocess_with_logging, run_subprocess_with_out_and_err, ensure_dir):
         run_subprocess_with_logging.return_value = 0
+        run_subprocess_with_out_and_err.return_value = ("git version 2.0.0", "", 0)
         src = "/src"
         remote = "http://github.com/some/project"
 
@@ -59,9 +61,11 @@ class GitTests(TestCase):
         run_subprocess_with_logging.assert_called_with("git clone http://github.com/some/project /src")
 
     @mock.patch("osbenchmark.utils.io.ensure_dir")
+    @mock.patch("osbenchmark.utils.process.run_subprocess_with_out_and_err")
     @mock.patch("osbenchmark.utils.process.run_subprocess_with_logging")
-    def test_clone_with_error(self, run_subprocess_with_logging, ensure_dir):
+    def test_clone_with_error(self, run_subprocess_with_logging, run_subprocess_with_out_and_err, ensure_dir):
         run_subprocess_with_logging.return_value = 128
+        run_subprocess_with_out_and_err.return_value = ("git version 2.0.0", "", 0)
         src = "/src"
         remote = "http://github.com/some/project"
 
@@ -128,7 +132,7 @@ class GitTests(TestCase):
         git.pull("/src", remote="my-origin", branch="feature-branch")
         run_subprocess_with_out_and_err.assert_has_calls([
             # pull, fetch, rebase, checkout
-            mock.call("git -C /src --version")
+            mock.call("git --version")
             ] * 4)
         calls = [
             mock.call("git -C /src fetch --prune --tags my-origin"),


### PR DESCRIPTION
### Description
If git is not installed, the following error message is emitted, for instance, when a `list workloads` command is issued.  (A similar message appears for other commands like `execute-test` as well).
```
ERROR] Cannot list. [Errno 2] No such file or directory: 'git'.
```
This PR changes the message to:
```
[ERROR] Cannot list. Error invoking 'git', please install (or re-install).
```
The latter message had been added in change `0xd1eba717`, but was not active during the initial clone of the workloads repository.

### Testing
Ran the unit tests and integ tests.  Had to update some of the existing tests, since the probe behavior is hardcoded.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

