### PR TITLE
Add a Jinja filter to aid with version checking

### DIFF
--- a/osbenchmark/builder/utils/template_renderer.py
+++ b/osbenchmark/builder/utils/template_renderer.py
@@ -3,6 +3,7 @@ from jinja2 import select_autoescape
 
 from osbenchmark.exceptions import InvalidSyntax, SystemSetupError
 from osbenchmark.utils import io
+from osbenchmark.workload import loader
 
 
 class TemplateRenderer:
@@ -11,6 +12,7 @@ class TemplateRenderer:
 
     def _render_template_file(self, root_path, variables, file_name):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(root_path), autoescape=select_autoescape(['html', 'xml']))
+        env.filters["version_between"] = loader.version_between
         template = env.get_template(io.basename(file_name))
         # force a new line at the end. Jinja seems to remove it.
         return template.render(variables) + "\n"
@@ -20,6 +22,7 @@ class TemplateRenderer:
 
     def _render_template_string(self, template_string, variables):
         env = jinja2.Environment(loader=jinja2.BaseLoader, autoescape=select_autoescape(['html', 'xml']))
+        env.filters["version_between"] = loader.version_between
         template = env.from_string(template_string)
 
         return template.render(variables)

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -691,6 +691,13 @@ class TemplateSource:
         return ",\n".join(source)
 
 
+# A Jinja filter that tests if a version string lies within a specified range.
+# For instance, "1.2.3" lies between "1.0.0" and "2.0.0".
+def version_between(version, frm, to):
+    return list(map(int, version.split('.'))) >= list(map(int, frm.split('.'))) and \
+        list(map(int, version.split('.'))) <= list(map(int, to.split('.')))
+
+
 def default_internal_template_vars(glob_helper=lambda f: [], clock=time.Clock):
     """
     Dict of internal global variables used by our jinja2 renderers
@@ -751,6 +758,7 @@ def render_template(template_source, template_vars=None, template_internal_vars=
             for env_global_key, env_global_value in template_internal_vars[macro_type].items():
                 getattr(env, macro_type)[env_global_key] = env_global_value
 
+    env.filters["version_between"] = version_between
     template = env.from_string(template_source)
     return template.render()
 

--- a/tests/builder/utils/template_renderer_test.py
+++ b/tests/builder/utils/template_renderer_test.py
@@ -22,6 +22,18 @@ class TemplateRendererTest(TestCase):
 
         self.template_renderer.render_template_file(self.root_path, self.variables, self.file_name)
 
+    def test_version_between_filter(self):
+        self.assertEqual(self.template_renderer.render_template_string('{{ "2.0.0" | version_between("2.0.0", "3.0.0")}}',
+                                                                       self.variables), "True")
+        self.assertEqual(self.template_renderer.render_template_string('{{ "2.2.3" | version_between("2.0.0", "3.0.0")}}',
+                                                                       self.variables), "True")
+        self.assertEqual(self.template_renderer.render_template_string('{{ "3.0.0" | version_between("2.0.0", "3.0.0")}}',
+                                                                       self.variables), "True")
+        self.assertEqual(self.template_renderer.render_template_string('{{ "1.9.0" | version_between("2.0.0", "3.0.0")}}',
+                                                                       self.variables), "False")
+        self.assertEqual(self.template_renderer.render_template_string('{{ "3.0.1" | version_between("2.0.0", "3.0.0")}}',
+                                                                       self.variables), "False")
+
     @mock.patch('jinja2.Environment.get_template')
     def test_template_syntax_error(self, get_template):
         get_template.side_effect = TemplateSyntaxError("fake", 12)


### PR DESCRIPTION
### Description
Customizing workloads to operate differently on different versions of OpenSearch is convoluted.  This change adds a Jinja filter `version_between` that can be used to test if an OpenSearch version falls within a specified range of versions.  For instance, a workload can be customized to operate in a backward-compatible way on OpenSearch 1.X and use updated capabilities on OpenSearch 2.X.

### Issues Resolved
#548 

### Testing
Added a test, ran unit and integ tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
