### PR TITLE
Update force merge polling

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -690,10 +690,11 @@ class ForceMerge(Runner):
         merge_params = self._default_kw_params(params)
         if max_num_segments:
             merge_params["max_num_segments"] = max_num_segments
+        # Request end time will not be 100% accurate, since we are using polling
+        # to check whether task status is completed or not.
         if mode == "polling":
-            if params.get(self.PARAM_WAIT_FOR_COMPLETION):
-                self.logger.warning(
-                    "%s is set for polling. It will be updated to false", self.PARAM_WAIT_FOR_COMPLETION)
+            self.logger.warning(
+                "%s will be updated to false to run force merge in asynchronous way", self.PARAM_WAIT_FOR_COMPLETION)
             merge_params[self.PARAM_WAIT_FOR_COMPLETION] = "false"
             request_context_holder.on_client_request_start()
             response_task = await opensearch.indices.forcemerge(**merge_params)

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -1158,118 +1158,91 @@ class ForceMergeRunnerTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
-    async def test_force_merge_with_polling_no_timeout(self, opensearch, on_client_request_start, on_client_request_end):
-        opensearch.indices.forcemerge.return_value = as_future()
-
-        force_merge = runner.ForceMerge()
-        await force_merge(opensearch, params={"index" : "_all", "mode": "polling", 'poll-period': 0})
-        opensearch.indices.forcemerge.assert_called_once_with(index="_all")
-
-    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
-    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
-    @mock.patch("opensearchpy.OpenSearch")
-    @run_async
     async def test_force_merge_with_polling(self, opensearch, on_client_request_start, on_client_request_end):
-        opensearch.indices.forcemerge.return_value = as_future(exception=opensearchpy.ConnectionTimeout())
-        opensearch.tasks.list.side_effect = [
-            as_future({
-                "nodes": {
-                    "Ap3OfntPT7qL4CBeKvamxg": {
-                        "name": "instance-0000000001",
-                        "transport_address": "10.46.79.231:19693",
-                        "host": "10.46.79.231",
-                        "ip": "10.46.79.231:19693",
-                        "roles": [
-                            "data",
-                            "ingest",
-                            "master",
-                            "remote_cluster_client",
-                            "transform"
-                        ],
-                        "attributes": {
-                            "logical_availability_zone": "zone-1",
-                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
-                            "availability_zone": "us-east4-a",
-                            "instance_configuration": "gcp.data.highio.1",
-                            "transform.node": "true",
-                            "region": "unknown-region"
-                        },
-                        "tasks": {
-                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
-                                "node": "Ap3OfntPT7qL4CBeKvamxg",
-                                "id": 417009036,
-                                "type": "transport",
-                                "action": "indices:admin/forcemerge",
-                                "start_time_in_millis": 1598018980850,
-                                "running_time_in_nanos": 3659821411,
-                                "cancellable": False,
-                                "headers": {}
-                            }
-                        }
-                    }
-                }
-            }),
-            as_future({
-                "nodes": {}
-            })
-        ]
+        opensearch.indices.forcemerge.return_value = as_future({"task": "7PtzISisT5SiwlBGUi2GzQ:2820798"})
+        opensearch.tasks.get.return_value = as_future({
+          "completed": True,
+          "task": {
+            "node": "7PtzISisT5SiwlBGUi2GzQ",
+            "id": 2820798,
+            "type": "transport",
+            "action": "indices:admin/forcemerge",
+            "description": "Force-merge indices [_all], , onlyExpungeDeletes[false], flush[true]",
+            "start_time_in_millis": 1711389911601,
+            "running_time_in_nanos": 2806258,
+            "cancellable": False,
+            "cancelled": False,
+            "headers": {}
+          },
+          "response": {
+            "_shards": {
+              "total": 10,
+              "successful": 10,
+              "failed": 0
+            }
+          }
+        })
         force_merge = runner.ForceMerge()
-        await force_merge(opensearch, params={"index": "_all", "mode": "polling", "poll-period": 0})
-        opensearch.indices.forcemerge.assert_called_once_with(index="_all")
+        await force_merge(opensearch, params={
+            "index": "_all", "mode": "polling", 'poll-period': 10, "wait_for_completion": True})
+        opensearch.indices.forcemerge.assert_called_once_with(index="_all", wait_for_completion='false')
+        opensearch.tasks.get.assert_called_once_with(task_id="7PtzISisT5SiwlBGUi2GzQ:2820798")
 
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
     async def test_force_merge_with_polling_and_params(self, opensearch, on_client_request_start, on_client_request_end):
-        opensearch.indices.forcemerge.return_value = as_future(exception=opensearchpy.ConnectionTimeout())
-        opensearch.tasks.list.side_effect = [
+        opensearch.indices.forcemerge.return_value = as_future({"task": "7PtzISisT5SiwlBGUi2GzQ:2820798"})
+        opensearch.tasks.get.side_effect = [
             as_future({
-                "nodes": {
-                    "Ap3OfntPT7qL4CBeKvamxg": {
-                        "name": "instance-0000000001",
-                        "transport_address": "10.46.79.231:19693",
-                        "host": "10.46.79.231",
-                        "ip": "10.46.79.231:19693",
-                        "roles": [
-                            "data",
-                            "ingest",
-                            "master",
-                            "remote_cluster_client",
-                            "transform"
-                        ],
-                        "attributes": {
-                            "logical_availability_zone": "zone-1",
-                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
-                            "availability_zone": "us-east4-a",
-                            "instance_configuration": "gcp.data.highio.1",
-                            "transform.node": "true",
-                            "region": "unknown-region"
-                        },
-                        "tasks": {
-                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
-                                "node": "Ap3OfntPT7qL4CBeKvamxg",
-                                "id": 417009036,
-                                "type": "transport",
-                                "action": "indices:admin/forcemerge",
-                                "start_time_in_millis": 1598018980850,
-                                "running_time_in_nanos": 3659821411,
-                                "cancellable": False,
-                                "headers": {}
-                            }
-                        }
-                    }
-                }
+              "completed": False,
+              "task": {
+                "node": "7PtzISisT5SiwlBGUi2GzQ",
+                "id": 2820798,
+                "type": "transport",
+                "action": "indices:admin/forcemerge",
+                "description": "Force-merge indices [_all], , onlyExpungeDeletes[false], flush[true]",
+                "start_time_in_millis": 1711389911601,
+                "running_time_in_nanos": 2806258,
+                "cancellable": False,
+                "cancelled": False,
+                "headers": {}
+              },
+              "response": {}
             }),
             as_future({
-                "nodes": {}
+              "completed": True,
+              "task": {
+                "node": "7PtzISisT5SiwlBGUi2GzQ",
+                "id": 2820798,
+                "type": "transport",
+                "action": "indices:admin/forcemerge",
+                "description": "Force-merge indices [_all], , onlyExpungeDeletes[false], flush[true]",
+                "start_time_in_millis": 1711389911601,
+                "running_time_in_nanos": 2806258,
+                "cancellable": "false",
+                "cancelled": "false",
+                "headers": {}
+              },
+              "response": {
+                "_shards": {
+                  "total": 10,
+                  "successful": 10,
+                  "failed": 0
+                }
+              }
             })
         ]
         force_merge = runner.ForceMerge()
         # request-timeout should be ignored as mode:polling
-        await force_merge(opensearch, params={"index" : "_all", "mode": "polling", "max-num-segments": 1,
-                                      "request-timeout": 50000, "poll-period": 0})
-        opensearch.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=50000)
+        await force_merge(opensearch, params={
+            "index": "_all", "mode": "polling", "max-num-segments": 1, "request-timeout": 50000, "poll-period": 10
+        })
+        opensearch.indices.forcemerge.assert_called_once_with(
+            index="_all", max_num_segments=1, request_timeout=50000, wait_for_completion='false')
+        opensearch.tasks.get.assert_called_with(task_id="7PtzISisT5SiwlBGUi2GzQ:2820798")
+        self.assertEqual(opensearch.tasks.get.call_count, 2)
 
 
 class IndicesStatsRunnerTests(TestCase):


### PR DESCRIPTION
### Description
Change force merge polling logic to use wait_for_completion
to false, to make it async and use task's get api to check
whether task is completed or not to exit from force merge.

Here, request end time is calcuated only after task is completed.
This request end time will not be 100% accurate, since, we use polling to check
whether task status is completed or not.


### Issues Resolved


### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
