### PR TITLE
Preset opensearch-benchmark-git dir to support dockerfile change in #601

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -18,6 +18,8 @@ standardReleasePipelineWithGenericTrigger(
             string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
             string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: [
                 'su $(id -un 1000) -c "cd docker/ci',
+                'mkdir -p opensearch-benchmark-git',
+                'echo Production > opensearch-benchmark-git/status.txt'
                 'git clone https://github.com/opensearch-project/opensearch-benchmark opensearch-benchmark',
                 'cp -a opensearch-benchmark/* ./"',
                 'cd docker/ci',


### PR DESCRIPTION
### Description
Preset opensearch-benchmark-git dir to support dockerfile change in #601

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4723

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
