### PR TITLE
Increase 'mapping.total_fields.limit' to '2000'

### DIFF
--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -4,6 +4,7 @@
   ],
   "settings": {
     "index": {
+      "mapping.total_fields.limit": 2000
     }
   },
   "mappings": {


### PR DESCRIPTION
### Description
With the addition of segment replication related fields in the `node-stats` telemetry the total number of fields in the `benchmark-metrics-*` indices exceed the default limit of 1000. This results in `Limit of total fields [1000] in index [benchmark-metrics-04-2024] has been exceeded` errors in datastore cluster. 

This PR increases the default limit to 2000. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
