### PR TITLE
Corrected setting name for max_slice_count

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -2710,7 +2710,7 @@ class UpdateConcurrentSegmentSearchSettings(Runner):
             }
         }
         if max_slice_count is not None:
-            body["persistent"]["search.concurrent_segment_search.max_slice_count"] = max_slice_count
+            body["persistent"]["search.concurrent.max_slice_count"] = max_slice_count
         await opensearch.cluster.put_settings(body=body)
 
     def __repr__(self, *args, **kwargs):

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -6822,7 +6822,7 @@ class UpdateConcurrentSegmentSearchSettingsTests(TestCase):
         opensearch.cluster.put_settings.assert_called_once_with(body={
             "persistent": {
                 "search.concurrent_segment_search.enabled": "false",
-                "search.concurrent_segment_search.max_slice_count": 2
+                "search.concurrent.max_slice_count": 2
             }
         })
 
@@ -6843,6 +6843,6 @@ class UpdateConcurrentSegmentSearchSettingsTests(TestCase):
         opensearch.cluster.put_settings.assert_called_once_with(body={
             "persistent": {
                 "search.concurrent_segment_search.enabled": "true",
-                "search.concurrent_segment_search.max_slice_count": 2
+                "search.concurrent.max_slice_count": 2
             }
         })


### PR DESCRIPTION
### Description
Need to correct setting name for recently added runner EnableConcurrentSegmentSearch. As per [documentation](https://opensearch.org/docs/latest/search-plugins/concurrent-segment-search/) correct setting name is `search.concurrent.max_slice_count`. With current setting name the runner and calling operation will fail.

Original PR https://github.com/opensearch-project/opensearch-benchmark/pull/591

### Testing
- [x] New functionality includes testing

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
