### PR TITLE
Add support to pass efficient filter body to vector search params

### DIFF
--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -2917,6 +2917,9 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             Context.NEIGHBORS,
             self.data_set_dir
         )
+        filter_body = {
+            "key": "value"
+        }
 
         # Create a QueryVectorsFromDataSetParamSource with relevant params
         test_param_source_params = {
@@ -2924,7 +2927,8 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_format": self.DEFAULT_TYPE,
             "data_set_path": data_set_path,
             "neighbors_data_set_path": neighbors_data_set_path,
-            "k": k
+            "k": k,
+            "filter": filter_body,
         }
         query_param_source = VectorSearchPartitionParamSource(
             workload.Workload(name="unit-test"),
@@ -2946,6 +2950,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
                 self.DEFAULT_DIMENSION,
                 k,
                 100,
+                filter_body,
             )
 
         # Assert last call creates stop iteration
@@ -2959,6 +2964,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             expected_dimension: int,
             expected_k: int,
             expected_size=None,
+            expected_filter=None,
     ):
         body = actual_params.get("body")
         self.assertIsInstance(body, dict)
@@ -2978,6 +2984,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertEqual(len(neighbor), expected_dimension)
         size = body.get("size")
         self.assertEqual(size, expected_size if expected_size else expected_k)
+        self.assertEqual(field.get("filter"), expected_filter)
 
 
 class BulkVectorsFromDataSetParamSourceTestCase(TestCase):


### PR DESCRIPTION
### Description
if filter is passed as params, copy filter value as efficient
filter to vector search query body.

### Issues Resolved

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
```
updated existing test to check filter
================= 1221 passed, 5 skipped, 4 warnings in 16.58s =================
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
