### PR TITLE
Add PIP_ONLY_BINARY to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -y update && \
 RUN groupadd --gid 1000 opensearch-benchmark && \
     useradd -d /opensearch-benchmark -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash benchmark
 
+ENV PIP_ONLY_BINARY=h5py
 RUN if [ -z "$VERSION" ] ; then python3 -m pip install opensearch-benchmark ; else python3 -m pip install opensearch-benchmark==$VERSION ; fi
 
 WORKDIR /opensearch-benchmark


### PR DESCRIPTION
### Description
When building Docker image for ARM64, we're still hitting the same error we encountered before. To unblock build error in Jenkins, we need to add this [change](https://github.com/opensearch-project/opensearch-benchmark/pull/574) (that was originally added to the Makefile in this PR) to the Dockerfile.

### Testing
1. Built Dockerfile with this change
2. Imported h5py and verified binaries were used. As seen below, methods and properties are viewable, implying that binaries (precompiled) was selected over tar.gz
```
benchmark@d1b42b9974e2:~$ python3
Python 3.11.2 (main, Mar 23 2023, 03:00:37) [GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import h5py
>>> dir
KeyboardInterrupt
>>> dir(h5py)
['AttributeManager', 'Dataset', 'Datatype', 'Empty', 'ExternalLink', 'File', 'Group', 'HLObject', 'HardLink', 'MultiBlockSlice', 'Reference', 'RegionReference', 'SoftLink', 'UNLIMITED', 'VirtualLayout', 'VirtualSource', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_conv', '_errors', '_hl', '_objects', '_proxy', '_register_converters', '_register_lzf', '_selector', '_unregister_converters', '_warn', 'atexit', 'check_dtype', 'check_enum_dtype', 'check_opaque_dtype', 'check_ref_dtype', 'check_string_dtype', 'check_vlen_dtype', 'defs', 'enable_ipython_completer', 'enum_dtype', 'filters', 'get_config', 'h5', 'h5a', 'h5ac', 'h5d', 'h5ds', 'h5f', 'h5fd', 'h5g', 'h5i', 'h5l', 'h5o', 'h5p', 'h5pl', 'h5py_warnings', 'h5r', 'h5s', 'h5t', 'h5z', 'is_hdf5', 'opaque_dtype', 'ref_dtype', 'regionref_dtype', 'register_driver', 'registered_drivers', 'run_tests', 'special_dtype', 'string_dtype', 'unregister_driver', 'utils', 'version', 'vlen_dtype']
>>>
```
[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
