### PR TITLE
Update opensearch-py to 2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "opensearch-py[async]==2.4.1",
+    "opensearch-py[async]==2.5.0",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT


### PR DESCRIPTION
### Description
This contains fix to accept wait_for_completion parameter for index force merge api.

### Issues Resolved


### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
