### PR TITLE
Add email addresses for Maintainers on MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,11 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                             | Affiliation |
-| ----------------------- | ----------------------------------------------------- | ----------- |
-| Ian Hoang               | [IanHoang](https://github.com/IanHoang)               | Amazon      |
-| Govind Kamat            | [gkamat](https://github.com/gkamat)                   | Amazon      |
-| Mingyang Shi            | [beaioun](https://github.com/beaioun)                 | OSCI        |
-| Chinmay Gadgil          | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
-| Rishabh Singh           | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |
+| Maintainer              | GitHub ID                                             | Affiliation | Email Address                     |
+| ----------------------- | ----------------------------------------------------- | ----------- | --------------------------------- |
+| Ian Hoang               | [IanHoang](https://github.com/IanHoang)               | Amazon      | ianhoang16@gmail.com              |
+| Govind Kamat            | [gkamat](https://github.com/gkamat)                   | Amazon      | govind_kamat@yahoo.com            |
+| Mingyang Shi            | [beaioun](https://github.com/beaioun)                 | OSCI        | mmyyshi@gmail.com                 |
+| Chinmay Gadgil          | [cgchinmay](https://github.com/cgchinmay)             | Amazon      | chinmay5j@gmail.com               |
+| Rishabh Singh           | [rishabh6788](https://github.com/rishabh6788)         | Amazon      | rishabhksingh@gmail.com           |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      | vijayan.balasubramanian@gmail.com |


### PR DESCRIPTION
### Description
Adding maintainer email addresses to MAINTAINERS.md

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
