### PR TITLE
Fix --number-of-docs bug in create-workload

### DIFF
--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -126,8 +126,11 @@ class StoreKeyPairAsDict(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         custom_dict = {}
 
-        # If values contains spaces, user provided 2+ key value pairs
-        kv_pairs = values[0].split(" ")
+        if len(values) == 1:
+            # If values contains spaces, user provided 2+ key value pairs
+            kv_pairs = values[0].split(" ")
+        else:
+            kv_pairs = values
 
         for kv in kv_pairs:
             try:

--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -125,7 +125,11 @@ class StoreKeyPairAsDict(argparse.Action):
     """
     def __call__(self, parser, namespace, values, option_string=None):
         custom_dict = {}
-        for kv in values:
+
+        # If values contains spaces, user provided 2+ key value pairs
+        kv_pairs = values[0].split(" ")
+
+        for kv in kv_pairs:
             try:
                 k,v = kv.split(":")
                 custom_dict[k] = v

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -42,7 +42,7 @@ class IndexExtractor:
         try:
             for index in self.custom_workload.indices:
                 extracted_indices += self.extract(workload_path, index.name)
-        except opensearchpy.exceptions.NotFoundError as e:
+        except opensearchpy.exceptions.NotFoundError:
             raise exceptions.SystemSetupError(f"Index [{index.name}] does not exist.")
         except opensearchpy.OpenSearchException:
             self.logger.error("Failed at extracting index [%s]", index)
@@ -177,7 +177,7 @@ class SequentialCorpusExtractor(CorpusExtractor):
 
         total_documents = self.client.count(index=index)["count"]
 
-        logger.info("total documents: %s, documents limit: %s", total_documents, documents_limit)
+        logger.info("Total documents in index: %s, number of docs user requested: %s", total_documents, documents_limit)
 
         documents_to_extract = total_documents if not documents_limit else min(total_documents, documents_limit)
 
@@ -185,7 +185,7 @@ class SequentialCorpusExtractor(CorpusExtractor):
             # Only time when documents-1k.json will be less than 1K documents is
             # when the documents_limit is < 1k documents or source index has less than 1k documents
             if documents_limit < self.DEFAULT_TEST_MODE_DOC_COUNT:
-                test_mode_warning_msg = f"Due to --number-of-docs set by user, " + \
+                test_mode_warning_msg = "Due to --number-of-docs set by user, " + \
                     f"test-mode docs will be less than the default {self.DEFAULT_TEST_MODE_DOC_COUNT} documents."
                 console.warn(test_mode_warning_msg)
 

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -177,8 +177,6 @@ class SequentialCorpusExtractor(CorpusExtractor):
 
         total_documents = self.client.count(index=index)["count"]
 
-        logger.info("Total documents in index: %s, number of docs user requested: %s", total_documents, documents_limit)
-
         documents_to_extract = total_documents if not documents_limit else min(total_documents, documents_limit)
 
         if documents_limit:
@@ -191,10 +189,10 @@ class SequentialCorpusExtractor(CorpusExtractor):
 
             # Notify users when they specified more documents than available in index
             if documents_limit > total_documents:
-                documents_to_extract_msg = f"User requested to extract {documents_limit} documents " + \
+                documents_to_extract_warning_msg = f"User requested to extract {documents_limit} documents " + \
                     f"but there are only {total_documents} documents in {index}. " + \
                     f"Will only extract {total_documents} documents from {index}."
-                console.warn(documents_to_extract_msg)
+                console.warn(documents_to_extract_warning_msg)
 
         if documents_to_extract > 0:
             logger.info("[%d] total docs in index [%s]. Extracting [%s] docs.", total_documents, index, documents_to_extract)

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -12,8 +12,9 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
-from opensearchpy import OpenSearchException
+import opensearchpy.exceptions
 
+from osbenchmark import exceptions
 from osbenchmark.utils import console
 from osbenchmark.workload_generator.config import CustomWorkload
 
@@ -41,8 +42,10 @@ class IndexExtractor:
         try:
             for index in self.custom_workload.indices:
                 extracted_indices += self.extract(workload_path, index.name)
-        except OpenSearchException:
-            self.logger("Failed at extracting index [%s]", index)
+        except opensearchpy.exceptions.NotFoundError as e:
+            raise exceptions.SystemSetupError(f"Index {index.name} does not exist.")
+        except opensearchpy.OpenSearchException:
+            self.logger.error("Failed at extracting index [%s]", index)
             failed_indices += index
 
         return extracted_indices, failed_indices

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -43,7 +43,7 @@ class IndexExtractor:
             for index in self.custom_workload.indices:
                 extracted_indices += self.extract(workload_path, index.name)
         except opensearchpy.exceptions.NotFoundError as e:
-            raise exceptions.SystemSetupError(f"Index {index.name} does not exist.")
+            raise exceptions.SystemSetupError(f"Index [{index.name}] does not exist.")
         except opensearchpy.OpenSearchException:
             self.logger.error("Failed at extracting index [%s]", index)
             failed_indices += index

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -189,7 +189,7 @@ class SequentialCorpusExtractor(CorpusExtractor):
 
             # Notify users when they specified more documents than available in index
             if documents_limit > total_documents:
-                documents_to_extract_warning_msg = f"User requested to extract {documents_limit} documents " + \
+                documents_to_extract_warning_msg = f"User requested extraction of {documents_limit} documents " + \
                     f"but there are only {total_documents} documents in {index}. " + \
                     f"Will only extract {total_documents} documents from {index}."
                 console.warn(documents_to_extract_warning_msg)

--- a/osbenchmark/workload_generator/helpers.py
+++ b/osbenchmark/workload_generator/helpers.py
@@ -129,13 +129,13 @@ def process_indices(indices, document_frequency, indices_docs_mapping):
     processed_indices = []
     for index_name in indices:
         try:
-            # Setting equal to None means OSB will grab all docs available in index
+            #Setting number_of_docs_for_index to None means OSB will grab all docs available in index
             number_of_docs_for_index = None
             if indices_docs_mapping and index_name in indices_docs_mapping:
                 number_of_docs_for_index = int(indices_docs_mapping[index_name])
                 if number_of_docs_for_index <= 0:
                     raise exceptions.SystemSetupError(
-                        "If using --number-of-docs, ensure values are greater than 0")
+                        "Values specified with --number-of-docs must be greater than 0")
 
             index = Index(
                 name=index_name,
@@ -145,7 +145,7 @@ def process_indices(indices, document_frequency, indices_docs_mapping):
             processed_indices.append(index)
 
         except ValueError as e:
-            raise exceptions.SystemSetupError("Ensure you are using use integers if providing number of docs.", e)
+            raise exceptions.SystemSetupError("Ensure you are using integers if providing --number-of-docs.", e)
 
     return processed_indices
 
@@ -165,6 +165,6 @@ def validate_index_documents_map(indices, indices_docs_map):
     for index_name in indices_docs_map:
         if index_name not in indices:
             raise exceptions.SystemSetupError(
-                "Index name mentioned in --number-of-docs was not found in --indices. " +
-                "Ensure that indices in --number-of-docs are present in --indices."
+                f"Index {index_name} provided in --number-of-docs was not found in --indices. " +
+                "Ensure that all indices in --number-of-docs are present in --indices."
             )

--- a/osbenchmark/workload_generator/helpers.py
+++ b/osbenchmark/workload_generator/helpers.py
@@ -133,6 +133,9 @@ def process_indices(indices, document_frequency, indices_docs_mapping):
             number_of_docs_for_index = None
             if indices_docs_mapping and index_name in indices_docs_mapping:
                 number_of_docs_for_index = int(indices_docs_mapping[index_name])
+                if number_of_docs_for_index <= 0:
+                    raise exceptions.SystemSetupError(
+                        "If using --number-of-docs, ensure values are greater than 0")
 
             index = Index(
                 name=index_name,
@@ -162,6 +165,6 @@ def validate_index_documents_map(indices, indices_docs_map):
     for index_name in indices_docs_map:
         if index_name not in indices:
             raise exceptions.SystemSetupError(
-                "Index from <index>:<doc_count> pair was not found in --indices. " +
-                "Ensure that indices from all <index>:<doc_count> pairs exist in --indices."
+                "Index name mentioned in --number-of-docs was not found in --indices. " +
+                "Ensure that indices in --number-of-docs are present in --indices."
             )

--- a/osbenchmark/workload_generator/helpers.py
+++ b/osbenchmark/workload_generator/helpers.py
@@ -129,7 +129,7 @@ def process_indices(indices, document_frequency, indices_docs_mapping):
     processed_indices = []
     for index_name in indices:
         try:
-            # Check if user provided number of docs for index
+            # Setting equal to None means OSB will grab all docs available in index
             number_of_docs_for_index = None
             if indices_docs_mapping and index_name in indices_docs_mapping:
                 number_of_docs_for_index = int(indices_docs_mapping[index_name])

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -40,6 +40,7 @@ def create_workload(cfg):
     console.info(f"Connected to OpenSearch cluster [{info['name']}] version [{info['version']['number']}].\n", logger=logger)
 
     processed_indices = process_indices(indices, document_frequency, number_of_docs)
+    logger.info("Processed Indices: %s", processed_indices)
 
     custom_workload = CustomWorkload(
         workload_name=workload_name,


### PR DESCRIPTION
### Description
Currently, there's a bug in create-workload when users specify the number of docs to extract from an index. Addressing the fix in this PR. This PR also adds more error handling  and warnings to streamline user experience.

### Issues Resolved
#658 

### Testing
- [x] New functionality includes testing

Tested with these scenarios:
- Running create-workload with 2+ number of docs entries
- Testing number of docs entry with 0 or less docs
- Testing number of docs entry with less than 1K docs
- Testing number of docs entry that does not exist in the cluster

```
(.venv) hoangia@80a9971b1103 opensearch-benchmark % opensearch-benchmark create-workload --target-hosts=XXXXXX --client-options=basic_auth_user:'XXXXXX',basic_auth_password:'XXXXXX' --indices=movies-1000,movies-2000,nyc_taxis  --output-path=~/Desktop/ --workload=test-workload --number-of-docs="movies-2000:1500 nyc_taxis:1500"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Connected to OpenSearch cluster [69622e766ec7eb17f038aed664796847] version [2.5.0].

A workload already exists at /Users/hoangia/Desktop/test-workload. Would you like to remove it? (y/n): y
[INFO] Removing workload of the same name.
Extracting documents for index [movies-1000] for test mode... 1000/1000 docs [100.0% done]
Extracting documents for index [movies-1000]...               1000/1000 docs [100.0% done]
Extracting documents for index [movies-2000] for test mode... 1000/1000 docs [100.0% done]
Extracting documents for index [movies-2000]...               1500/1500 docs [100.0% done]
Extracting documents for index [nyc_taxis] for test mode...   1000/1000 docs [100.0% done]
Extracting documents for index [nyc_taxis]...                 1500/1500 docs [100.0% done]

[INFO] Workload test-workload has been created. Run it with: opensearch-benchmark --workload-path=/Users/hoangia/Desktop/test-workload

-------------------------------
[INFO] SUCCESS (took 4 seconds)
-------------------------------
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
