### PR TITLE
Bumping Jinja2 to version 3.1.1 for CVE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ install_requires = [
     # License: MIT
     "jsonschema==3.1.1",
     # License: BSD
-    "Jinja2==2.11.3",
+    "Jinja2==3.1.3",
     # License: BSD
     "markupsafe==2.0.1",
     # License: MIT


### PR DESCRIPTION
### Description
This change updates the setup file for Jinja2 from version 2.11.3 to 3.1.3 to resolve the CVE in the older version.

### Issues Resolved
#481 

### Testing
- [ ] New functionality includes testing

Test locally and through Github Actions
The Jinja2 3.1.3 was tested to be compatible with OSB

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
