### PR TITLE
Excluding opensearch-benchmarkd process while finding benchmark process

### DIFF
--- a/osbenchmark/utils/process.py
+++ b/osbenchmark/utils/process.py
@@ -133,9 +133,12 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
 
 def is_benchmark_process(p):
     cmdline = p.cmdline()
-    # On Linux, /proc/PID/status truncates the command name to 15 characters.
+    # On Linux, /proc/PID/status truncates the command name to 15 characters which matches both opensearch-benchmark
+    # and opensearch-benchmarkd. Hence, checking command line to exclude opensearch-benchmarkd process.
     return p.name() == "opensearch-benchmark" or \
-        p.name() == "opensearch-benc" or \
+        (p.name() == "opensearch-benc" and
+         len(cmdline) > 1 and
+         os.path.basename(cmdline[1]) != "opensearch-benchmarkd") or \
         (len(cmdline) > 1 and
          os.path.basename(cmdline[0].lower()).startswith("python") and
          os.path.basename(cmdline[1]) == "opensearch-benchmark")


### PR DESCRIPTION
### Description
On Linux, /proc/PID/status truncates the command name to 15 characters which matches both opensearch-benchmark and opensearch-benchmarkd. Adding an additional check to exclude opensearch-benchmarkd process.

### Testing
Validated by running benchmark daemon on three nodes and then by running execute test with ```--load-worker-coordinator-hosts``` option. The test ran fine on the worker nodes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
