### PR TITLE
Add docker-compose-tests.yml back in to fix integ tests

### DIFF
--- a/docker/Dockerfile-development
+++ b/docker/Dockerfile-development
@@ -1,0 +1,75 @@
+################################################################################ For Development Testing Only
+# Build stage 0 `builder`:
+# Install OpenSearch Benchmark from source inside a virtualenv
+################################################################################
+
+FROM python:3.11.2-slim as builder
+
+RUN apt-get -y update && \
+    apt-get install -y curl git gcc && \
+    apt-get -y upgrade && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opensearch-benchmark/
+COPY ./setup.py /opensearch-benchmark/
+COPY ./setup.cfg /opensearch-benchmark/
+COPY ./version.txt /opensearch-benchmark/
+COPY ./README.md /opensearch-benchmark/
+COPY ./MANIFEST.in /opensearch-benchmark/
+COPY ./osbenchmark/ /opensearch-benchmark/osbenchmark/
+COPY ./scripts/ /opensearch-benchmark/scripts/
+
+RUN python3 -m venv /opensearch-benchmark/venv
+ENV PATH="/opensearch-benchmark/venv/bin:$PATH"
+
+WORKDIR /opensearch-benchmark
+# Wipe away any lingering caches, copied over from the local machine
+RUN find ./opensearch-benchmark -name '__pycache__' -o -name '*.pyc' | xargs rm -f
+RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install /opensearch-benchmark
+
+################################################################################
+# Build stage 1 (the actual OpenSearch Benchmark image):
+# Copy OpenSearch Benchmark from stage 0 and fix permissions to support randomized UIDs
+# Define VOLUME for ~/.benchmark
+################################################################################
+
+FROM python:3.11.2-slim
+
+ENV BENCHMARK_RUNNING_IN_DOCKER True
+
+RUN apt-get -y update && \
+    apt-get install -y curl git pbzip2 pigz && \
+    apt-get -y upgrade && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 opensearch-benchmark && \
+    useradd -d /opensearch-benchmark -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash benchmark
+
+COPY --chown=1000:0 --from=builder /opensearch-benchmark/venv /opensearch-benchmark/venv
+
+WORKDIR /opensearch-benchmark
+
+RUN mkdir -p /opensearch-benchmark/.benchmark && \
+    chown -R 1000:0 /opensearch-benchmark/.benchmark
+
+USER 1000
+
+ENV PATH=/opensearch-benchmark/venv/bin:$PATH
+
+ARG VERSION
+ARG BUILD_DATE
+
+LABEL org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="OpenSearch-Project" \
+  org.label-schema.name="opensearch-benchmark" \
+  org.label-schema.url="https://opensearch.org/" \
+  org.label-schema.version="$VERSION" \
+  org.label-schema.license="Apache-2.0" \
+  org.label-schema.description="A community driven, open source project to run performance tests for OpenSearch" \
+  org.label-schema.build-date="$BUILD_DATE" \
+  org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Benchmark"
+
+VOLUME ["/opensearch-benchmark/.benchmark"]
+
+ENTRYPOINT [ "opensearch-benchmark" ]

--- a/docker/docker-compose-tests.yml
+++ b/docker/docker-compose-tests.yml
@@ -1,0 +1,37 @@
+version: '3'
+services:
+  opensearch-node1:
+    image: opensearchproject/opensearch:1.1.0
+    container_name: opensearch-node1
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - discovery.seed_hosts=opensearch-node1
+      - cluster.initial_master_nodes=opensearch-node1
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - opensearch-net
+    healthcheck:
+          test: curl -f http://localhost:9200 -u admin:admin --insecure
+          interval: 5s
+          timeout: 2s
+          retries: 10
+networks:
+  opensearch-net:
+
+volumes:
+  opensearch-data1:
+    driver: local


### PR DESCRIPTION
### Description
Integration tests are currently searching for `docker-compose-tests.yml` which was removed yesterday. Adding it back in.
Example
```
ERROR it/sources_test.py::test_sources[in-memory-it] - FileNotFoundError: [Errno 2] No such file or directory: 'docker-compose'
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
