### PR TITLE
Jenkins file point to 1.3 branch temporarily instead of main

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -15,7 +15,7 @@ standardReleasePipelineWithGenericTrigger(
         wait: true,
         parameters: [
             string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
-            string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
+            string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: '1.3'),
             string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: [
                 'su $(id -un 1000) -c "cd docker/ci',
                 'git clone https://github.com/opensearch-project/opensearch-benchmark opensearch-benchmark',


### PR DESCRIPTION
### Description
Pushed patch release from new `1.3` branch but Jenkins is running into following error:
```
#14 [linux/amd64 4/6] RUN if [ -z "1.4.0" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==1.4.0 ; fi
#0 1.734 ERROR: Ignored the following versions that require a different python version: 0.0.1 Requires-Python >=3.8,<3.10; 0.0.2 Requires-Python >=3.8,<3.10; 0.1.0 Requires-Python >=3.8,<3.10
#0 1.735 ERROR: Could not find a version that satisfies the requirement opensearch-benchmark==1.4.0 (from versions: 0.2.0, 0.3.0, 0.4.0, 0.4.1, 0.5.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.3.1)
```

We need to update jenkins file to point to `1.3` instead of `main` as a quick workaround. In the future, we should have a way where the Github Actions can take a "branch" parameter so that `main` isn't the only branch we can push releases from.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
