### PR TITLE
Add new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_template.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_template.yml
@@ -1,5 +1,5 @@
 ---
-name: Documentation request 🎆
+name: Documentation request 📖
 description: Suggest new documentation or improvements to existing documentation
 labels: [documentation, untriaged]
 body:

--- a/.github/ISSUE_TEMPLATE/documentation_template.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_template.yml
@@ -1,0 +1,26 @@
+---
+name: Documentation request 🎆
+description: Suggest new documentation or improvements to existing documentation
+labels: [documentation, untriaged]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit a documentation request!
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Is there a problem with the current documentation
+      description: A clear and concise description of what the problem is. Ex. I'm unable to find documentation on [...]
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Provide references
+      description: List out links to existing documentation if applicable
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the documentation request here.

--- a/.github/ISSUE_TEMPLATE/documentation_template.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_template.yml
@@ -10,8 +10,8 @@ body:
   - type: textarea
     id: suggestion
     attributes:
-      label: Is there a problem with the current documentation
-      description: A clear and concise description of what the problem is. Ex. I'm unable to find documentation on [...]
+      label: Please provide details on how and where the documentation can be improved
+      description: A clear and concise description of the issue. For instance, "I'm unable to find documentation on [...]"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
### Description
Now that we have [this board ](https://github.com/orgs/opensearch-project/projects/228/views/1)for documentation, we should create an issue template to easily create issues for documentation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
