### PR TITLE
Add back h5py restriction in Dockerfile to unblock Docker Build for ARM images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -y update && \
 RUN groupadd --gid 1000 opensearch-benchmark && \
     useradd -d /opensearch-benchmark -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash benchmark
 
-RUN if [ -z "$VERSION" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==$VERSION ; fi
+RUN python3 -m pip install h5py==3.10.0; if [ -z "$VERSION" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==$VERSION ; fi
 
 WORKDIR /opensearch-benchmark
 


### PR DESCRIPTION
### Description

Dockerbuild job in Jenkins is currently blocked when building images for ARM. Add back h5py restriction in Dockerfile to unblock Docker Build for ARM images.

### Testing
Tested this in a c6g.large EC2 instance and reproduced it. Confirmed build and image works after we added this line back in.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
