### PR TITLE
Fix client processing time calculation in ForceMerge Runner

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -698,6 +698,7 @@ class ForceMerge(Runner):
                 tasks = await opensearch.tasks.list(params={"actions": "indices:admin/forcemerge"})
                 if len(tasks["nodes"]) == 0:
                     # empty nodes response indicates no tasks
+                    request_context_holder.on_client_request_end()
                     complete = True
         else:
             request_context_holder.on_client_request_start()


### PR DESCRIPTION
### Description
Enhance client processing time calculation in the ForceMerge Runner to address a critical issue. This improvement rectifies an error encountered when utilizing polling, where the force merge times out during the initial call **without raising an exception**, and subsequently completes successfully. Previously, the request_context_holder.on_client_request_end() wasn't appropriately calculated in such scenarios. For further context, please refer to the discussion [here](https://github.com/opensearch-project/opensearch-benchmark/pull/450#issuecomment-1962750962).
### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/pull/450#issuecomment-1962750962

### Testing
[Describe how this change was tested]
- Tested by @VijayanB [here]( https://github.com/opensearch-project/opensearch-benchmark/pull/450#issuecomment-1964549671)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
