### PR TITLE
Add support to use corpus for vector search params

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -852,6 +852,7 @@ class VectorSearchParamSource(SearchParamSource):
     def __init__(self, workload, params, **kwargs):
         super().__init__(workload, params, **kwargs)
         self.delegate_param_source = VectorSearchPartitionParamSource(workload, params, self.query_params, **kwargs)
+        self.corpora = self.delegate_param_source.corpora
 
     def partition(self, partition_index, total_partitions):
         return self.delegate_param_source.partition(partition_index, total_partitions)
@@ -885,7 +886,8 @@ class VectorDataSetPartitionParamSource(ParamSource):
         self.field_name: str = parse_string_parameter("field", params)
         self.context = context
         self.data_set_format = parse_string_parameter("data_set_format", params)
-        self.data_set_path = parse_string_parameter("data_set_path", params)
+        self.data_set_path = parse_string_parameter("data_set_path", params, "")
+        self.data_set_corpus = parse_string_parameter("data_set_corpus", params, "")
         self.total_num_vectors: int = parse_int_parameter("num_vectors", params, -1)
         self.num_vectors = 0
         self.total = 1
@@ -893,13 +895,38 @@ class VectorDataSetPartitionParamSource(ParamSource):
         self.percent_completed = 0
         self.offset = 0
         self.data_set: DataSet = None
+        self.corpora = self.extract_corpora(self.data_set_corpus, self.data_set_format)
+
+    def _get_corpora_file_paths(self, name, source_format):
+        document_files = []
+        for corpus in self.corpora:
+            if corpus.name != name:
+                continue
+            filtered_corpus = corpus.filter(source_format=source_format)
+            document_files.extend([document.document_file for document in filtered_corpus.documents])
+        return document_files
 
     @property
     def infinite(self):
         return False
 
-    def _is_last_partition(self, partition_index, total_partitions):
+    @staticmethod
+    def _is_last_partition(partition_index, total_partitions):
         return partition_index == total_partitions - 1
+
+    def _validate_data_set(self):
+        if not self.data_set_path and not self.data_set_corpus:
+            raise exceptions.ConfigurationError(
+                "Dataset is missing. Provide either dataset file path or valid corpus.")
+
+    @staticmethod
+    def _validate_data_set_corpus(data_set_path_list):
+        if not data_set_path_list:
+            raise exceptions.ConfigurationError(
+                "Dataset is missing. Provide either dataset file path or valid corpus.")
+        if data_set_path_list and len(data_set_path_list) > 1:
+            raise exceptions.ConfigurationError(
+                "Vector Search does not support more than one document file path '%s'." % data_set_path_list)
 
     def partition(self, partition_index, total_partitions):
         """
@@ -912,6 +939,11 @@ class VectorDataSetPartitionParamSource(ParamSource):
         Returns:
             The parameter source for this particular partition
         """
+        self._validate_data_set()
+        if self.data_set_corpus and not self.data_set_path:
+            data_set_path = self._get_corpora_file_paths(self.data_set_corpus, self.data_set_format)
+            self._validate_data_set_corpus(data_set_path)
+            self.data_set_path = data_set_path[0]
         if self.data_set is None:
             self.data_set: DataSet = get_data_set(
                 self.data_set_format, self.data_set_path, self.context)
@@ -947,6 +979,33 @@ class VectorDataSetPartitionParamSource(ParamSource):
         Returns: A single parameter from this source
         """
 
+    def extract_corpora(self, corpus_name, source_format):
+        """
+        Extracts corpora from available corpora in workload for given name and format.
+
+        @param corpus_name: filter corpora by this name
+        @param source_format: filter corpora by this source format
+        @return: corpora that matches given name and source format
+        """
+        if not corpus_name:
+            return []
+        corpora = []
+        workload_corpora_names = []
+        for corpus in self.workload.corpora:
+            workload_corpora_names.append(corpus.name)
+            if corpus.name != corpus_name:
+                continue
+            filtered_corpus = corpus.filter(source_format=source_format)
+            if filtered_corpus and filtered_corpus.number_of_documents(source_format=source_format) > 0:
+                corpora.append(filtered_corpus)
+            break
+
+        # the workload has corpora but none of them match
+        if workload_corpora_names and not corpora:
+            raise exceptions.ConfigurationError(
+                "The provided corpus %s does not match any of the corpora %s." % (corpus_name, workload_corpora_names))
+        return corpora
+
 
 class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     """ Parameter source for k-NN. Queries are created from data set
@@ -968,6 +1027,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_REPETITIONS = "repetitions"
     PARAMS_NAME_NEIGHBORS_DATA_SET_FORMAT = "neighbors_data_set_format"
     PARAMS_NAME_NEIGHBORS_DATA_SET_PATH = "neighbors_data_set_path"
+    PARAMS_NAME_NEIGHBORS_DATA_SET_CORPUS = "neighbors_data_set_corpus"
     PARAMS_NAME_OPERATION_TYPE = "operation-type"
     PARAMS_VALUE_VECTOR_SEARCH = "vector-search"
     PARAMS_NAME_ID_FIELD_NAME = "id-field-name"
@@ -984,6 +1044,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.neighbors_data_set_format = parse_string_parameter(
             self.PARAMS_NAME_NEIGHBORS_DATA_SET_FORMAT, params, self.data_set_format)
         self.neighbors_data_set_path = params.get(self.PARAMS_NAME_NEIGHBORS_DATA_SET_PATH)
+        self.neighbors_data_set_corpus = params.get(self.PARAMS_NAME_NEIGHBORS_DATA_SET_CORPUS)
         self.neighbors_data_set = None
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
@@ -993,6 +1054,11 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             self.PARAMS_NAME_OPERATION_TYPE: operation_type,
             self.PARAMS_NAME_ID_FIELD_NAME: params.get(self.PARAMS_NAME_ID_FIELD_NAME),
         })
+        # if neighbors data set is defined as corpus, extract corresponding corpus from workload
+        # and add it to corpora list
+        if self.neighbors_data_set_corpus:
+            neighbors_corpora = self.extract_corpora(self.neighbors_data_set_corpus, self.neighbors_data_set_format)
+            self.corpora.extend(corpora for corpora in neighbors_corpora if corpora not in self.corpora)
 
     def _update_request_params(self):
         request_params = self.query_params.get(self.PARAMS_NAME_REQUEST_PARAMS, {})
@@ -1016,6 +1082,11 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
     def partition(self, partition_index, total_partitions):
         partition = super().partition(partition_index, total_partitions)
+        if self.neighbors_data_set_corpus and not self.neighbors_data_set_path:
+            neighbors_data_set_path = self._get_corpora_file_paths(
+                self.neighbors_data_set_corpus, self.neighbors_data_set_format)
+            self._validate_data_set_corpus(neighbors_data_set_path)
+            self.neighbors_data_set_path = neighbors_data_set_path[0]
         if not self.neighbors_data_set_path:
             self.neighbors_data_set_path = self.data_set_path
         # add neighbor instance to partition

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -2662,6 +2662,23 @@ class VectorSearchParamSourceTests(TestCase):
             ).partition(0, 1)
         )
 
+    def test_either_data_set_path_or_corpus(self):
+        test_param_source_params = {
+            "index": VectorSearchParamSourceTests.DEFAULT_INDEX_NAME,
+            "field": VectorSearchParamSourceTests.DEFAULT_FIELD_NAME,
+            "data_set_format": "hdf5",
+            "data_set_corpus": "corpus_name",
+            "data_set_path": "file-path",
+        }
+        self.assertRaises(
+            ConfigurationError,
+            lambda: self.TestVectorsFromDataSetParamSource(
+                workload.Workload(name="unit-test"),
+                test_param_source_params,
+                self.DEFAULT_CONTEXT
+            )
+        )
+
     def test_missing_corpus(self):
         test_param_source_params = {
             "index": VectorSearchParamSourceTests.DEFAULT_INDEX_NAME,


### PR DESCRIPTION
### Description
This commit allows vector search paramsource to accept corpus as dataset similar to bulk. 
Added tests to verify the corpus can be parsed and used as dataset path/neighbor's dataset path/query's dataset path.

### Issues Resolved
Part of #442 
### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
```
tests/workload/params_test.py::VectorSearchParamSourceTests::test_corpus_contains_more_than_one_files PASSED [ 95%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_corpus_not_found_in_workload PASSED [ 95%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_invalid_data_set_format PASSED [ 95%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_invalid_data_set_path PASSED [ 95%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_missing_corpus PASSED [ 95%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_missing_data_set_path_or_corpus PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_missing_params PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_partition_bigann PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_partition_hdf5 PASSED [ 96%]
tests/workload/params_test.py::VectorSearchParamSourceTests::test_partition_hdf5_corpus PASSED [ 96%]


================= 1221 passed, 5 skipped, 4 warnings in 17.16s =================
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
