### PR TITLE
Add shorthand alternatives for command line options in OSB

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -158,24 +158,29 @@ def create_arg_parser():
     create_workload_parser = subparsers.add_parser("create-workload", help="Create a Benchmark workload from existing data")
     create_workload_parser.add_argument(
         "--workload",
+        "-w",
         required=True,
         help="Name of the generated workload")
     create_workload_parser.add_argument(
         "--indices",
+        "-i",
         type=non_empty_list,
         required=True,
         help="Comma-separated list of indices to include in the workload")
     create_workload_parser.add_argument(
         "--target-hosts",
+        "-th",
         default="",
         required=True,
         help="Comma-separated list of host:port pairs which should be targeted")
     create_workload_parser.add_argument(
         "--client-options",
+        "-co",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS,
         help=f"Comma-separated list of client options to use. (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS})")
     create_workload_parser.add_argument(
         "--output-path",
+        "-op",
         default=os.path.join(os.getcwd(), "workloads"),
         help="Workload output directory (default: workloads/)")
     create_workload_parser.add_argument(
@@ -193,10 +198,12 @@ def create_arg_parser():
     compare_parser = subparsers.add_parser("compare", help="Compare two test_executions")
     compare_parser.add_argument(
         "--baseline",
+        "-b",
         required=True,
         help=f"TestExecution ID of the baseline (see {PROGRAM_NAME} list test_executions).")
     compare_parser.add_argument(
         "--contender",
+        "-c",
         required=True,
         help=f"TestExecution ID of the contender (see {PROGRAM_NAME} list test_executions).")
     compare_parser.add_argument(
@@ -206,6 +213,7 @@ def create_arg_parser():
         default=metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES)
     compare_parser.add_argument(
         "--results-format",
+        "-rfo",
         help="Define the output format for the command line results (default: markdown).",
         choices=["markdown", "csv"],
         default="markdown")
@@ -216,6 +224,7 @@ def create_arg_parser():
         default="right")
     compare_parser.add_argument(
         "--results-file",
+        "-rfi",
         help="Write the command line results also to the provided file.",
         default="")
     compare_parser.add_argument(
@@ -232,7 +241,6 @@ def create_arg_parser():
         help="Comma-separated list of TestExecution IDs to aggregate")
     aggregate_parser.add_argument(
         "--test-execution-id",
-        "-tid",
         help="Define a unique id for this aggregated test_execution.",
         default="")
     aggregate_parser.add_argument(
@@ -439,6 +447,7 @@ def create_arg_parser():
 
     test_execution_parser.add_argument(
         "--test-execution-id",
+        "-tid",
         help="Define a unique id for this test_execution.",
         default=str(uuid.uuid4()))
     test_execution_parser.add_argument(

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -102,7 +102,7 @@ def create_arg_parser():
                                      description=BANNER + "\n\n A benchmarking tool for OpenSearch",
                                      epilog="Find out more about Benchmark at {}".format(console.format.link(doc_link())),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
+    parser.add_argument('-v', '--version', action='version', version="%(prog)s " + version.version())
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -83,7 +83,6 @@ def create_arg_parser():
         )
         workload_source_group.add_argument(
             "--workload-path",
-            "-wlp",
             help="Define the path to a workload.")
         subparser.add_argument(
             "--workload-revision",
@@ -133,6 +132,7 @@ def create_arg_parser():
     add_workload_source(info_parser)
     info_parser.add_argument(
         "--workload",
+        "-w",
         help=f"Define the workload to use. List possible workloads with `{PROGRAM_NAME} list workloads`."
         # we set the default value later on because we need to determine whether the user has provided this value.
         # default="geonames"
@@ -140,6 +140,7 @@ def create_arg_parser():
 
     info_parser.add_argument(
         "--workload-params",
+        "-wp",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the workload as variables.",
         default=""
     )
@@ -169,18 +170,17 @@ def create_arg_parser():
         help="Comma-separated list of indices to include in the workload")
     create_workload_parser.add_argument(
         "--target-hosts",
-        "-th",
+        "-t",
         default="",
         required=True,
         help="Comma-separated list of host:port pairs which should be targeted")
     create_workload_parser.add_argument(
         "--client-options",
-        "-co",
+        "-c",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS,
         help=f"Comma-separated list of client options to use. (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS})")
     create_workload_parser.add_argument(
         "--output-path",
-        "-op",
         default=os.path.join(os.getcwd(), "workloads"),
         help="Workload output directory (default: workloads/)")
     create_workload_parser.add_argument(
@@ -213,7 +213,6 @@ def create_arg_parser():
         default=metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES)
     compare_parser.add_argument(
         "--results-format",
-        "-rfo",
         help="Define the output format for the command line results (default: markdown).",
         choices=["markdown", "csv"],
         default="markdown")
@@ -224,7 +223,6 @@ def create_arg_parser():
         default="right")
     compare_parser.add_argument(
         "--results-file",
-        "-rfi",
         help="Write the command line results also to the provided file.",
         default="")
     compare_parser.add_argument(
@@ -235,12 +233,12 @@ def create_arg_parser():
     aggregate_parser = subparsers.add_parser("aggregate", help="Aggregate multiple test_executions")
     aggregate_parser.add_argument(
         "--test-executions",
-        "--t",
         type=non_empty_list,
         required=True,
         help="Comma-separated list of TestExecution IDs to aggregate")
     aggregate_parser.add_argument(
         "--test-execution-id",
+        "-tid",
         help="Define a unique id for this aggregated test_execution.",
         default="")
     aggregate_parser.add_argument(
@@ -391,6 +389,7 @@ def create_arg_parser():
         default="")
     start_parser.add_argument(
         "--test-execution-id",
+        "-tid",
         required=True,
         help="Define a unique id for this test_execution.",
         default="")
@@ -428,7 +427,6 @@ def create_arg_parser():
     for p in [list_parser, test_execution_parser]:
         p.add_argument(
             "--distribution-version",
-            "-dv",
             type=supported_os_version,
             help="Define the version of the OpenSearch distribution to download. "
                  "Check https://opensearch.org/docs/version-history/ for released versions.",
@@ -452,7 +450,6 @@ def create_arg_parser():
         default=str(uuid.uuid4()))
     test_execution_parser.add_argument(
         "--pipeline",
-        "-p",
         help="Select the pipeline to run.",
         # the default will be dynamically derived by
         # test_execution_orchestrator based on the
@@ -479,7 +476,6 @@ def create_arg_parser():
     )
     test_execution_parser.add_argument(
         "--test-procedure",
-        "-tp",
         help=f"Define the test_procedure to use. List possible test_procedures for workloads with `{PROGRAM_NAME} list workloads`.")
     test_execution_parser.add_argument(
         "--provision-config-instance",
@@ -508,7 +504,7 @@ def create_arg_parser():
     )
     test_execution_parser.add_argument(
         "--target-hosts",
-        "-th",
+        "-t",
         help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
              "(default: localhost:9200).",
         default="")  # actually the default is pipeline specific and it is set later
@@ -518,7 +514,7 @@ def create_arg_parser():
         default="localhost")
     test_execution_parser.add_argument(
         "--client-options",
-        "-co",
+        "-c",
         help=f"Define a comma-separated list of client options to use. The options will be passed to the OpenSearch "
              f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
@@ -544,11 +540,9 @@ def create_arg_parser():
     task_filter_group = test_execution_parser.add_mutually_exclusive_group()
     task_filter_group.add_argument(
         "--include-tasks",
-        "-it",
         help="Defines a comma-separated list of tasks to run. By default all tasks of a test_procedure are run.")
     task_filter_group.add_argument(
         "--exclude-tasks",
-        "-et",
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a test_procedure are run.")
     test_execution_parser.add_argument(
         "--user-tag",
@@ -557,7 +551,6 @@ def create_arg_parser():
         default="")
     test_execution_parser.add_argument(
         "--results-format",
-        "-rfo",
         help="Define the output format for the command line results (default: markdown).",
         choices=["markdown", "csv"],
         default="markdown")
@@ -573,7 +566,6 @@ def create_arg_parser():
         default="available")
     test_execution_parser.add_argument(
         "--results-file",
-        "-rfi",
         help="Write the command line results also to the provided file.",
         default="")
     test_execution_parser.add_argument(
@@ -598,7 +590,7 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--kill-running-processes",
-        "-krp",
+        "-k",
         action="store_true",
         default=False,
         help="If any processes is running, it is going to kill them and allow Benchmark to continue to run."
@@ -622,7 +614,6 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--randomization-repeat-frequency",
-        "-rf",
         help=f"The repeat_frequency for query randomization. Ignored if randomization is off"
              f"(default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -83,6 +83,7 @@ def create_arg_parser():
         )
         workload_source_group.add_argument(
             "--workload-path",
+            "-wlp",
             help="Define the path to a workload.")
         subparser.add_argument(
             "--workload-revision",
@@ -231,6 +232,7 @@ def create_arg_parser():
         help="Comma-separated list of TestExecution IDs to aggregate")
     aggregate_parser.add_argument(
         "--test-execution-id",
+        "-tid",
         help="Define a unique id for this aggregated test_execution.",
         default="")
     aggregate_parser.add_argument(
@@ -418,6 +420,7 @@ def create_arg_parser():
     for p in [list_parser, test_execution_parser]:
         p.add_argument(
             "--distribution-version",
+            "-dv",
             type=supported_os_version,
             help="Define the version of the OpenSearch distribution to download. "
                  "Check https://opensearch.org/docs/version-history/ for released versions.",
@@ -440,6 +443,7 @@ def create_arg_parser():
         default=str(uuid.uuid4()))
     test_execution_parser.add_argument(
         "--pipeline",
+        "-p",
         help="Select the pipeline to run.",
         # the default will be dynamically derived by
         # test_execution_orchestrator based on the
@@ -455,15 +459,18 @@ def create_arg_parser():
     add_workload_source(test_execution_parser)
     test_execution_parser.add_argument(
         "--workload",
+        "-w",
         help=f"Define the workload to use. List possible workloads with `{PROGRAM_NAME} list workloads`."
     )
     test_execution_parser.add_argument(
         "--workload-params",
+        "-wp",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the workload as variables.",
         default=""
     )
     test_execution_parser.add_argument(
         "--test-procedure",
+        "-tp",
         help=f"Define the test_procedure to use. List possible test_procedures for workloads with `{PROGRAM_NAME} list workloads`.")
     test_execution_parser.add_argument(
         "--provision-config-instance",
@@ -492,6 +499,7 @@ def create_arg_parser():
     )
     test_execution_parser.add_argument(
         "--target-hosts",
+        "-th",
         help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
              "(default: localhost:9200).",
         default="")  # actually the default is pipeline specific and it is set later
@@ -501,6 +509,7 @@ def create_arg_parser():
         default="localhost")
     test_execution_parser.add_argument(
         "--client-options",
+        "-co",
         help=f"Define a comma-separated list of client options to use. The options will be passed to the OpenSearch "
              f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
@@ -526,9 +535,11 @@ def create_arg_parser():
     task_filter_group = test_execution_parser.add_mutually_exclusive_group()
     task_filter_group.add_argument(
         "--include-tasks",
+        "-it",
         help="Defines a comma-separated list of tasks to run. By default all tasks of a test_procedure are run.")
     task_filter_group.add_argument(
         "--exclude-tasks",
+        "-et",
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a test_procedure are run.")
     test_execution_parser.add_argument(
         "--user-tag",
@@ -537,6 +548,7 @@ def create_arg_parser():
         default="")
     test_execution_parser.add_argument(
         "--results-format",
+        "-rfo",
         help="Define the output format for the command line results (default: markdown).",
         choices=["markdown", "csv"],
         default="markdown")
@@ -552,6 +564,7 @@ def create_arg_parser():
         default="available")
     test_execution_parser.add_argument(
         "--results-file",
+        "-rfi",
         help="Write the command line results also to the provided file.",
         default="")
     test_execution_parser.add_argument(
@@ -576,6 +589,7 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--kill-running-processes",
+        "-krp",
         action="store_true",
         default=False,
         help="If any processes is running, it is going to kill them and allow Benchmark to continue to run."


### PR DESCRIPTION
### Description
Adds short-hand alternatives for commonly used command line options in OSB.

Now, rather than running:
`opensearch-benchmark execute-test --workload=geonames --target-hosts=127.0.0.1:9200 --test-mode --kill-running-processes`

one can instead run:
`opensearch-benchmark execute-test -w=geonames -th=127.0.0.1:9200 --test-mode -krp`

### Issues Resolved
#639 

### Testing
Tested by using shorthand alternatives for the commands changed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
