### PR TITLE
Add support to big-ann ground truth file format

### DIFF
--- a/tests/utils/dataset_test.py
+++ b/tests/utils/dataset_test.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 from osbenchmark.utils.dataset import Context, get_data_set, HDF5DataSet, BigANNVectorDataSet
 from osbenchmark.utils.parse import ConfigurationError
-from tests.utils.dataset_helper import create_data_set
+from tests.utils.dataset_helper import create_data_set, create_ground_truth
 
 DEFAULT_INDEX_NAME = "test-index"
 DEFAULT_FIELD_NAME = "test-field"
@@ -47,6 +47,21 @@ class DataSetTestCase(TestCase):
         data_set_instance = get_data_set("bigann", valid_data_set_path, Context.INDEX)
         self.assertEqual(data_set_instance.FORMAT_NAME, BigANNVectorDataSet.FORMAT_NAME)
         self.assertEqual(data_set_instance.size(), DEFAULT_NUM_VECTORS)
+
+    def testBigANNGroundTruthAsAcceptableDataSetFormat(self):
+        bin_extension = "bin"
+        data_set_dir = tempfile.mkdtemp()
+
+        valid_data_set_path = create_ground_truth(
+            100,
+            10,
+            bin_extension,
+            Context.NEIGHBORS,
+            data_set_dir
+        )
+        data_set_instance = get_data_set("bigann", valid_data_set_path, Context.NEIGHBORS)
+        self.assertEqual(data_set_instance.FORMAT_NAME, BigANNVectorDataSet.FORMAT_NAME)
+        self.assertEqual(data_set_instance.size(), 100)
 
     def testUnSupportedDataSetFormat(self):
         with self.assertRaises(ConfigurationError) as _:


### PR DESCRIPTION
### Description
Bigann stores ground truth in different format than vector dataset. In this commit, added new dataset that is used by big-ann for ground truth.

### Issues Resolved
#530 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

 - make test
 - Locally tested with bigann neighbor dataset as input and verified that recall is 0.998
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
