### PR TITLE
Add new property to define operation

### DIFF
--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -410,7 +410,7 @@ class DefaultWorkloadPreparator(WorkloadProcessor):
     @staticmethod
     def prepare_docs(cfg, workload, corpus, preparator):
         for document_set in corpus.documents:
-            if document_set.is_bulk:
+            if document_set.is_supported_source_format:
                 data_root = data_dir(cfg, workload.name, corpus.name)
                 logging.getLogger(__name__).info("Resolved data root directory for document corpus [%s] in workload [%s] "
                                                  "to [%s].", corpus.name, workload.name, data_root)
@@ -581,8 +581,8 @@ class DocumentSetPreparator:
                                                    f"because no base URL is provided.") from None
                     else:
                         raise
-
-        self.create_file_offset_table(doc_path, document_set.number_of_lines)
+        if document_set.support_file_offset_table:
+            self.create_file_offset_table(doc_path, document_set.number_of_lines)
 
     def prepare_bundled_document_set(self, document_set, data_root):
         """
@@ -1302,7 +1302,7 @@ class WorkloadSpecificationReader:
                 base_url = self._r(doc_spec, "base-url", mandatory=False, default_value=default_base_url)
                 source_format = self._r(doc_spec, "source-format", mandatory=False, default_value=default_source_format)
 
-                if source_format == workload.Documents.SOURCE_FORMAT_BULK:
+                if source_format in workload.Documents.SUPPORTED_SOURCE_FORMAT:
                     docs = self._r(doc_spec, "source-file")
                     if io.is_archive(docs):
                         document_archive = docs

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -186,7 +186,9 @@ class ComponentTemplate:
 
 class Documents:
     SOURCE_FORMAT_BULK = "bulk"
-    SUPPORTED_SOURCE_FORMAT = [SOURCE_FORMAT_BULK]
+    SOURCE_FORMAT_HDF5 = "hdf5"
+    SOURCE_FORMAT_BIG_ANN = "big-ann"
+    SUPPORTED_SOURCE_FORMAT = [SOURCE_FORMAT_BULK, SOURCE_FORMAT_HDF5, SOURCE_FORMAT_BIG_ANN]
 
     def __init__(self, source_format, document_file=None, document_archive=None, base_url=None,
                  includes_action_and_meta_data=False,

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -186,6 +186,7 @@ class ComponentTemplate:
 
 class Documents:
     SOURCE_FORMAT_BULK = "bulk"
+    SUPPORTED_SOURCE_FORMAT = [SOURCE_FORMAT_BULK]
 
     def __init__(self, source_format, document_file=None, document_archive=None, base_url=None,
                  includes_action_and_meta_data=False,
@@ -270,6 +271,16 @@ class Documents:
     @property
     def is_bulk(self):
         return self.source_format == Documents.SOURCE_FORMAT_BULK
+
+    @property
+    def support_file_offset_table(self):
+        # Will support create file offset table only for bulk source formats. In future we can move it to
+        # a list instead of checking bulk directly
+        return self.source_format == Documents.SOURCE_FORMAT_BULK
+
+    @property
+    def is_supported_source_format(self):
+        return self.source_format in Documents.SUPPORTED_SOURCE_FORMAT
 
     def __str__(self):
         return "%s documents from %s" % (self.source_format, self.document_file)


### PR DESCRIPTION
### Description
Previously we only support bulk as source format. We want to extend Documents to support more source formats.
However, not every format is similar. For Vector Search we want to use HDF5/BIG_ANN formats that don't support file offset table. Hence, add property to decide whether they support specific operation or not.

### Issues Resolved
Part of #442 

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
