### PR TITLE
Removing the duplicate process check based on truncated name and relying on cmdline check

### DIFF
--- a/osbenchmark/utils/process.py
+++ b/osbenchmark/utils/process.py
@@ -133,12 +133,7 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
 
 def is_benchmark_process(p):
     cmdline = p.cmdline()
-    # On Linux, /proc/PID/status truncates the command name to 15 characters which matches both opensearch-benchmark
-    # and opensearch-benchmarkd. Hence, checking command line to exclude opensearch-benchmarkd process.
     return p.name() == "opensearch-benchmark" or \
-        (p.name() == "opensearch-benc" and
-         len(cmdline) > 1 and
-         os.path.basename(cmdline[1]) != "opensearch-benchmarkd") or \
         (len(cmdline) > 1 and
          os.path.basename(cmdline[0].lower()).startswith("python") and
          os.path.basename(cmdline[1]) == "opensearch-benchmark")

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -124,7 +124,7 @@ class ProcessTests(TestCase):
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         benchmark_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         # On Linux, the process name is truncated to 15 characters.
-        benchmark_process_l = ProcessTests.Process(106, "opensearch-benc", ["/usr/bin/python3", "~/.local/bin/osbenchmark"])
+        benchmark_process_l = ProcessTests.Process(106, "opensearch-benc", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         benchmark_process_e = ProcessTests.Process(107, "opensearch-benchmark", ["/usr/bin/python3", "~/.local/bin/opensearch-benchmark"])
         benchmark_process_mac = ProcessTests.Process(108, "Python", ["/Python.app/Contents/MacOS/Python",
                                                                      "~/.local/bin/opensearch-benchmark"])


### PR DESCRIPTION
### Description

On linux, the process name is truncated to 15 characters and hence it matches both opensearch-benchmark and opensearch-benchmarkd. This results in killing the daemon process and breaks the distributed run setup. Removing the name based check on the truncated name and relying on command line which provides the full command.

Keeping the name based check on full name as is.

### Testing
Tested in Linux system and verified daemon process is excluded in duplicate process check.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
