### PR TITLE
Address string issue in Groovy

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -17,10 +17,10 @@ standardReleasePipelineWithGenericTrigger(
             string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
             string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
             string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: [
-                "su $(id -un 1000) -c \"cd docker/ci",
-                "git clone https://github.com/opensearch-project/opensearch-benchmark --branch ${tag} --single-branch opensearch-benchmark",
-                "cp -a opensearch-benchmark/* ./\"",
-                "cd docker/ci",
+                'su $(id -un 1000) -c "cd docker/ci',
+                "git clone https://github.com/opensearch-project/opensearch-benchmark --single-branch --branch ${tag} opensearch-benchmark",
+                'cp -a opensearch-benchmark/* ./"',
+                'cd docker/ci',
                 [
                     'bash',
                     'build-image-multi-arch.sh',


### PR DESCRIPTION
### Description
This error was encountered in Jenkins:
```
WorkflowScript: 19: illegal string body character after dollar sign;
   solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 19, column 70.
   SCRIPT_WITH_COMMANDS', value: [
                                 ^

1 error
```

Adding a quick fix. 
[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
