### PR TITLE
Support hdf5 files in bulk operation

### DIFF
--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -9,7 +9,6 @@ import struct
 from abc import ABC, ABCMeta, abstractmethod
 from enum import Enum
 from typing import cast
-
 import h5py
 import numpy as np
 
@@ -158,6 +157,20 @@ class HDF5DataSet(DataSet):
             return "attributes"
 
         raise Exception("Unsupported context")
+
+def context_string_to_context(context_string: str) -> Context:
+    if context_string == "neighbors":
+        return Context.NEIGHBORS
+    elif context_string == "train":
+        return Context.INDEX
+    elif context_string == "test":
+        return Context.QUERY
+    elif context_string == "max_distance_neighbors":
+        return Context.MAX_DISTANCE_NEIGHBORS
+    elif context_string == "min_score_neighbors":
+        return Context.MIN_SCORE_NEIGHBORS
+    else:
+        raise ValueError(f"Invalid context string: {context_string}")
 
 
 class BigANNDataSet(DataSet):

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -515,7 +515,6 @@ class BulkIndex(Runner):
         if not detailed_results:
             opensearch.return_raw_response()
         request_context_holder.on_client_request_start()
-
         if with_action_metadata:
             api_kwargs.pop("index", None)
             # only half of the lines are documents

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1477,6 +1477,12 @@ class WorkloadSpecificationReader:
                                             default_value=workload.Documents.SOURCE_FORMAT_BULK)
             default_action_and_meta_data = self._r(corpus_spec, "includes-action-and-meta-data", mandatory=False,
                                                    default_value=False)
+            default_generate_increasing_vector_ids = self._r(corpus_spec, "generate-increasing-vector-ids", mandatory=False,
+                                                   default_value=False)
+            default_id_field_name =  self._r(corpus_spec, "id-field-name", mandatory=False,
+                                                            default_value=None)
+            default_vector_field_name =  self._r(corpus_spec, "vector-field-name", mandatory=False,
+                                                            default_value=None)
             corpus_target_idx = None
             corpus_target_ds = None
             corpus_target_type = None
@@ -1518,6 +1524,12 @@ class WorkloadSpecificationReader:
 
                     includes_action_and_meta_data = self._r(doc_spec, "includes-action-and-meta-data", mandatory=False,
                                                             default_value=default_action_and_meta_data)
+                    generate_increasing_vector_ids = self._r(doc_spec, "generate-increasing-vector-ids", mandatory=False,
+                                                            default_value=default_generate_increasing_vector_ids)
+                    id_field_name = self._r(doc_spec, "id-field-name", mandatory=False,
+                                                            default_value=default_id_field_name)
+                    vector_field_name =  self._r(doc_spec, "vector-field-name", mandatory=False,
+                                                            default_value=default_vector_field_name)
                     if includes_action_and_meta_data:
                         target_idx = None
                         target_type = None
@@ -1558,6 +1570,9 @@ class WorkloadSpecificationReader:
                                            base_url=base_url,
                                            source_url=source_url,
                                            includes_action_and_meta_data=includes_action_and_meta_data,
+                                           generate_increasing_vector_ids=generate_increasing_vector_ids,
+                                           id_field_name = id_field_name,
+                                           vector_field_name = vector_field_name,
                                            number_of_documents=num_docs,
                                            compressed_size_in_bytes=compressed_bytes,
                                            uncompressed_size_in_bytes=uncompressed_bytes,

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -191,7 +191,7 @@ class Documents:
     SUPPORTED_SOURCE_FORMAT = [SOURCE_FORMAT_BULK, SOURCE_FORMAT_HDF5, SOURCE_FORMAT_BIG_ANN]
 
     def __init__(self, source_format, document_file=None, document_archive=None, base_url=None, source_url=None,
-                 includes_action_and_meta_data=False,
+                 includes_action_and_meta_data=False, generate_increasing_vector_ids=False, id_field_name=None, vector_field_name=None,
                  number_of_documents=0, compressed_size_in_bytes=0, uncompressed_size_in_bytes=0, target_index=None,
                  target_data_stream=None, target_type=None, meta_data=None):
         """
@@ -227,6 +227,9 @@ class Documents:
         self.base_url = base_url
         self.source_url = source_url
         self.includes_action_and_meta_data = includes_action_and_meta_data
+        self.generate_increasing_vector_ids = generate_increasing_vector_ids
+        self.id_field_name = id_field_name
+        self.vector_field_name = vector_field_name
         self._number_of_documents = number_of_documents
         self._compressed_size_in_bytes = compressed_size_in_bytes
         self._uncompressed_size_in_bytes = uncompressed_size_in_bytes
@@ -296,19 +299,61 @@ class Documents:
         return ", ".join(r)
 
     def __hash__(self):
-        return hash(self.source_format) ^ hash(self.document_file) ^ hash(self.document_archive) ^ hash(self.base_url) ^ \
-               hash(self.source_url) ^ hash(self.includes_action_and_meta_data) ^ hash(self.number_of_documents) ^ \
-               hash(self.compressed_size_in_bytes) ^ hash(self.uncompressed_size_in_bytes) ^ hash(self.target_index) ^ \
-               hash(self.target_data_stream) ^ hash(self.target_type) ^ hash(frozenset(self.meta_data.items()))
+        return (
+            hash(self.source_format)
+            ^ hash(self.document_file)
+            ^ hash(self.document_archive)
+            ^ hash(self.base_url)
+            ^ hash(self.source_url)
+            ^ hash(self.includes_action_and_meta_data)
+            ^ hash(self.id_field_name)
+            ^ hash(self.vector_field_name)
+            ^ hash(self.generate_increasing_vector_ids)
+            ^ hash(self.number_of_documents)
+            ^ hash(self.compressed_size_in_bytes)
+            ^ hash(self.uncompressed_size_in_bytes)
+            ^ hash(self.target_index)
+            ^ hash(self.target_data_stream)
+            ^ hash(self.target_type)
+            ^ hash(frozenset(self.meta_data.items()))
+        )
 
     def __eq__(self, othr):
-        return (isinstance(othr, type(self)) and
-                (self.source_format, self.document_file, self.document_archive, self.base_url, self.source_url,
-                 self.includes_action_and_meta_data, self.number_of_documents, self.compressed_size_in_bytes,
-                 self.uncompressed_size_in_bytes, self.target_type, self.target_data_stream, self.target_type, self.meta_data) ==
-                (othr.source_format, othr.document_file, othr.document_archive, othr.base_url, self.source_url,
-                 othr.includes_action_and_meta_data, othr.number_of_documents, othr.compressed_size_in_bytes,
-                 othr.uncompressed_size_in_bytes, othr.target_type, othr.target_data_stream, othr.target_type, othr.meta_data))
+        return isinstance(othr, type(self)) and (
+            self.source_format,
+            self.document_file,
+            self.document_archive,
+            self.base_url,
+            self.source_url,
+            self.includes_action_and_meta_data,
+            self.generate_increasing_vector_ids,
+            self.id_field_name,
+            self.vector_field_name,
+            self.number_of_documents,
+            self.compressed_size_in_bytes,
+            self.uncompressed_size_in_bytes,
+            self.target_type,
+            self.target_data_stream,
+            self.target_type,
+            self.meta_data,
+        ) == (
+            othr.source_format,
+            othr.document_file,
+            othr.document_archive,
+            othr.base_url,
+            self.source_url,
+            othr.includes_action_and_meta_data,
+            othr.generate_increasing_vector_ids,
+            othr.id_field_name,
+            othr.vector_field_name,
+            othr.number_of_documents,
+            othr.compressed_size_in_bytes,
+            othr.uncompressed_size_in_bytes,
+            othr.target_type,
+            othr.target_data_stream,
+            othr.target_type,
+            othr.meta_data,
+        )
 
 
 class DocumentCorpus:

--- a/tests/utils/dataset_test.py
+++ b/tests/utils/dataset_test.py
@@ -6,7 +6,7 @@
 import tempfile
 from unittest import TestCase
 
-from osbenchmark.utils.dataset import Context, get_data_set, HDF5DataSet, BigANNVectorDataSet
+from osbenchmark.utils.dataset import Context, get_data_set, HDF5DataSet, BigANNVectorDataSet, context_string_to_context
 from osbenchmark.utils.parse import ConfigurationError
 from tests.utils.dataset_helper import create_data_set, create_ground_truth
 
@@ -66,3 +66,28 @@ class DataSetTestCase(TestCase):
     def testUnSupportedDataSetFormat(self):
         with self.assertRaises(ConfigurationError) as _:
             get_data_set("random", "/some/path", Context.INDEX)
+
+class TestContextStringToContext(TestCase):
+    def test_neighbors_context(self):
+        context = context_string_to_context("neighbors")
+        self.assertEqual(context, Context.NEIGHBORS)
+
+    def test_index_context(self):
+        context = context_string_to_context("train")
+        self.assertEqual(context, Context.INDEX)
+
+    def test_query_context(self):
+        context = context_string_to_context("test")
+        self.assertEqual(context, Context.QUERY)
+
+    def test_max_distance_neighbors_context(self):
+        context = context_string_to_context("max_distance_neighbors")
+        self.assertEqual(context, Context.MAX_DISTANCE_NEIGHBORS)
+
+    def test_min_score_neighbors_context(self):
+        context = context_string_to_context("min_score_neighbors")
+        self.assertEqual(context, Context.MIN_SCORE_NEIGHBORS)
+
+    def test_invalid_context_string(self):
+        with self.assertRaises(ValueError):
+            context_string_to_context("invalid_string")


### PR DESCRIPTION
### Description
Adds hdf5 file support for bulk ingestion. hdf5 files contain datasets of vectors in a non-json format so @VijayanB wrote separate parameter operations to send vectors to the bulk API. This PR adds vector support within OSB's bulk operation. This is advantageous for vector search benchmarking since the `bulk` operation supports additional features, and it decreases the number of vector search-specific features.

### Testing
- [X] New functionality includes testing

Unit tests and manual verification. I modified the cohere 1000 document to include the information needed for the bulk operation. 

Steps taken for manual verification:
Parameter file:
```
{
    "target_index_name": "target_index",
    "target_field_name": "target_field",
    "target_index_body": "indices/faiss-index.json",
    "target_index_primary_shards": 1,
    "target_index_dimension": 768,
    "target_index_space_type": "l2",
    
    "target_index_bulk_size": 5,
    "target_index_bulk_index_data_set_format": "hdf5",
    "target_index_bulk_indexing_clients": 10,
    "target_index_bulk_index_data_set_corpus": "cohere",
    
    "target_index_max_num_segments": 1,
    "target_index_force_merge_timeout": 300,
    "hnsw_ef_search": 100,
    "hnsw_ef_construction": 100,

    "query_k": 100,
    "query_body": {
         "docvalue_fields" : ["_id"],
         "stored_fields" : "_none_"
    },

    "query_data_set_format": "hdf5",
    "query_data_set_corpus": "cohere",
    "query_count": 100
}

```

Bulk schedule:
```
{
    "operation": {
        "name": "delete-target-index",
        "operation-type": "delete-index",
        "only-if-exists": true,
        "index": "{{ target_index_name | default('target_index') }}"
    }
},
{
    "operation": {
        "name": "create-target-index",
        "operation-type": "create-index",
        "index": "{{ target_index_name | default('target_index') }}"
    }
},
{
    "operation": {
        "name": "bulk",
        "operation-type": "bulk",
        "bulk-size": 5,
        "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
        "source_format": "hdf5",
        "index": "target_index",
        "field": "target_field",
        "vector_dataset_context": "index",
        "corpora": ["cohere"]
    },
    "clients": {{ target_index_bulk_indexing_clients | default(1)}}
},
{
    "name" : "refresh-target-index",
    "operation" : "refresh-target-index"
}

```

Corpus changes:
```
"corpora": [
    {
      "name": "cohere",
      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
      "target-index": "{{ target_index_name }}",
      "documents": [
        {
          "source-file": "documents-1k.hdf5.bz2",
          "source-format": "hdf5",
          "document-count": 1000,
          "generate-increasing-vector-ids": true,
          "id-field-name": "_id",
          "vector-field-name": "target_field"
        }
      ]
    },
```

bulk-procedure:
```
    "name": "bulk-procedure",
    "default": false,
    "schedule": [
       {{ benchmark.collect(parts="common/bulk-schedule.json") }},

       {{ benchmark.collect(parts="common/search-only-schedule.json") }}
    ]
},
```

Result:
```
.venv) finnrobl@80a9970f4597 opensearch-benchmark % export PARAMS=/Users/finnrobl/Code/opensearch-benchmark-workloads/vectorsearch/params/bulk-params.json 
(.venv) finnrobl@80a9970f4597 opensearch-benchmark % opensearch-benchmark execute-test --target-hosts $ENDPOINT \                                                
    --workload-path /Users/finnrobl/Code/opensearch-benchmark-workloads/vectorsearch  --workload-params $PARAMS \
    --pipeline benchmark-only \
    --kill-running-processes \
  --test-procedure bulk-procedure

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: e8307702-7dda-4a30-8b87-6f2fc1834ecb
[INFO] Executing test with workload [vectorsearch], test_procedure [bulk-procedure] and provision_config_instance ['external'] with version [3.0.0-SNAPSHOT].

[WARNING] merges_total_time is 16 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 7 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 63 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 120 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running delete-target-index                                                    [100% done]
Running create-target-index                                                    [100% done]
Running bulk                                                                   [100% done]
Running refresh-target-index                                                   [100% done]
Running warmup-indices                                                         [100% done]
Running prod-queries                                                           [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |           Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                |   0.0371833 |    min |
|             Min cumulative indexing time across primary shards |                |           0 |    min |
|          Median cumulative indexing time across primary shards |                | 0.000116667 |    min |
|             Max cumulative indexing time across primary shards |                |   0.0370667 |    min |
|            Cumulative indexing throttle time of primary shards |                |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                |           0 |    min |
|                        Cumulative merge time of primary shards |                | 0.000266667 |    min |
|                       Cumulative merge count of primary shards |                |           1 |        |
|                Min cumulative merge time across primary shards |                |           0 |    min |
|             Median cumulative merge time across primary shards |                |           0 |    min |
|                Max cumulative merge time across primary shards |                | 0.000266667 |    min |
|               Cumulative merge throttle time of primary shards |                |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                |           0 |    min |
|                      Cumulative refresh time of primary shards |                |  0.00468333 |    min |
|                     Cumulative refresh count of primary shards |                |          12 |        |
|              Min cumulative refresh time across primary shards |                |           0 |    min |
|           Median cumulative refresh time across primary shards |                |     0.00105 |    min |
|              Max cumulative refresh time across primary shards |                |  0.00363333 |    min |
|                        Cumulative flush time of primary shards |                |       0.002 |    min |
|                       Cumulative flush count of primary shards |                |           2 |        |
|                Min cumulative flush time across primary shards |                |           0 |    min |
|             Median cumulative flush time across primary shards |                |           0 |    min |
|                Max cumulative flush time across primary shards |                |       0.002 |    min |
|                                        Total Young Gen GC time |                |        0.01 |      s |
|                                       Total Young Gen GC count |                |           1 |        |
|                                          Total Old Gen GC time |                |           0 |      s |
|                                         Total Old Gen GC count |                |           0 |        |
|                                                     Store size |                |   0.0173898 |     GB |
|                                                  Translog size |                |   0.0150675 |     GB |
|                                         Heap used for segments |                |           0 |     MB |
|                                       Heap used for doc values |                |           0 |     MB |
|                                            Heap used for terms |                |           0 |     MB |
|                                            Heap used for norms |                |           0 |     MB |
|                                           Heap used for points |                |           0 |     MB |
|                                    Heap used for stored fields |                |           0 |     MB |
|                                                  Segment count |                |          10 |        |
|                                                 Min Throughput |           bulk |     1640.19 | docs/s |
|                                                Mean Throughput |           bulk |     1640.19 | docs/s |
|                                              Median Throughput |           bulk |     1640.19 | docs/s |
|                                                 Max Throughput |           bulk |     1640.19 | docs/s |
|                                        50th percentile latency |           bulk |     17.3579 |     ms |
|                                        90th percentile latency |           bulk |     45.1002 |     ms |
|                                        99th percentile latency |           bulk |     83.7313 |     ms |
|                                       100th percentile latency |           bulk |      88.521 |     ms |
|                                   50th percentile service time |           bulk |     17.3579 |     ms |
|                                   90th percentile service time |           bulk |     45.1002 |     ms |
|                                   99th percentile service time |           bulk |     83.7313 |     ms |
|                                  100th percentile service time |           bulk |      88.521 |     ms |
|                                                     error rate |           bulk |           0 |      % |
|                                                 Min Throughput | warmup-indices |       36.24 |  ops/s |
|                                                Mean Throughput | warmup-indices |       36.24 |  ops/s |
|                                              Median Throughput | warmup-indices |       36.24 |  ops/s |
|                                                 Max Throughput | warmup-indices |       36.24 |  ops/s |
|                                       100th percentile latency | warmup-indices |     27.4253 |     ms |
|                                  100th percentile service time | warmup-indices |     27.4253 |     ms |
|                                                     error rate | warmup-indices |           0 |      % |
|                                                 Min Throughput |   prod-queries |       149.9 |  ops/s |
|                                                Mean Throughput |   prod-queries |       149.9 |  ops/s |
|                                              Median Throughput |   prod-queries |       149.9 |  ops/s |
|                                                 Max Throughput |   prod-queries |       149.9 |  ops/s |
|                                        50th percentile latency |   prod-queries |     3.36225 |     ms |
|                                        90th percentile latency |   prod-queries |      4.6824 |     ms |
|                                        99th percentile latency |   prod-queries |     58.3903 |     ms |
|                                       100th percentile latency |   prod-queries |     109.023 |     ms |
|                                   50th percentile service time |   prod-queries |     3.36225 |     ms |
|                                   90th percentile service time |   prod-queries |      4.6824 |     ms |
|                                   99th percentile service time |   prod-queries |     58.3903 |     ms |
|                                  100th percentile service time |   prod-queries |     109.023 |     ms |
|                                                     error rate |   prod-queries |           0 |      % |
|                                                  Mean recall@k |   prod-queries |        0.37 |        |
|                                                  Mean recall@1 |   prod-queries |        0.07 |        |


--------------------------------
[INFO] SUCCESS (took 63 seconds)
```


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
