### PR TITLE
add default value for master-node when provisioning cluster using OSB

### DIFF
--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -62,6 +62,14 @@ def install(cfg):
     master_nodes = cfg.opts("builder", "master.nodes")
     seed_hosts = cfg.opts("builder", "seed.hosts")
 
+    # Ensure node_name and master_nodes match, using node_name as the default
+    if node_name not in master_nodes:
+        print(
+            f"The provided --node-name '{node_name}' and --master-nodes '{master_nodes}' are different. "
+            f"Using '{node_name}' for both node name and initial master node."
+        )
+        master_nodes = [node_name]
+
     if build_type == "tar":
         binary_supplier = supplier.create(cfg, sources, distribution, provision_config_instance, plugins)
         p = provisioner.local(cfg=cfg, provision_config_instance=provision_config_instance, plugins=plugins, ip=ip, http_port=http_port,


### PR DESCRIPTION
### Description
As mentioned by @gkamat, when provisioning a cluster in OSB, the master node specification should match the node name. This change ensures that these two values always match, by performing a check before building the cluster and ensuring the two values match before moving on.

### Issues Resolved
[#380](https://github.com/opensearch-project/opensearch-benchmark/issues/380)

### Testing
- [✔️] New functionality includes testing

tested with `make test` + `make it` and by provisioning clusters with mismatched values, as well as missing values for either node-name or master-node value.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
