### PR TITLE
Adding Vijayan as OpenSearch Benchmark Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788
+* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788 @VijayanB

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer        | GitHub ID                                             | Affiliation |
-| ----------------- | ----------------------------------------------------- | ----------- |
-| Ian Hoang         | [IanHoang](https://github.com/IanHoang)               | Amazon      |
-| Govind Kamat      | [gkamat](https://github.com/gkamat)                   | Amazon      |
-| Mingyang Shi      | [beaioun](https://github.com/beaioun)                 | OSCI        |
-| Chinmay Gadgil    | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
-| Rishabh Singh     | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |
+| Maintainer              | GitHub ID                                             | Affiliation |
+| ----------------------- | ----------------------------------------------------- | ----------- |
+| Ian Hoang               | [IanHoang](https://github.com/IanHoang)               | Amazon      |
+| Govind Kamat            | [gkamat](https://github.com/gkamat)                   | Amazon      |
+| Mingyang Shi            | [beaioun](https://github.com/beaioun)                 | OSCI        |
+| Chinmay Gadgil          | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
+| Rishabh Singh           | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |

--- a/setup.py
+++ b/setup.py
@@ -135,10 +135,10 @@ first_supported_version = "{}.{}".format(supported_python_versions[0][0], suppor
 first_unsupported_version = "{}.{}".format(supported_python_versions[-1][0], supported_python_versions[-1][1] + 1)
 
 setup(name="opensearch-benchmark",
-      author="Ian Hoang, Govind Kamat, Mingyang Shi, Chinmay Gadgil, Rishabh Singh",
-      author_email="ianhoang16@gmail.com, govind_kamat@yahoo.com, mmyyshi@gmail.com, chinmay5j@gmail.com, rishabhksingh@gmail.com",
-      maintainer="Ian Hoang, Govind Kamat, Mingyang Shi, Chinmay Gadgil, Rishabh Singh",
-      maintainer_email="ianhoang16@gmail.com, govind_kamat@yahoo.com, mmyyshi@gmail.com, chinmay5j@gmail.com, rishabhksingh@gmail.com",
+      author="Ian Hoang, Govind Kamat, Mingyang Shi, Chinmay Gadgil, Rishabh Singh, Vijayan Balasubramanian",
+      author_email="ianhoang16@gmail.com, govind_kamat@yahoo.com, mmyyshi@gmail.com, chinmay5j@gmail.com, rishabhksingh@gmail.com, vijayan.balasubramanian@gmail.com",
+      maintainer="Ian Hoang, Govind Kamat, Mingyang Shi, Chinmay Gadgil, Rishabh Singh, Vijayan Balasubramanian",
+      maintainer_email="ianhoang16@gmail.com, govind_kamat@yahoo.com, mmyyshi@gmail.com, chinmay5j@gmail.com, rishabhksingh@gmail.com, vijayan.balasubramanian@gmail.com",
       version=__versionstr__,
       description="Macrobenchmarking framework for OpenSearch",
       long_description=long_description,


### PR DESCRIPTION
### Description
Adding @VijayanB as a maintainer as voted upon by the existing maintainers of OpenSearch Benchmark project per the [maintainer guidelines](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer).

Vijayan has made numerous contributions to OSB code that supports running benchmarks on vector workloads.

Please find all his contributions below:
- [OpenSearch Benchmark Repository Contributions](https://github.com/opensearch-project/opensearch-benchmark/pulls?q=is%3Apr+author%3AVijayanB)
- [OpenSearch Benchmark Workloads Repository Contributions](https://github.com/opensearch-project/opensearch-benchmark-workloads/pulls?q=is%3Apr+is%3Aclosed+author%3AVijayanB)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
