### PR TITLE
Added runners for enabling concurrent segment search via settings

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -2696,3 +2696,17 @@ class DeployMlModel(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "deploy-ml-model"
+
+class EnableConcurrentSegmentSearch(Runner):
+    @time_func
+    async def __call__(self, opensearch, params):
+        enable_setting = params.get("enable", "false")
+        body = {
+            "transient": {
+                "search.concurrent_segment_search.enabled": enable_setting
+              } 
+            }
+        await opensearch.cluster.put_settings(body=body)
+
+    def __repr__(self, *args, **kwargs):
+        return "enable-concurrent-segment-search"

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -107,6 +107,7 @@ def register_default_runners():
     register_runner(workload.OperationType.DeployMlModel, Retry(DeployMlModel()), async_runner=True)
     register_runner(workload.OperationType.TrainKnnModel, Retry(TrainKnnModel()), async_runner=True)
     register_runner(workload.OperationType.DeleteKnnModel, Retry(DeleteKnnModel()), async_runner=True)
+    register_runner(workload.OperationType.EnableConcurrentSegmentSearch, Retry(EnableConcurrentSegmentSearch()), async_runner=True)
 
 def runner_for(operation_type):
     try:
@@ -2702,10 +2703,10 @@ class EnableConcurrentSegmentSearch(Runner):
     async def __call__(self, opensearch, params):
         enable_setting = params.get("enable", "false")
         body = {
-            "transient": {
+            "persistent": {
                 "search.concurrent_segment_search.enabled": enable_setting
-              } 
             }
+        }
         await opensearch.cluster.put_settings(body=body)
 
     def __repr__(self, *args, **kwargs):

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -635,6 +635,7 @@ class OperationType(Enum):
     DeleteMlModel = 1041
     RegisterMlModel = 1042
     DeployMlModel = 1043
+    EnableConcurrentSegmentSearch = 1044
 
     @property
     def admin_op(self):
@@ -752,6 +753,8 @@ class OperationType(Enum):
             return OperationType.TrainKnnModel
         elif v == "delete-knn-model":
             return OperationType.DeleteKnnModel
+        elif v == "enable-concurrent-segment-search":
+            return OperationType.EnableConcurrentSegmentSearch
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -635,7 +635,7 @@ class OperationType(Enum):
     DeleteMlModel = 1041
     RegisterMlModel = 1042
     DeployMlModel = 1043
-    EnableConcurrentSegmentSearch = 1044
+    UpdateConcurrentSegmentSearchSettings = 1044
 
     @property
     def admin_op(self):
@@ -753,8 +753,8 @@ class OperationType(Enum):
             return OperationType.TrainKnnModel
         elif v == "delete-knn-model":
             return OperationType.DeleteKnnModel
-        elif v == "enable-concurrent-segment-search":
-            return OperationType.EnableConcurrentSegmentSearch
+        elif v == "update-concurrent-segment-search-settings":
+            return OperationType.UpdateConcurrentSegmentSearchSettings
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -6785,3 +6785,23 @@ class CreateSearchPipelineRunnerTests(TestCase):
             await r(opensearch, params)
 
         self.assertEqual(0, opensearch.transport.perform_request.call_count)
+
+class EnableConcurrentSegmentSearchTests(TestCase):
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_enable_concurrent_segment_search(self, opensearch, on_client_request_start, on_client_request_end):
+        opensearch.cluster.put_settings.return_value = as_future()
+        params = {
+            "enable": "true"
+        }
+
+        r = runner.EnableConcurrentSegmentSearch()
+        await r(opensearch, params)
+
+        opensearch.cluster.put_settings.assert_called_once_with(body={
+            "transient": {
+                "search.concurrent_segment_search.enabled": "true"
+            } 
+        })

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -6786,7 +6786,7 @@ class CreateSearchPipelineRunnerTests(TestCase):
 
         self.assertEqual(0, opensearch.transport.perform_request.call_count)
 
-class EnableConcurrentSegmentSearchTests(TestCase):
+class UpdateConcurrentSegmentSearchSettingsTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
@@ -6797,11 +6797,52 @@ class EnableConcurrentSegmentSearchTests(TestCase):
             "enable": "true"
         }
 
-        r = runner.EnableConcurrentSegmentSearch()
+        r = runner.UpdateConcurrentSegmentSearchSettings()
         await r(opensearch, params)
 
         opensearch.cluster.put_settings.assert_called_once_with(body={
             "persistent": {
                 "search.concurrent_segment_search.enabled": "true"
+            }
+        })
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_max_slice_count(self, opensearch, on_client_request_start, on_client_request_end):
+        opensearch.cluster.put_settings.return_value = as_future()
+        params = {
+            "max_slice_count": 2
+        }
+
+        r = runner.UpdateConcurrentSegmentSearchSettings()
+        await r(opensearch, params)
+
+        opensearch.cluster.put_settings.assert_called_once_with(body={
+            "persistent": {
+                "search.concurrent_segment_search.enabled": "false",
+                "search.concurrent_segment_search.max_slice_count": 2
+            }
+        })
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_concurrent_segment_search_settings(self, opensearch, on_client_request_start, on_client_request_end):
+        opensearch.cluster.put_settings.return_value = as_future()
+        params = {
+            "enable": "true",
+            "max_slice_count": 2
+        }
+
+        r = runner.UpdateConcurrentSegmentSearchSettings()
+        await r(opensearch, params)
+
+        opensearch.cluster.put_settings.assert_called_once_with(body={
+            "persistent": {
+                "search.concurrent_segment_search.enabled": "true",
+                "search.concurrent_segment_search.max_slice_count": 2
             }
         })

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -6801,7 +6801,7 @@ class EnableConcurrentSegmentSearchTests(TestCase):
         await r(opensearch, params)
 
         opensearch.cluster.put_settings.assert_called_once_with(body={
-            "transient": {
+            "persistent": {
                 "search.concurrent_segment_search.enabled": "true"
-            } 
+            }
         })


### PR DESCRIPTION
### Description
Added EnableConcurrentSegmentSearch runner, this will be used in semantic search workloads like https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/noaa_semantic_search or one that is in PR https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/342 

### Issues Resolved
building block for https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/341

### Testing
- [x] New functionality includes testing

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
