### PR TITLE
Specify multiple search clients for easier benchmarking

### DIFF
--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -253,7 +253,7 @@ class SummaryResultsPublisher:
 
     def _publish_best_client_settings(self, record, task):
         num_clients = re.search(r"_(\d+)_clients$", task).group(1)
-        return self._join(self._line("Num clients that achieved maximium throughput", "", num_clients, ""))
+        return self._join(self._line("Num clients to reach max throughput", "", num_clients, ""))
 
     def _publish_percentiles(self, name, task, value, unit="ms"):
         lines = []

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1596,11 +1596,22 @@ class WorkloadSpecificationReader:
             schedule = []
 
             for op in self._r(test_procedure_spec, "schedule", error_ctx=name):
-                if "parallel" in op:
-                    task = self.parse_parallel(op["parallel"], ops, name)
+                if "clients_list" in op:
+                    self.logger.info("Clients list specified, running multiple search tasks with %s clients.", op["clients_list"])
+                    for client in op["clients_list"]:
+                        op["clients"] = client
+
+                        new_name = name + "_" + str(client) + "_clients"
+                        new_task = self.parse_task(op, ops, new_name)
+                        new_task.name = new_name
+                        schedule.append(new_task)
                 else:
-                    task = self.parse_task(op, ops, name)
-                schedule.append(task)
+                    if "parallel" in op:
+                        task = self.parse_parallel(op["parallel"], ops, name)
+                    else:
+                        task = self.parse_task(op, ops, name)
+
+                    schedule.append(task)
 
             # verify we don't have any duplicate task names (which can be confusing / misleading in results_publishing).
             known_task_names = set()

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -2477,6 +2477,52 @@ class WorkloadSpecificationReaderTests(TestCase):
         self.assertEqual("search-two-clients", schedule[1].name)
         self.assertEqual("search", schedule[1].operation.name)
 
+    def test_parse_clients_list(self):
+        workload_specification = {
+            "description": "description for unit test",
+            "operations": [
+                {
+                    "name": "search",
+                    "operation-type": "search",
+                    "index": "_all"
+                }
+            ],
+            "test_procedure": {
+                "name": "default-test_procedure",
+                "schedule": [
+                    {
+                        "name": "search-one-client",
+                        "operation": "search",
+                        "clients": 1,
+                        "clients_list": [1,2,3]
+                    },
+                    {
+                        "name": "search-two-clients",
+                        "operation": "search",
+                        "clients": 2
+                    }
+                ]
+            }
+        }
+
+        reader = loader.WorkloadSpecificationReader(selected_test_procedure="default-test_procedure")
+        resulting_workload = reader("unittest", workload_specification, "/mappings")
+        self.assertEqual("unittest", resulting_workload.name)
+        test_procedure = resulting_workload.test_procedures[0]
+        self.assertTrue(test_procedure.selected)
+        schedule = test_procedure.schedule
+        self.assertEqual(4, len(schedule))
+
+        self.assertEqual("default-test_procedure_1_clients", schedule[0].name)
+        self.assertEqual("search", schedule[0].operation.name)
+        self.assertEqual("default-test_procedure_2_clients", schedule[1].name)
+        self.assertEqual("search", schedule[1].operation.name)
+        self.assertEqual("default-test_procedure_3_clients", schedule[2].name)
+        self.assertEqual("search", schedule[2].operation.name)
+
+        self.assertEqual("search-two-clients", schedule[3].name)
+        self.assertEqual("search", schedule[3].operation.name)
+
     def test_parse_indices_valid_workload_specification(self):
         workload_specification = {
             "description": "description for unit test",

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -2488,7 +2488,7 @@ class WorkloadSpecificationReaderTests(TestCase):
                 }
             ],
             "test_procedure": {
-                "name": "default-test_procedure",
+                "name": "default-test-procedure",
                 "schedule": [
                     {
                         "name": "search-one-client",
@@ -2505,7 +2505,7 @@ class WorkloadSpecificationReaderTests(TestCase):
             }
         }
 
-        reader = loader.WorkloadSpecificationReader(selected_test_procedure="default-test_procedure")
+        reader = loader.WorkloadSpecificationReader(selected_test_procedure="default-test-procedure")
         resulting_workload = reader("unittest", workload_specification, "/mappings")
         self.assertEqual("unittest", resulting_workload.name)
         test_procedure = resulting_workload.test_procedures[0]
@@ -2513,15 +2513,33 @@ class WorkloadSpecificationReaderTests(TestCase):
         schedule = test_procedure.schedule
         self.assertEqual(4, len(schedule))
 
-        self.assertEqual("default-test_procedure_1_clients", schedule[0].name)
+        self.assertEqual("default-test-procedure_1_clients", schedule[0].name)
         self.assertEqual("search", schedule[0].operation.name)
-        self.assertEqual("default-test_procedure_2_clients", schedule[1].name)
+        self.assertEqual("default-test-procedure_2_clients", schedule[1].name)
         self.assertEqual("search", schedule[1].operation.name)
-        self.assertEqual("default-test_procedure_3_clients", schedule[2].name)
+        self.assertEqual("default-test-procedure_3_clients", schedule[2].name)
         self.assertEqual("search", schedule[2].operation.name)
 
         self.assertEqual("search-two-clients", schedule[3].name)
         self.assertEqual("search", schedule[3].operation.name)
+    # pylint: disable=W0212
+    def test_naming_with_clients_list(self):
+        reader = loader.WorkloadSpecificationReader(selected_test_procedure="default-test_procedure")
+        # Test case 1: name contains both "_" and "-"
+        result = reader._rename_task_based_on_num_clients("test_name-task", 5)
+        self.assertEqual(result, "test_name-task_5_clients")
+
+        # Test case 2: name contains only "-"
+        result = reader._rename_task_based_on_num_clients("test-name", 3)
+        self.assertEqual(result, "test-name-3-clients")
+
+        # Test case 3: name contains only "_"
+        result = reader._rename_task_based_on_num_clients("test_name", 2)
+        self.assertEqual(result, "test_name_2_clients")
+
+        # Test case 4: name contains neither "_" nor "-"
+        result = reader._rename_task_based_on_num_clients("testname", 1)
+        self.assertEqual(result, "testname_1_clients")
 
     def test_parse_indices_valid_workload_specification(self):
         workload_specification = {


### PR DESCRIPTION
### Description
Finding the maximum search throughput for an OpenSearch cluster is an important benchmarking scenario in vector search. Currently the only way to figure out the maximum search throughput is to perform multiple benchmark runs with different search client settings (e.g. search_clients = 3, search_clients = 5, ...). Waiting for a run to conclude, changing the config, and rerunning OSB with the associated startup time is tedious. Ideally the maximum throughput could be found automatically.

This PR allows users to provide a `clients_list` in a operation which runs the operation with each client setting. 

For instance, a user might specify `"clients_list": [1, 5]` in their parameters.
Then OSB will schedule search tasks with 1, 5, 10, and 12 clients. The final benchmark results will look something like the following:
```
|                                                 Min Throughput | search-only_5_clients |     1637.47 |  ops/s |
|                                                Mean Throughput | search-only_5_clients |     1637.47 |  ops/s |
|                                              Median Throughput | search-only_5_clients |     1637.47 |  ops/s |
|                                                 Max Throughput | search-only_5_clients |     1637.47 |  ops/s |
|                                        50th percentile latency | search-only_5_clients |     1.34731 |     ms |
|                                        90th percentile latency | search-only_5_clients |     1.85056 |     ms |
|                                        99th percentile latency | search-only_5_clients |     6.70892 |     ms |
|                                       100th percentile latency | search-only_5_clients |     6.79992 |     ms |
|                                   50th percentile service time | search-only_5_clients |     1.34731 |     ms |
|                                   90th percentile service time | search-only_5_clients |     1.85056 |     ms |
|                                   99th percentile service time | search-only_5_clients |     6.70892 |     ms |
|                                  100th percentile service time | search-only_5_clients |     6.79992 |     ms |
|                                                     error rate | search-only_5_clients |           0 |      % |
|                                  Num clients to max throughput |                       |           5 |        |
|                                                  Mean recall@k | search-only_1_clients |        0.92 |        |
|                                                  Mean recall@1 | search-only_1_clients |        0.99 |        |
|                                                  Mean recall@k | search-only_5_clients |        0.92 |        |
|                                                  Mean recall@1 | search-only_5_clients |        0.99 |        |
```



### Issues Resolved
Closes #613 

### Testing
- [X] New functionality includes testing

Unit tested `loader.py` changes + verified with multiple OSB runs that result publisher output looks good.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
