### PR TITLE
Add calculate-recall parameter to vector search and skip calculating recall if number clients > cpu cores

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -37,7 +37,7 @@ from enum import Enum
 from functools import total_ordering
 from io import BytesIO
 from os.path import commonprefix
-from os import cpu_count as os_cpu_count
+import os
 from typing import List, Optional
 
 import ijson
@@ -1345,7 +1345,7 @@ class Query(Runner):
                 num_clients = params.get("num_clients", 0)
                 if num_clients == 0:
                     self.logger.debug("Expected num_clients to be specified but was not.")
-                cpu_count = os_cpu_count()
+                cpu_count = os.cpu_count()
                 if cpu_count < num_clients:
                     self.logger.warning("Number of clients, %s, specified is greater than the number of CPUs, %s, available."\
                                         "This will lead to unperformant context switching on load generation host. Performance "\

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -37,7 +37,7 @@ from enum import Enum
 from functools import total_ordering
 from io import BytesIO
 from os.path import commonprefix
-import os
+import multiprocessing
 from typing import List, Optional
 
 import ijson
@@ -1342,10 +1342,12 @@ class Query(Runner):
                     })
 
             def _get_should_calculate_recall(params: dict) -> bool:
+                # set in global config (benchmark.ini) and passed by AsyncExecutor
                 num_clients = params.get("num_clients", 0)
                 if num_clients == 0:
                     self.logger.debug("Expected num_clients to be specified but was not.")
-                cpu_count = os.cpu_count()
+                # default is set for runner unit tests based on default logic for available.cores in worker_coordinator
+                cpu_count = params.get("num_cores", multiprocessing.cpu_count())
                 if cpu_count < num_clients:
                     self.logger.warning("Number of clients, %s, specified is greater than the number of CPUs, %s, available."\
                                         "This will lead to unperformant context switching on load generation host. Performance "\

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -37,6 +37,7 @@ from enum import Enum
 from functools import total_ordering
 from io import BytesIO
 from os.path import commonprefix
+from os import cpu_count as os_cpu_count
 from typing import List, Optional
 
 import ijson
@@ -1320,29 +1321,47 @@ class Query(Runner):
 
                 return correct / min_num_of_results
 
+            def _set_initial_recall_values(params: dict, result: dict) -> None:
+                # Add recall@k and recall@1 to the initial result only if k is present in the params and calculate_recall is true
+                if "k" in params:
+                    result.update({
+                        "recall@k": 0,
+                        "recall@1": 0
+                    })
+                # Add recall@max_distance and recall@max_distance_1 to the initial result only if max_distance is present in the params
+                elif "max_distance" in params:
+                    result.update({
+                        "recall@max_distance": 0,
+                        "recall@max_distance_1": 0
+                    })
+                # Add recall@min_score and recall@min_score_1 to the initial result only if min_score is present in the params
+                elif "min_score" in params:
+                    result.update({
+                        "recall@min_score": 0,
+                        "recall@min_score_1": 0
+                    })
+
+            def _get_should_calculate_recall(params: dict) -> bool:
+                num_clients = params.get("num_clients", 0)
+                if num_clients == 0:
+                    self.logger.debug("Expected num_clients to be specified but was not.")
+                cpu_count = os_cpu_count()
+                if cpu_count < num_clients:
+                    self.logger.warning("Number of clients, %s, specified is greater than the number of CPUs, %s, available."\
+                                        "This will lead to unperformant context switching on load generation host. Performance "\
+                                        "metrics may not be accurate. Skipping recall calculation.", num_clients, cpu_count)
+                    return False
+                return params.get("calculate-recall", True)
+
             result = {
                 "weight": 1,
                 "unit": "ops",
                 "success": True,
             }
-            # Add recall@k and recall@1 to the initial result only if k is present in the params
-            if "k" in params:
-                result.update({
-                    "recall@k": 0,
-                    "recall@1": 0
-                })
-            # Add recall@max_distance and recall@max_distance_1 to the initial result only if max_distance is present in the params
-            elif "max_distance" in params:
-                result.update({
-                    "recall@max_distance": 0,
-                    "recall@max_distance_1": 0
-                })
-            # Add recall@min_score and recall@min_score_1 to the initial result only if min_score is present in the params
-            elif "min_score" in params:
-                result.update({
-                    "recall@min_score": 0,
-                    "recall@min_score_1": 0
-                })
+            # deal with clients here. Need to get num_clients
+            should_calculate_recall = _get_should_calculate_recall(params)
+            if should_calculate_recall:
+                _set_initial_recall_values(params, result)
 
             doc_type = params.get("type")
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
@@ -1366,6 +1385,10 @@ class Query(Runner):
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")
                 return result
+
+            if not should_calculate_recall:
+                return result
+
             id_field = parse_string_parameter("id-field-name", params, "_id")
             candidates = []
             for hit in response_json['hits']['hits']:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1624,6 +1624,9 @@ class AsyncExecutor:
                 processing_start = time.perf_counter()
                 self.schedule_handle.before_request(processing_start)
                 async with self.opensearch["default"].new_request_context() as request_context:
+                    # add num_clients to the parameter so that vector search runner can skip calculating recall
+                    # if num_clients > cpu_count().
+                    params.update({"num_clients": self.task.clients})
                     total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.opensearch, params, self.on_error)
                     request_start = request_context.request_start
                     request_end = request_context.request_end

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1626,7 +1626,8 @@ class AsyncExecutor:
                 async with self.opensearch["default"].new_request_context() as request_context:
                     # add num_clients to the parameter so that vector search runner can skip calculating recall
                     # if num_clients > cpu_count().
-                    params.update({"num_clients": self.task.clients})
+                    if params:
+                        params.update({"num_clients": self.task.clients})
                     total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.opensearch, params, self.on_error)
                     request_start = request_context.request_start
                     request_end = request_context.request_end

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -549,6 +549,7 @@ class SearchParamSource(ParamSource):
                 f"'type' not supported with 'data-stream' for operation '{kwargs.get('operation_name')}'")
         request_cache = params.get("cache", None)
         detailed_results = params.get("detailed-results", False)
+        calculate_recall = params.get("calculate-recall", True)
         query_body = params.get("body", None)
         pages = params.get("pages", None)
         results_per_page = params.get("results-per-page", None)
@@ -561,6 +562,7 @@ class SearchParamSource(ParamSource):
             "type": type_name,
             "cache": request_cache,
             "detailed-results": detailed_results,
+            "calculate-recall": calculate_recall,
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
             "body": query_body

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -852,6 +852,8 @@ class ForceMergeParamSource(ParamSource):
 
 class VectorSearchParamSource(SearchParamSource):
     def __init__(self, workload, params, **kwargs):
+        # print workload
+        logging.getLogger(__name__).info("Workload: [%s], params: [%s]", workload, params)
         super().__init__(workload, params, **kwargs)
         self.delegate_param_source = VectorSearchPartitionParamSource(workload, params, self.query_params, **kwargs)
         self.corpora = self.delegate_param_source.corpora

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -2578,7 +2578,6 @@ class TrainKnnModelRunnerTests(TestCase):
         with self.assertRaisesRegex(TimeoutError, f'Failed to create model: {self.model_id} within {self.retries} retries'):
             await runner_under_test(opensearch, self.request)
 
-
 class VectorSearchQueryRunnerTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
@@ -3278,6 +3277,263 @@ class VectorSearchQueryRunnerTests(TestCase):
             body=params["body"],
             headers={"Accept-Encoding": "identity"}
         )
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_query_vector_search_should_skip_calculate_recall(self, opensearch, on_client_request_start, on_client_request_end):
+        with mock.patch("os.cpu_count", return_value=8):
+            num_clients = 9
+            class WorkerCoordinatorTestParamSource:
+                def __init__(self, workload=None, params=None, **kwargs):
+                    if params is None:
+                        params = {}
+                    self._indices = workload.indices
+                    self._params = params
+                    self._current = 1
+                    self._total = params.get("size")
+                    self.infinite = self._total is None
+
+                def partition(self, partition_index, total_partitions):
+                    return self
+
+                @property
+                def percent_completed(self):
+                    if self.infinite:
+                        return None
+                    return self._current / self._total
+
+                def params(self):
+                    if not self.infinite and self._current > self._total:
+                        raise StopIteration()
+                    self._current += 1
+                    return self._params
+            # pylint: disable=C0415
+            from osbenchmark.worker_coordinator import worker_coordinator
+            # pylint: disable=C0415
+            from osbenchmark.workload import params
+            # pylint: disable=C0415
+            from osbenchmark import workload
+
+            # create task here
+            # sampler is mock
+            # create actual schedule w new params
+
+            opensearch.init_request_context.return_value = {
+                "client_request_start": 0,
+                "request_start": 1,
+                "request_end": 11,
+                "client_request_end": 12
+            }
+
+            search_response = {
+                "timed_out": False,
+                "took": 5,
+                "hits": {
+                    "total": {
+                        "value": 3,
+                        "relation": "eq"
+                    },
+                    "hits": [
+                        {
+                            "_id": 101,
+                            "_score": 0.95
+                        },
+                        {
+                            "_id": 102,
+                            "_score": 0.88
+                        },
+                        {
+                            "_id": 103,
+                            "_score": 0.1
+                        }
+                    ]
+                }
+            }
+            opensearch.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+
+            params.register_param_source_for_name("worker-coordinator-test-param-source", WorkerCoordinatorTestParamSource)
+            test_workload = workload.Workload(name="unittest", description="unittest workload",
+                                    indices=None,
+                                    test_procedures=None)
+
+            task = workload.Task("time-based", workload.Operation("time-based",
+                workload.OperationType.VectorSearch.to_hyphenated_string(),
+                params={
+                    "index": "_all",
+                    "type": None,
+                    "operation-type": "vector-search",
+                    "detailed-results": True,
+                    "response-compression-enabled": False,
+                    "k": 3,
+                    "neighbors": [101, 102, 103],
+                    "body": {
+                        "query": {
+                            "knn": {
+                                "location": {
+                                    "vector": [
+                                        5,
+                                        4
+                                    ],
+                                    "k": 3
+                                }
+                            }}
+                    },
+                    "request-params": {},
+                    "cache": False
+                },
+                param_source="worker-coordinator-test-param-source"),
+                warmup_time_period=0.5, time_period=0.5, clients=num_clients,
+                params={ "clients": num_clients},
+                completes_parent=False)
+
+            sampler = worker_coordinator.Sampler(start_timestamp=0)
+
+            runner.register_runner(operation_type=workload.OperationType.VectorSearch, runner=runner.Query(), async_runner=True)
+            param_source = workload.operation_parameters(test_workload, task)
+            # pylint: disable=C0415
+            import threading
+            schedule = worker_coordinator.schedule_for(task, 0, param_source)
+            executor = worker_coordinator.AsyncExecutor(client_id=0, task=task, schedule=schedule, opensearch={"default": opensearch},
+                                                        sampler=sampler, cancel=threading.Event(), complete=threading.Event(),
+                                                        on_error="continue")
+            # will run executor + vector search query runner.
+            await executor()
+
+            # make copy of samples since they disappear once first accessed.
+            samples = sampler.samples
+            recall_k = samples[0].request_meta_data.get("recall@k")
+            self.assertEqual(recall_k, None)
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_query_vector_search_should_actually_calculate_recall_with_default_value(self, opensearch,
+                                                                                           on_client_request_start, on_client_request_end):
+        with mock.patch("os.cpu_count", return_value=8):
+            num_clients = 8
+            class WorkerCoordinatorTestParamSource:
+                def __init__(self, workload=None, params=None, **kwargs):
+                    if params is None:
+                        params = {}
+                    self._indices = workload.indices
+                    self._params = params
+                    self._current = 1
+                    self._total = params.get("size")
+                    self.infinite = self._total is None
+
+                def partition(self, partition_index, total_partitions):
+                    return self
+
+                @property
+                def percent_completed(self):
+                    if self.infinite:
+                        return None
+                    return self._current / self._total
+
+                def params(self):
+                    if not self.infinite and self._current > self._total:
+                        raise StopIteration()
+                    self._current += 1
+                    return self._params
+            # pylint: disable=C0415
+            from osbenchmark.worker_coordinator import worker_coordinator
+            # pylint: disable=C0415
+            from osbenchmark.workload import params
+            # pylint: disable=C0415
+            from osbenchmark import workload
+
+            # create task here
+            # sampler is mock
+            # create actual schedule w new params
+
+            opensearch.init_request_context.return_value = {
+                "client_request_start": 0,
+                "request_start": 1,
+                "request_end": 11,
+                "client_request_end": 12
+            }
+
+            search_response = {
+                "timed_out": False,
+                "took": 5,
+                "hits": {
+                    "total": {
+                        "value": 3,
+                        "relation": "eq"
+                    },
+                    "hits": [
+                        {
+                            "_id": 101,
+                            "_score": 0.95
+                        },
+                        {
+                            "_id": 102,
+                            "_score": 0.88
+                        },
+                        {
+                            "_id": 103,
+                            "_score": 0.1
+                        }
+                    ]
+                }
+            }
+            opensearch.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+
+            params.register_param_source_for_name("worker-coordinator-test-param-source", WorkerCoordinatorTestParamSource)
+            test_workload = workload.Workload(name="unittest", description="unittest workload",
+                                    indices=None,
+                                    test_procedures=None)
+
+            task = workload.Task("time-based", workload.Operation("time-based",
+                workload.OperationType.VectorSearch.to_hyphenated_string(),
+                params={
+                    "index": "_all",
+                    "type": None,
+                    "operation-type": "vector-search",
+                    "detailed-results": True,
+                    "response-compression-enabled": False,
+                    "k": 3,
+                    "neighbors": [101, 102, 103],
+                    "body": {
+                        "query": {
+                            "knn": {
+                                "location": {
+                                    "vector": [
+                                        5,
+                                        4
+                                    ],
+                                    "k": 3
+                                }
+                            }}
+                    },
+                    "request-params": {},
+                    "cache": False
+                },
+                param_source="worker-coordinator-test-param-source"),
+                warmup_time_period=0.5, time_period=0.5, clients=num_clients,
+                params={ "clients": num_clients},
+                completes_parent=False)
+
+            sampler = worker_coordinator.Sampler(start_timestamp=0)
+
+            runner.register_runner(operation_type=workload.OperationType.VectorSearch, runner=runner.Query(), async_runner=True)
+            param_source = workload.operation_parameters(test_workload, task)
+            # pylint: disable=C0415
+            import threading
+            schedule = worker_coordinator.schedule_for(task, 0, param_source)
+            executor = worker_coordinator.AsyncExecutor(client_id=0, task=task, schedule=schedule, opensearch={"default": opensearch},
+                                                        sampler=sampler, cancel=threading.Event(), complete=threading.Event(),
+                                                        on_error="continue")
+            # will run executor + vector search query runner.
+            await executor()
+
+            # make copy of samples since they disappear once first accessed.
+            samples = sampler.samples
+            recall_k = samples[0].request_meta_data.get("recall@k")
+            self.assertEqual(recall_k, 1.0)
 
 
 class PutPipelineRunnerTests(TestCase):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -2271,7 +2271,8 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual(True, p["calculate-recall"])
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2307,7 +2308,8 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual(True, p["calculate-recall"])
         self.assertEqual("data-stream-1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
@@ -2354,7 +2356,8 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual(True, p["calculate-recall"])
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2390,7 +2393,8 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual(True, p["calculate-recall"])
         self.assertEqual("_all", p["index"])
         self.assertEqual("type1", p["type"])
         self.assertDictEqual({}, p["request-params"])
@@ -2423,7 +2427,8 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual(True, p["calculate-recall"])
         self.assertEqual("data-stream-2", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -2291,7 +2291,6 @@ class SearchParamSourceTests(TestCase):
 
     def test_uses_data_stream(self):
         ds1 = workload.DataStream(name="data-stream-1")
-
         source = params.SearchParamSource(workload=workload.Workload(name="unit-test", data_streams=[ds1]), params={
             "body": {
                 "query": {


### PR DESCRIPTION
### Description
When the number of search clients is greater than the number of cpu cores [recall drops unexpectedly](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/347). @VijayanB is investigating the cause, but this PR throws a warning if num_clients > the cpu cores available and skips calculating the recall. It also adds a parameter `calculate-recall` to specify whether or not to calculate recall (either `calculate-recall: true` or `calculate-recall: false`).

### Testing
- [x] New functionality includes testing

Unit tests.
Also tested on mac with 12 cores. Skips recall calculation if num_clients > 12, calculates recall otherwise. `calculate-recall` parameter works as expected. Will add unit tests in a second PR by EOD.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
