### PR TITLE
Added runners to register and deploy ml-model

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -41,6 +41,7 @@ from typing import List, Optional
 
 import ijson
 from opensearchpy import ConnectionTimeout
+from opensearchpy import NotFoundError
 
 from osbenchmark import exceptions, workload
 from osbenchmark.utils import convert
@@ -1291,8 +1292,8 @@ class DeletePipeline(Runner):
                                                     master_timeout=params.get("master-timeout"),
                                                     timeout=params.get("timeout"),
                                                     )
-        except:
-            pass # no current pipeline
+        except NotFoundError as e:
+            self.logger.info("No current pipeline [%s] to delete.", params.get("id"))
 
     def __repr__(self, *args, **kwargs):
         return "delete-pipeline"
@@ -2395,20 +2396,18 @@ class DeleteMlModel(Runner):
                     }
                 }
             },
-            "size": 1000
+            "size": params.get('number-of-hits-to-return', 1000)
         }
 
         model_ids = set()
-        try:
-            resp = await opensearch.transport.perform_request('POST', '/_plugins/_ml/models/_search', body=body)
-            for item in resp['hits']['hits']:
-                doc = item.get('_source')
-                if doc:
-                    id = doc.get('model_id')
-                    if id:
-                        model_ids.add(id)
-        except:
-            pass # no current model
+
+        resp = await opensearch.transport.perform_request('POST', '/_plugins/_ml/models/_search', body=body)
+        for item in resp['hits']['hits']:
+            doc = item.get('_source')
+            if doc:
+                id = doc.get('model_id')
+                if id:
+                    model_ids.add(id)
 
         for model_id in model_ids:
             resp=await opensearch.transport.perform_request('POST', '/_plugins/_ml/models/' + model_id + '/_undeploy')
@@ -2435,20 +2434,17 @@ class RegisterMlModel(Runner):
                 "match": {
                     "name": body['name']
                 }
-            },
-            "size": 1000
+            }
         }
         model_id = None
-        try:
-            resp = await opensearch.transport.perform_request('POST', '/_plugins/_ml/models/_search', body=search_body)
-            for item in resp['hits']['hits']:
-                doc = item.get('_source')
-                if doc:
-                    model_id = doc.get('model_id')
-                    if model_id:
-                        break
-        except:
-            pass
+
+        resp = await opensearch.transport.perform_request('POST', '/_plugins/_ml/models/_search', body=search_body)
+        for item in resp['hits']['hits']:
+            doc = item.get('_source')
+            if doc:
+                model_id = doc.get('model_id')
+                if model_id:
+                    break
 
         if not model_id:
             resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/models/_register', body=body)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1292,7 +1292,7 @@ class DeletePipeline(Runner):
                                                     master_timeout=params.get("master-timeout"),
                                                     timeout=params.get("timeout"),
                                                     )
-        except NotFoundError as e:
+        except NotFoundError:
             self.logger.info("No current pipeline [%s] to delete.", params.get("id"))
 
     def __repr__(self, *args, **kwargs):

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -606,12 +606,13 @@ class OperationType(Enum):
     ForceMerge = 1001
     ClusterHealth = 1002
     PutPipeline = 1003
-    Refresh = 1004
-    CreateIndex = 1005
-    DeleteIndex = 1006
-    CreateIndexTemplate = 1007
-    DeleteIndexTemplate = 1008
-    ShrinkIndex = 1009
+    DeletePipeline = 1004
+    Refresh = 1005
+    CreateIndex = 1006
+    DeleteIndex = 1007
+    CreateIndexTemplate = 1008
+    DeleteIndexTemplate = 1009
+    ShrinkIndex = 1010
     Sleep = 1018
     DeleteSnapshotRepository = 1019
     CreateSnapshotRepository = 1020
@@ -629,6 +630,9 @@ class OperationType(Enum):
     CreateComponentTemplate = 1032
     DeleteComponentTemplate = 1033
     CreateSearchPipeline = 1040
+    DeleteMlModel = 1041
+    RegisterMlModel = 1042
+    DeployMlModel = 1043
 
     @property
     def admin_op(self):
@@ -670,6 +674,8 @@ class OperationType(Enum):
             return OperationType.RawRequest
         elif v == "put-pipeline":
             return OperationType.PutPipeline
+        elif v == "delete-pipeline":
+            return OperationType.DeletePipeline
         elif v == "refresh":
             return OperationType.Refresh
         elif v == "create-index":
@@ -734,6 +740,12 @@ class OperationType(Enum):
             return OperationType.ListAllPointInTime
         elif v == "create-search-pipeline":
             return OperationType.CreateSearchPipeline
+        elif v == "delete-ml-model":
+            return OperationType.DeleteMlModel
+        elif v == "register-ml-model":
+            return OperationType.RegisterMlModel
+        elif v == "deploy-ml-model":
+            return OperationType.DeployMlModel
         else:
             raise KeyError(f"No enum value for [{v}]")
 


### PR DESCRIPTION
### Description
Added runners DeletePipeline, DeleteMlModel, RegisterMlModel and DeployMlModel. So that we can run the new workload semantic_search, that does indexing and search with vector embedding.

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/198

### Testing
Tested by executing the neural_search workload

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
