### PR TITLE
Add Rishabh as maintainer after vote

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat @beaioun @cgchinmay
+* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Govind Kamat      | [gkamat](https://github.com/gkamat)                   | Amazon      |
 | Mingyang Shi      | [beaioun](https://github.com/beaioun)                 | OSCI        |
 | Chinmay Gadgil    | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
+| Rishabh Singh     | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |


### PR DESCRIPTION
### Description
Elected to add Rishabh as a maintainer after reviewing his work for OpenSearch project and OSB. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
