### PR TITLE
Always print test_execution_id

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -794,6 +794,9 @@ def configure_results_publishing_params(args, cfg):
     cfg.add(config.Scope.applicationOverride, "results_publishing", "numbers.align", args.results_numbers_align)
 
 
+def print_test_execution_id(args):
+    console.info(f"[Test Execution ID]: {args.test_execution_id}")
+
 def dispatch_sub_command(arg_parser, args, cfg):
     sub_command = args.subcommand
 
@@ -832,6 +835,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             configure_builder_params(args, cfg)
             builder.install(cfg)
         elif sub_command == "start":
+            print_test_execution_id(args)
             cfg.add(config.Scope.applicationOverride, "system", "test_execution.id", args.test_execution_id)
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             cfg.add(config.Scope.applicationOverride, "builder", "runtime.jdk", args.runtime_jdk)
@@ -846,6 +850,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
             # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute-test" only
             # to run the actual benchmark (i.e. generating load).
+            print_test_execution_id(args)
             if args.effective_start_date:
                 cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)
             cfg.add(config.Scope.applicationOverride, "system", "test_execution.id", args.test_execution_id)


### PR DESCRIPTION
### Description
[Describe what this change achieves]

display test execution id before running test for start and execution-test commands. These are the only 2 subcommands which use this argument.

### Issues Resolved
[List any issues this PR will resolve]
#471 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]
Ran without custom test execution id
```
python3 osbenchmark/benchmark.py execute-test --pipeline=benchmark-only --workload=percolator --target-host=https://localhost:9200/ --client-options=basic_auth_user:admin,basic_auth_password:admin,verify_certs:false --test-mode                                     

[INFO] [Test Execution ID]: a7b0f002-573c-41c6-a2fb-8df7d9ad0ff6
[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Executing test with workload [percolator], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [2.12.0]
```

With custom id
```
python3 osbenchmark/benchmark.py execute-test --pipeline=benchmark-only --workload=percolator --target-host=https://localhost:9200/ --client-options=basic_auth_user:admin,basic_auth_password:admin,verify_certs:false --test-mode --test-execution-id "custom-test-123"

[INFO] [Test Execution ID]: custom-test-123
```
Validated `make test`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
