### PR TITLE
change op-metrics to op_metrics in aggregator file

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -80,7 +80,7 @@ class Aggregator:
     def build_aggregated_results(self):
         test_exe = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
         aggregated_results = {
-            "op-metrics": [],
+            "op_metrics": [],
             "correctness_metrics": self.aggregate_json_by_key("correctness_metrics"),
             "total_time": self.aggregate_json_by_key("total_time"),
             "total_time_per_shard": self.aggregate_json_by_key("total_time_per_shard"),
@@ -131,7 +131,7 @@ class Aggregator:
                 "error_rate": aggregated_task_metrics["error_rate"],
                 "duration": aggregated_task_metrics["duration"]
             }
-            aggregated_results["op-metrics"].append(op_metric)
+            aggregated_results["op_metrics"].append(op_metric)
 
         # extract the necessary data from the first test execution, since the configurations should be identical for all test executions
         current_timestamp = self.config.opts("system", "time.start")


### PR DESCRIPTION
### Description
Aggregated test results were not working properly when being used with OSB's `compare` command. This is because `op_metrics` was being spelled as `op-metrics` (using a dash instead of an underscore).

### Issues Resolved
#656 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
