### PR TITLE
Add maintainers after OSCI Autumn 2023

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat
+* @IanHoang @gkamat @beaioun @cgchinmay

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,3 +8,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ----------------- | ----------------------------------------------------- | ----------- |
 | Ian Hoang         | [IanHoang](https://github.com/IanHoang)               | Amazon      |
 | Govind Kamat      | [gkamat](https://github.com/gkamat)                   | Amazon      |
+| Mingyang Shi      | [beaioun](https://github.com/beaioun)                 | OSCI        |
+| Chinmay Gadgil    | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |


### PR DESCRIPTION
### Description
Based on the [maintainer responsibilities for OpenSearch](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities), we have decided to nominate the following individuals from the OSCI program to become maintainers of OSB:
- Mingyang Shi (@beaioun)
- Chinmay Gadgil (@cgchinmay)

### Issues Resolved
N/A

### Testing
N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
