### PR TITLE
Fix h5py build issues encountered during the release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check-venv:
 
 install-user: venv-create
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
+	. $(VENV_ACTIVATE_FILE); PIP_ONLY_BINARY=h5py $(PIP_WRAPPER) install -e .
 
 install: install-user
 	# Also install development dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -y update && \
 RUN groupadd --gid 1000 opensearch-benchmark && \
     useradd -d /opensearch-benchmark -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash benchmark
 
-RUN python3 -m pip install h5py==3.10.0; if [ -z "$VERSION" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==$VERSION ; fi
+RUN if [ -z "$VERSION" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==$VERSION ; fi
 
 WORKDIR /opensearch-benchmark
 


### PR DESCRIPTION
### Description
`h5py` wheels are supplied for different versions on Intel and ARM architectures, and the build from source of this package is not straightforward, leading to issues during the OSB release.  This change ensures that a source build is not attempted.

### Issues Resolved
#570 

### Testing
Built OSB manually on both `x86` and `aarch64`.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
