### PR TITLE
Adds --randomization-alpha flag controlling distribution of repeated queries

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -590,7 +590,7 @@ def create_arg_parser():
     test_execution_parser.add_argument(
         "--randomization-alpha",
         help=f"The alpha parameter used for the Zipf distribution for query randomization. Low values spread the distribution out, "
-             f"high values favor the most common queries more. "
+             f"high values favor the most common queries. "
              f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA)
 

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -587,6 +587,12 @@ def create_arg_parser():
         help=f"The number of standard values to generate for each field for query randomization."
              f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N)
+    test_execution_parser.add_argument(
+        "--randomization-alpha",
+        help=f"The alpha parameter used for the Zipf distribution for query randomization. Low values spread the distribution out, "
+             f"high values favor the most common queries more. "
+             f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA}).",
+        default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA)
 
     ###############################################################################
     #
@@ -906,6 +912,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.repeat_frequency", args.randomization_repeat_frequency)
             cfg.add(config.Scope.applicationOverride, "workload", "randomization.n", args.randomization_n)
+            cfg.add(config.Scope.applicationOverride, "workload", "randomization.alpha", args.randomization_alpha)
             configure_workload_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)
             configure_telemetry_params(args, cfg)

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -935,12 +935,13 @@ class TestModeWorkloadProcessor(WorkloadProcessor):
 class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
     DEFAULT_RF = 0.3
     DEFAULT_N = 5000
+    DEFAULT_ALPHA = 1
     def __init__(self, cfg):
         self.randomization_enabled = cfg.opts("workload", "randomization.enabled", mandatory=False, default_value=False)
         self.rf = float(cfg.opts("workload", "randomization.repeat_frequency", mandatory=False, default_value=self.DEFAULT_RF))
         self.logger = logging.getLogger(__name__)
         self.N = int(cfg.opts("workload", "randomization.n", mandatory=False, default_value=self.DEFAULT_N))
-        self.zipf_alpha = 1
+        self.zipf_alpha = float(cfg.opts("workload", "randomization.alpha", mandatory=False, default_value=self.DEFAULT_ALPHA))
         self.H_list = self.precompute_H(self.N, self.zipf_alpha)
 
     # Helper functions for computing Zipf distribution


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/opensearch-benchmark/pull/455 introduced a way to controllably randomize range queries in workloads, which is useful in testing caching behavior. One relevant parameter is Zipf alpha, which changes the shape of the Zipf distribution used for repeated queries. If alpha is small, queries will be more evenly distributed, while if it's large the few most common queries will be preferred more. 

I intended to include this as a flag in my original PR but I apparently forgot to do this, and currently alpha is hardcoded to 1. This PR exposes `--randomization-alpha` so the user can set this value explicitly. 
### Issues Resolved
N/A

### Testing
- [x] New functionality includes testing

Manually tested in a debug version of this branch, by checking the value of the flag made it to QueryRandomizerWorkloadProcessor.zipf_alpha, and checking the indices generated for different values of alpha match what we would expect.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
