### PR TITLE
Publish recall as a kpi metric

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -2070,7 +2070,7 @@ class GlobalStats:
                             "max": item["max"]
                         }
                     })
-            elif metric == "kpi_metrics":
+            elif metric == "correctness_metrics":
                 for item in value:
                     if "recall@k" in item:
                         all_results.append({

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1410,7 +1410,6 @@ class TestExecution:
         if self.plugin_params:
             d["plugin-params"] = self.plugin_params
         return d
-
     def to_result_dicts(self):
         """
         :return: a list of dicts, suitable for persisting the results of this test execution in a format that is Kibana-friendly.
@@ -2071,7 +2070,7 @@ class GlobalStats:
                             "max": item["max"]
                         }
                     })
-            elif metric == "correctness_metrics":
+            elif metric == "kpi_metrics":
                 for item in value:
                     if "recall@k" in item:
                         all_results.append({

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -13,7 +13,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# 	http://www.apache.org/licenses/LICENSE-2.0
+#	http://www.apache.org/licenses/LICENSE-2.
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -1782,12 +1782,11 @@ class GlobalStatsCalculator:
                         ),
                     )
 
-                    result.add_kpi_metrics(
+                    result.add_correctness_metrics(
                         t,
                         task.operation.name,
                         self.single_latency(t, op_type, metric_name="recall@k"),
                         self.single_latency(t, op_type, metric_name="recall@1"),
-                        self.single_latency(t, op_type, metric_name="recall_time_ms"),
                         error_rate,
                         duration,
                     )
@@ -1986,7 +1985,7 @@ class GlobalStatsCalculator:
 class GlobalStats:
     def __init__(self, d=None):
         self.op_metrics = self.v(d, "op_metrics", default=[])
-        self.kpi_metrics = self.v(d, "kpi_metrics", default=[])
+        self.correctness_metrics = self.v(d, "correctness_metrics", default=[])
         self.total_time = self.v(d, "total_time")
         self.total_time_per_shard = self.v(d, "total_time_per_shard", default={})
         self.indexing_throttle_time = self.v(d, "indexing_throttle_time")
@@ -2072,6 +2071,22 @@ class GlobalStats:
                             "max": item["max"]
                         }
                     })
+            elif metric == "correctness_metrics":
+                for item in value:
+                    if "recall@k" in item:
+                        all_results.append({
+                            "task": item["task"],
+                            "operation": item["operation"],
+                            "name": "recall@k",
+                            "value": item["recall@k"]
+                        })
+                    if "recall@1" in item:
+                        all_results.append({
+                            "task": item["task"],
+                            "operation": item["operation"],
+                            "name": "recall@1",
+                            "value": item["recall@1"]
+                        })
             elif metric.startswith("total_transform_") and value is not None:
                 for item in value:
                     all_results.append({
@@ -2115,13 +2130,12 @@ class GlobalStats:
             doc["meta"] = meta
         self.op_metrics.append(doc)
 
-    def add_kpi_metrics(self, task, operation, recall_at_k_stats, recall_at_1_stats, recall_time_ms_stats, error_rate, duration):
-        self.kpi_metrics.append({
+    def add_correctness_metrics(self, task, operation, recall_at_k_stats, recall_at_1_stats, error_rate, duration):
+        self.correctness_metrics.append({
             "task": task,
             "operation": operation,
             "recall@k": recall_at_k_stats,
             "recall@1":recall_at_1_stats,
-            "recall_time_ms": recall_time_ms_stats,
             "error_rate": error_rate,
             "duration": duration
             }

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -13,7 +13,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.
+#	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1759,17 +1759,10 @@ class GlobalStatsCalculator:
                     result.add_op_metrics(
                         t,
                         task.operation.name,
-                        self.summary_stats(
-                            "throughput",
-                            t,
-                            op_type,
-                            percentiles_list=self.throughput_percentiles,
-                        ),
+                        self.summary_stats("throughput", t, op_type, percentiles_list=self.throughput_percentiles),
                         self.single_latency(t, op_type),
                         self.single_latency(t, op_type, metric_name="service_time"),
-                        self.single_latency(
-                            t, op_type, metric_name="client_processing_time"
-                        ),
+                        self.single_latency(t, op_type, metric_name="client_processing_time"),
                         self.single_latency(t, op_type, metric_name="processing_time"),
                         error_rate,
                         duration,

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -156,11 +156,15 @@ class SummaryResultsPublisher:
             metrics_table.extend(self._publish_error_rate(record, task))
             self.add_warnings(warnings, record, task)
 
-        for record in stats.kpi_metrics:
+        for record in stats.correctness_metrics:
             task = record["task"]
-            res = self._publish_recall(record, task)
-            if res:
-                metrics_table.extend(res)
+
+            keys = record.keys()
+            recall_keys_in_task_dict = "recall@1" in keys and "recall@k" in keys
+            if recall_keys_in_task_dict and record["recall@1"] and record["recall@k"]:
+                res = self._publish_recall(record, task)
+                if res:
+                    metrics_table.extend(res)
 
         self.write_results(metrics_table)
 
@@ -213,8 +217,7 @@ class SummaryResultsPublisher:
         try:
             return self._join(
                 self._line("Mean recall@k", task, recall_k["mean"], "", lambda v: "%.2f" % v),
-                self._line("Mean recall@1", task, recall_1["mean"], "", lambda v: "%.2f" % v),
-                *self._publish_percentiles("recall_k percentiles", task, recall_k, unit="")
+                self._line("Mean recall@1", task, recall_1["mean"], "", lambda v: "%.2f" % v)
             )
         except KeyError:
             return None

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -157,7 +157,6 @@ class SummaryResultsPublisher:
             self.add_warnings(warnings, record, task)
 
         for record in stats.correctness_metrics:
-        for record in stats.correctness_metrics:
             task = record["task"]
 
             keys = record.keys()

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -157,14 +157,13 @@ class SummaryResultsPublisher:
             self.add_warnings(warnings, record, task)
 
         for record in stats.correctness_metrics:
+        for record in stats.correctness_metrics:
             task = record["task"]
 
             keys = record.keys()
             recall_keys_in_task_dict = "recall@1" in keys and "recall@k" in keys
-            if recall_keys_in_task_dict and record["recall@1"] and record["recall@k"]:
-                res = self._publish_recall(record, task)
-                if res:
-                    metrics_table.extend(res)
+            if recall_keys_in_task_dict and "mean" in record["recall@1"] and "mean" in record["recall@k"]:
+                metrics_table.extend(self._publish_recall(record, task))
 
         self.write_results(metrics_table)
 
@@ -211,16 +210,13 @@ class SummaryResultsPublisher:
         return self._publish_percentiles("processing time", task, values["processing_time"])
 
     def _publish_recall(self, values, task):
-        recall_k = values["recall@k"]
-        recall_1 = values["recall@1"]
+        recall_k_mean = values["recall@k"]["mean"]
+        recall_1_mean = values["recall@1"]["mean"]
 
-        try:
-            return self._join(
-                self._line("Mean recall@k", task, recall_k["mean"], "", lambda v: "%.2f" % v),
-                self._line("Mean recall@1", task, recall_1["mean"], "", lambda v: "%.2f" % v)
-            )
-        except KeyError:
-            return None
+        return self._join(
+            self._line("Mean recall@k", task, recall_k_mean, "", lambda v: "%.2f" % v),
+            self._line("Mean recall@1", task, recall_1_mean, "", lambda v: "%.2f" % v)
+        )
 
     def _publish_percentiles(self, name, task, value, unit="ms"):
         lines = []

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -881,7 +881,7 @@ class SamplePostprocessor:
                             name=recall_metric_name,
                             value=sample.request_meta_data[recall_metric_name],
                             unit="",
-                            task=sample.task.name,  # todo change unit to segment count unit...
+                            task=sample.task.name,
                             operation=sample.operation_name,
                             operation_type=sample.operation_type,
                             sample_type=sample.sample_type,

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -938,7 +938,7 @@ class SamplePostprocessor:
         end = time.perf_counter()
         self.logger.debug("Calculating throughput took [%f] seconds.", (end - start))
         start = end
-        for task, samples in aggregates.items(): # returns dict of task, and samples.
+        for task, samples in aggregates.items():
             meta_data = self.merge(
                 self.workload_meta_data,
                 self.test_procedure_meta_data,

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1233,7 +1233,6 @@ class Sampler:
     def add(self, task, client_id, sample_type, meta_data, absolute_time, request_start, latency, service_time,
             client_processing_time, processing_time, throughput, ops, ops_unit, time_period, percent_completed,
             dependent_timing=None):
-        self.logger.debug("Logging with metadata: [%s]", meta_data)
         try:
             self.q.put_nowait(
                 Sample(client_id, absolute_time, request_start, self.start_timestamp, task, sample_type, meta_data,
@@ -1413,7 +1412,7 @@ class ThroughputCalculator:
             self.task_stats[task] = ThroughputCalculator.TaskStats(bucket_interval=bucket_interval_secs,
                                                                    sample_type=first_sample.sample_type,
                                                                    start_time=first_sample.absolute_time - first_sample.time_period)
-        current = self.task_stats[task] # TaskStats object
+        current = self.task_stats[task]
         count = current.total_count
         last_sample = None
         for sample in current_samples:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -870,13 +870,6 @@ class SamplePostprocessor:
                             sample.request_meta_data,
                         )
 
-                        self.logger.debug(
-                            "Here are the sample stats: Task: %s, operation: %s, operation_type; %s, sample_type: %s",
-                            sample.task.name,
-                            sample.operation_name,
-                            sample.operation_type,
-                            sample.sample_type,
-                        )
                         self.metrics_store.put_value_cluster_level(
                             name=recall_metric_name,
                             value=sample.request_meta_data[recall_metric_name],

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1436,97 +1436,105 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
-                "distribution-major-version": 5,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": "oss",
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
-                "plugin-params": {
-                    "some-param": True
-                },
                 "active": True,
-                "name": "old_gc_time",
-                "value": {
-                    "single": 5
-                },
+                "distribution-major-version": 5,
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "plugin-params": {"some-param": True},
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                }
+                },
+                "name": "kpi_metrics",
+                "value": {"single": []}
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
-                "distribution-major-version": 5,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": "oss",
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
-                "plugin-params": {
-                    "some-param": True
-                },
                 "active": True,
-                "name": "throughput",
+                "distribution-major-version": 5,
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "plugin-params": {"some-param": True},
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated"
+                },
+                "name": "old_gc_time",
+                "value": {"single": 5}
+            },
+            {
+                "benchmark-version": "0.4.4",
+                "benchmark-revision": "123abc",
+                "environment": "unittest",
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-timestamp": "20160131T000000Z",
+                "distribution-version": "5.0.0",
+                "distribution-flavor": "oss",
+                "user-tags": {"os": "Linux"},
+                "workload": "unittest-workload",
+                "test_procedure": "index",
+                "provision-config-instance": "4gheap",
+                "active": True,
+                "distribution-major-version": 5,
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "plugin-params": {"some-param": True},
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated",
+                    "op-type": "bulk"
+                },
                 "task": "index #1",
                 "operation": "index",
+                "name": "throughput",
                 "value": {
                     "min": 1000,
                     "median": 1250,
                     "max": 1500,
                     "unit": "docs/s"
-                },
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated",
-                    "op-type": "bulk"
                 }
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
-                "distribution-major-version": 5,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": "oss",
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
-                "plugin-params": {
-                    "some-param": True
-                },
                 "active": True,
-                "name": "young_gc_time",
-                "value": {
-                    "single": 100
-                },
+                "distribution-major-version": 5,
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "plugin-params": {"some-param": True},
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                }
+                },
+                "name": "young_gc_time",
+                "value": {"single": 100}
             }
         ]
         self.es_mock.bulk_index.assert_called_with(
@@ -1588,85 +1596,97 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": None,
                 "distribution-version": None,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": None,
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
                 "active": True,
-                "name": "old_gc_time",
-                "value": {
-                    "single": 5
-                },
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                }
+                },
+                "name": "kpi_metrics",
+                "value": {"single": []}
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": None,
                 "distribution-version": None,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": None,
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
                 "active": True,
-                "name": "throughput",
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated"
+                },
+                "name": "old_gc_time",
+                "value": {"single": 5}
+            },
+            {
+                "benchmark-version": "0.4.4",
+                "benchmark-revision": None,
+                "environment": "unittest",
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-timestamp": "20160131T000000Z",
+                "distribution-version": None,
+                "distribution-flavor": None,
+                "user-tags": {"os": "Linux"},
+                "workload": "unittest-workload",
+                "test_procedure": "index",
+                "provision-config-instance": "4gheap",
+                "active": True,
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated",
+                    "op-type": "bulk"
+                },
                 "task": "index #1",
                 "operation": "index",
+                "name": "throughput",
                 "value": {
                     "min": 1000,
                     "median": 1250,
                     "max": 1500,
                     "unit": "docs/s"
-                },
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated",
-                    "op-type": "bulk"
                 }
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-flavor": None,
                 "distribution-version": None,
-                "user-tags": {
-                    "os": "Linux"
-                },
+                "distribution-flavor": None,
+                "user-tags": {"os": "Linux"},
                 "workload": "unittest-workload",
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
                 "active": True,
-                "name": "young_gc_time",
-                "value": {
-                    "single": 100
-                },
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                }
+                },
+                "name": "young_gc_time",
+                "value": {"single": 100}
             }
         ]
         self.es_mock.bulk_index.assert_called_with(index="benchmark-results-2016-01", doc_type="_doc", items=expected_docs)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1436,106 +1436,99 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": "5.0.0",
                 "distribution-flavor": "oss",
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
-                "test_procedure": "index",
-                "provision-config-instance": "4gheap",
-                "active": True,
+                "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
+                "user-tags": {
+                    "os": "Linux"
+                },
+                "workload": "unittest-workload",
                 "provision-config-revision": "123ab",
                 "workload-revision": "abc1",
-                "plugin-params": {"some-param": True},
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated"
-                },
-                "name": "kpi_metrics",
-                "value": {"single": []}
-            },
-            {
-                "benchmark-version": "0.4.4",
-                "benchmark-revision": "123abc",
-                "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
-                "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": "5.0.0",
-                "distribution-flavor": "oss",
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
-                "active": True,
-                "distribution-major-version": 5,
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
-                "plugin-params": {"some-param": True},
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated"
+                "plugin-params": {
+                    "some-param": True
                 },
+                "active": True,
                 "name": "old_gc_time",
-                "value": {"single": 5}
-            },
-            {
-                "benchmark-version": "0.4.4",
-                "benchmark-revision": "123abc",
-                "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
-                "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": "5.0.0",
-                "distribution-flavor": "oss",
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
-                "test_procedure": "index",
-                "provision-config-instance": "4gheap",
-                "active": True,
-                "distribution-major-version": 5,
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
-                "plugin-params": {"some-param": True},
+                "value": {
+                    "single": 5
+                },
                 "meta": {
                     "workload-type": "saturation-degree",
-                    "saturation": "70% saturated",
-                    "op-type": "bulk"
-                },
-                "task": "index #1",
-                "operation": "index",
-                "name": "throughput",
-                "value": {
-                    "min": 1000,
-                    "median": 1250,
-                    "max": 1500,
-                    "unit": "docs/s"
+                    "saturation": "70% saturated"
                 }
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": "5.0.0",
                 "distribution-flavor": "oss",
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
-                "test_procedure": "index",
-                "provision-config-instance": "4gheap",
-                "active": True,
+                "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
+                "user-tags": {
+                    "os": "Linux"
+                },
+                "workload": "unittest-workload",
                 "provision-config-revision": "123ab",
                 "workload-revision": "abc1",
-                "plugin-params": {"some-param": True},
+                "test_procedure": "index",
+                "provision-config-instance": "4gheap",
+                "plugin-params": {
+                    "some-param": True
+                },
+                "active": True,
+                "name": "throughput",
+                "task": "index #1",
+                "operation": "index",
+                "value": {
+                    "min": 1000,
+                    "median": 1250,
+                    "max": 1500,
+                    "unit": "docs/s"
+                },
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated",
+                    "op-type": "bulk"
+                }
+            },
+            {
+                "benchmark-version": "0.4.4",
+                "benchmark-revision": "123abc",
+                "environment": "unittest",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-timestamp": "20160131T000000Z",
+                "distribution-flavor": "oss",
+                "distribution-version": "5.0.0",
+                "distribution-major-version": 5,
+                "user-tags": {
+                    "os": "Linux"
+                },
+                "workload": "unittest-workload",
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
+                "test_procedure": "index",
+                "provision-config-instance": "4gheap",
+                "plugin-params": {
+                    "some-param": True
+                },
+                "active": True,
+                "name": "young_gc_time",
+                "value": {
+                    "single": 100
+                },
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                },
-                "name": "young_gc_time",
-                "value": {"single": 100}
+                }
             }
+            
         ]
         self.es_mock.bulk_index.assert_called_with(
             index="benchmark-results-2016-01",
@@ -1596,97 +1589,85 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": None,
                 "distribution-flavor": None,
-                "user-tags": {"os": "Linux"},
+                "distribution-version": None,
+                "user-tags": {
+                    "os": "Linux"
+                },
                 "workload": "unittest-workload",
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
                 "active": True,
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated"
-                },
-                "name": "kpi_metrics",
-                "value": {"single": []}
-            },
-            {
-                "benchmark-version": "0.4.4",
-                "benchmark-revision": None,
-                "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
-                "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": None,
-                "distribution-flavor": None,
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
-                "test_procedure": "index",
-                "provision-config-instance": "4gheap",
-                "active": True,
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
-                "meta": {
-                    "workload-type": "saturation-degree",
-                    "saturation": "70% saturated"
-                },
                 "name": "old_gc_time",
-                "value": {"single": 5}
-            },
-            {
-                "benchmark-version": "0.4.4",
-                "benchmark-revision": None,
-                "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
-                "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": None,
-                "distribution-flavor": None,
-                "user-tags": {"os": "Linux"},
-                "workload": "unittest-workload",
-                "test_procedure": "index",
-                "provision-config-instance": "4gheap",
-                "active": True,
-                "provision-config-revision": "123ab",
-                "workload-revision": "abc1",
+                "value": {
+                    "single": 5
+                },
                 "meta": {
                     "workload-type": "saturation-degree",
-                    "saturation": "70% saturated",
-                    "op-type": "bulk"
-                },
-                "task": "index #1",
-                "operation": "index",
-                "name": "throughput",
-                "value": {
-                    "min": 1000,
-                    "median": 1250,
-                    "max": 1500,
-                    "unit": "docs/s"
+                    "saturation": "70% saturated"
                 }
             },
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-execution-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
                 "test-execution-timestamp": "20160131T000000Z",
-                "distribution-version": None,
                 "distribution-flavor": None,
-                "user-tags": {"os": "Linux"},
+                "distribution-version": None,
+                "user-tags": {
+                    "os": "Linux"
+                },
                 "workload": "unittest-workload",
+                "provision-config-revision": "123ab",
+                "workload-revision": "abc1",
                 "test_procedure": "index",
                 "provision-config-instance": "4gheap",
                 "active": True,
+                "name": "throughput",
+                "task": "index #1",
+                "operation": "index",
+                "value": {
+                    "min": 1000,
+                    "median": 1250,
+                    "max": 1500,
+                    "unit": "docs/s"
+                },
+                "meta": {
+                    "workload-type": "saturation-degree",
+                    "saturation": "70% saturated",
+                    "op-type": "bulk"
+                }
+            },
+            {
+                "benchmark-version": "0.4.4",
+                "benchmark-revision": None,
+                "environment": "unittest",
+                "test-execution-id": OsResultsStoreTests.TEST_EXECUTION_ID,
+                "test-execution-timestamp": "20160131T000000Z",
+                "distribution-flavor": None,
+                "distribution-version": None,
+                "user-tags": {
+                    "os": "Linux"
+                },
+                "workload": "unittest-workload",
                 "provision-config-revision": "123ab",
                 "workload-revision": "abc1",
+                "test_procedure": "index",
+                "provision-config-instance": "4gheap",
+                "active": True,
+                "name": "young_gc_time",
+                "value": {
+                    "single": 100
+                },
                 "meta": {
                     "workload-type": "saturation-degree",
                     "saturation": "70% saturated"
-                },
-                "name": "young_gc_time",
-                "value": {"single": 100}
+                }
             }
         ]
         self.es_mock.bulk_index.assert_called_with(index="benchmark-results-2016-01", doc_type="_doc", items=expected_docs)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1528,7 +1528,6 @@ class OsResultsStoreTests(TestCase):
                     "saturation": "70% saturated"
                 }
             }
-            
         ]
         self.es_mock.bulk_index.assert_called_with(
             index="benchmark-results-2016-01",


### PR DESCRIPTION
### Description
Displays recall as part of the final benchmarking stats.
i.e.: 
```
------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |                     Task |       Value |   Unit |
|---------------------------------------------------------------:|-------------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                          |     16.1933 |    min |
.............................................................................................      .....................................................................
| Mean recall@k |             prod-queries |        0.99 |        |

|                                                  Mean recall@1 |             prod-queries |           1 |        |
|                           50th percentile recall_k percentiles |             prod-queries |           1 |        |
|                           90th percentile recall_k percentiles |             prod-queries |           1 |        |
|                           99th percentile recall_k percentiles |             prod-queries |           1 |        |
|                          100th percentile recall_k percentiles |             prod-queries |           1 |        |
```

### Issues Resolved
(From workloads repo): [282](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/282)
While this PR is not a general solution to #199, it does address the specific need mentioned in that issue of displaying the recall metadata as a summary. 

I have added a `kpi_metrics` field to the `GlobalStats` metric collector where additional metrics could be added. Users would then need to add display logic to the `results_publisher.py` file in order for the metrics to show up in the summary. 

### Testing
- [X] New functionality includes testing

I added some unit tests to assert that recall metrics were collected. I also altered the `OsResultsStoreTest` to account for the new `kpi_metrics` field.

I manually tested the `train-test` workload, which contains a vector search operation, and the `no-train-test-index-only` workload, which does not contain a vector search operation. Both workloads ran to completion and displayed the expected statistics (recall for `train-test`, and no recall metrics for `no-train-test-index-only`). 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
