### PR TITLE
Add approximate filters

### DIFF
--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -27,6 +27,7 @@ class Context(Enum):
     MAX_DISTANCE_NEIGHBORS = 4
     MIN_SCORE_NEIGHBORS = 5
     PARENTS = 6
+    ATTRIBUTES = 7
 
 
 class DataSet(ABC):
@@ -133,6 +134,7 @@ class HDF5DataSet(DataSet):
     def reset(self):
         self.current = self.BEGINNING
 
+    # pylint: disable=R0911
     @staticmethod
     def parse_context(context: Context) -> str:
         if context == Context.NEIGHBORS:
@@ -151,6 +153,9 @@ class HDF5DataSet(DataSet):
 
         if context == Context.MIN_SCORE_NEIGHBORS:
             return "min_score_neighbors"
+
+        if context == Context.ATTRIBUTES:
+            return "attributes"
 
         raise Exception("Unsupported context")
 

--- a/osbenchmark/utils/parse.py
+++ b/osbenchmark/utils/parse.py
@@ -22,7 +22,7 @@ def parse_string_parameter(key: str, params: dict, default: str = None) -> str:
 
 def parse_int_parameter(key: str, params: dict, default: int = None) -> int:
     if key not in params:
-        if default:
+        if default is not None:
             return default
         raise ConfigurationError(
             "Value cannot be None for param {}".format(key)
@@ -46,3 +46,17 @@ def parse_float_parameter(key: str, params: dict, default: float = None) -> floa
         return params[key]
 
     raise ConfigurationError("Value must be a float for param {}".format(key))
+
+
+def parse_bool_parameter(key: str, params: dict, default: bool = None) -> bool:
+    if key not in params:
+        if default is not None:
+            return default
+        raise ConfigurationError(
+            "Value cannot be None for param {}".format(key)
+        )
+
+    if isinstance(params[key], bool):
+        return params[key]
+
+    raise ConfigurationError("Value must be a bool for param {}".format(key))

--- a/tests/utils/dataset_helper.py
+++ b/tests/utils/dataset_helper.py
@@ -193,6 +193,27 @@ class BigANNGroundTruthBuilder(BigANNVectorBuilder):
             # file with distance.
             context.vectors.tofile(f)
 
+
+def create_attributes(num_vectors: int) -> np.ndarray:
+    rng = np.random.default_rng()
+
+    # Random strings and None
+    strings = ["str1", "str2", "str3"]
+
+    # First column: random choice from strings
+    col1 = rng.choice(strings, num_vectors).astype("S10")
+
+    # Second column: random choice from strings
+    col2 = rng.choice(strings, num_vectors).astype("S10")
+
+    # Third column: random numbers between 0 and 100
+    col3 = rng.integers(0, 101, num_vectors).astype("S10")
+
+    # Combine columns into a single array
+    random_vector = np.column_stack((col1, col2, col3))
+
+    return random_vector
+
 def create_parent_ids(num_vectors: int, group_size: int = 10) -> np.ndarray:
     num_ids = (num_vectors + group_size - 1) // group_size  # Calculate total number of different IDs needed
     ids = np.arange(1, num_ids + 1)  # Create an array of IDs starting from 1
@@ -235,6 +256,34 @@ def create_data_set(
     context = DataSetBuildContext(
         data_set_context,
         create_random_2d_array(num_vectors, dimension),
+        data_set_path)
+
+    if extension == HDF5DataSet.FORMAT_NAME:
+        HDF5Builder().add_data_set_build_context(context).build()
+    else:
+        BigANNVectorBuilder().add_data_set_build_context(context).build()
+
+    return data_set_path
+
+
+def create_attributes_data_set(
+        num_vectors: int,
+        dimension: int,
+        extension: str,
+        data_set_context: Context,
+        data_set_dir,
+        file_path: str = None
+) -> str:
+    if file_path:
+        data_set_path = file_path
+    else:
+        file_name_base = ''.join(random.choice(string.ascii_letters) for _ in
+                                 range(DEFAULT_RANDOM_STRING_LENGTH))
+        data_set_file_name = "{}.{}".format(file_name_base, extension)
+        data_set_path = os.path.join(data_set_dir, data_set_file_name)
+    context = DataSetBuildContext(
+        data_set_context,
+        create_attributes(num_vectors),
         data_set_path)
 
     if extension == HDF5DataSet.FORMAT_NAME:

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -3125,7 +3125,7 @@ class VectorSearchQueryRunnerTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
-    async def test_query_vector_radial_search_with_min_score(self, opensearch, on_client_request_start, on_client_request_end):
+    async def test_calculate_recall_with_negative_one_neighbors(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -3142,10 +3142,6 @@ class VectorSearchQueryRunnerTests(TestCase):
                     {
                         "_id": 102,
                         "_score": 0.88
-                    },
-                    {
-                        "_id": 103,
-                        "_score": 0.87
                     }
                 ]
             }
@@ -3159,8 +3155,8 @@ class VectorSearchQueryRunnerTests(TestCase):
             "operation-type": "vector-search",
             "detailed-results": True,
             "response-compression-enabled": False,
-            "min_score": 0.80,
-            "neighbors": [101, 102, 103],
+            "k": 4,
+            "neighbors": [101, 102, -1, -1],
             "body": {
                 "query": {
                     "knn": {
@@ -3169,27 +3165,19 @@ class VectorSearchQueryRunnerTests(TestCase):
                                 5,
                                 4
                             ],
-                            "min_score": 0.80,
+                            "k": 3
                         }
-                    }
-                }
+                    }}
             }
         }
 
         async with query_runner:
             result = await query_runner(opensearch, params)
 
-        self.assertEqual(1, result["weight"])
-        self.assertEqual("ops", result["unit"])
-        self.assertEqual(3, result["hits"])
-        self.assertEqual("eq", result["hits_relation"])
-        self.assertFalse(result["timed_out"])
-        self.assertEqual(5, result["took"])
+        self.assertEqual(result["recall@k"], 1.0)
         self.assertIn("recall_time_ms", result.keys())
-        self.assertIn("recall@min_score", result.keys())
-        self.assertEqual(result["recall@min_score"], 1.0)
-        self.assertIn("recall@min_score_1", result.keys())
-        self.assertEqual(result["recall@min_score_1"], 1.0)
+        self.assertIn("recall@1", result.keys())
+        self.assertEqual(result["recall@1"], 1)
         self.assertNotIn("error-type", result.keys())
 
         opensearch.transport.perform_request.assert_called_once_with(
@@ -3204,7 +3192,7 @@ class VectorSearchQueryRunnerTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
-    async def test_query_vector_radial_search_with_max_distance(self, opensearch, on_client_request_start, on_client_request_end):
+    async def test_calculate_recall_with_some_negative_one_neighbors(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,
             "took": 5,
@@ -3221,10 +3209,6 @@ class VectorSearchQueryRunnerTests(TestCase):
                     {
                         "_id": 102,
                         "_score": 0.88
-                    },
-                    {
-                        "_id": 103,
-                        "_score": 0.87
                     }
                 ]
             }
@@ -3238,8 +3222,8 @@ class VectorSearchQueryRunnerTests(TestCase):
             "operation-type": "vector-search",
             "detailed-results": True,
             "response-compression-enabled": False,
-            "max_distance": 15.0,
-            "neighbors": [101, 102, 103, 104],
+            "k": 6,
+            "neighbors": [101, 102, 103, 104, -1, -1],
             "body": {
                 "query": {
                     "knn": {
@@ -3248,27 +3232,87 @@ class VectorSearchQueryRunnerTests(TestCase):
                                 5,
                                 4
                             ],
-                            "max_distance": 15.0,
+                            "k": 3
                         }
-                    }
-                }
+                    }}
             }
         }
 
         async with query_runner:
             result = await query_runner(opensearch, params)
 
-        self.assertEqual(1, result["weight"])
-        self.assertEqual("ops", result["unit"])
-        self.assertEqual(3, result["hits"])
-        self.assertEqual("eq", result["hits_relation"])
-        self.assertFalse(result["timed_out"])
-        self.assertEqual(5, result["took"])
+        self.assertEqual(result["recall@k"], 0.5)
         self.assertIn("recall_time_ms", result.keys())
-        self.assertIn("recall@max_distance", result.keys())
-        self.assertEqual(result["recall@max_distance"], 0.75)
-        self.assertIn("recall@max_distance_1", result.keys())
-        self.assertEqual(result["recall@max_distance_1"], 1.0)
+        self.assertIn("recall@1", result.keys())
+        self.assertEqual(result["recall@1"], 1)
+        self.assertNotIn("error-type", result.keys())
+
+        opensearch.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/unittest/_search",
+            params={},
+            body=params["body"],
+            headers={"Accept-Encoding": "identity"}
+        )
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_calculate_recall_with_intermediate_negative_one_neighbors(self, opensearch,
+                                                                             on_client_request_start, on_client_request_end):
+        search_response = {
+            "timed_out": False,
+            "took": 5,
+            "hits": {
+                "total": {
+                    "value": 3,
+                    "relation": "eq"
+                },
+                "hits": [
+                    {
+                        "_id": 101,
+                        "_score": 0.95
+                    },
+                    {
+                        "_id": 102,
+                        "_score": 0.88
+                    }
+                ]
+            }
+        }
+        opensearch.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
+
+        query_runner = runner.Query()
+
+        params = {
+            "index": "unittest",
+            "operation-type": "vector-search",
+            "detailed-results": True,
+            "response-compression-enabled": False,
+            "k": 4,
+            "neighbors": [101, 103,102, 104, -1],
+            "body": {
+                "query": {
+                    "knn": {
+                        "location": {
+                            "vector": [
+                                5,
+                                4
+                            ],
+                            "k": 3
+                        }
+                    }}
+            }
+        }
+
+        async with query_runner:
+            result = await query_runner(opensearch, params)
+
+        self.assertEqual(result["recall@k"], 0.5)
+        self.assertIn("recall_time_ms", result.keys())
+        self.assertIn("recall@1", result.keys())
+        self.assertEqual(result["recall@1"], 1)
         self.assertNotIn("error-type", result.keys())
 
         opensearch.transport.perform_request.assert_called_once_with(


### PR DESCRIPTION
### Description
This change adds support for ingesting non-vector fields from an HDF5 dataset into OpenSearch k-NN. It also adds support for writing post-filtering queries. These changes aid the transition from k-NN's perf tool to using OSB for release benchmarking. 

Please see [OSB Workloads PR 364](https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/364) for usage examples. 

### Testing
- [X] New functionality includes testing

Unit tests were added that cover the new param and runner methods. Additionally all of the functionality has been tested via the parameter files in [OSB Workloads PR 364](https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/364).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
