### PR TITLE
Add support for multi-part data corpora downloads

### DIFF
--- a/osbenchmark/resources/workload-schema.json
+++ b/osbenchmark/resources/workload-schema.json
@@ -406,9 +406,33 @@
                   "format": "uri",
                   "description": "The root URL for these documents."
                 },
+                "source-url": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "The full URL to the document file.  This is intended for cases like when a signed URL needs to be used to access the file directly."
+                },
                 "source-file": {
                   "type": "string",
                   "description": "Name of file containing documents. This file has to be compressed either as bz2, zip or tar.gz and must contain exactly one JSON file with the same name (Examples: documents.json.bz2, documents.zip (which should contain one file called 'documents.json'))."
+                },
+                "source-file-parts": {
+                  "type": "array",
+                  "description": "A list of files that should be concatentated to create the source (document) file.  This is intended for cases where the document file is large enough that separating it into smaller parts is appropriate (optional).",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The name of the file corresponding to this part."
+                       },
+                      "size": {
+                        "type": "integer",
+                        "description": "The size of the file corresponding to this part."
+                       }
+                     }
+                  }
                 },
                 "source-format": {
                   "type": "string",

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -190,7 +190,7 @@ class Documents:
     SOURCE_FORMAT_BIG_ANN = "big-ann"
     SUPPORTED_SOURCE_FORMAT = [SOURCE_FORMAT_BULK, SOURCE_FORMAT_HDF5, SOURCE_FORMAT_BIG_ANN]
 
-    def __init__(self, source_format, document_file=None, document_archive=None, base_url=None, source_url=None,
+    def __init__(self, source_format, document_file=None, document_file_parts=None, document_archive=None, base_url=None, source_url=None,
                  includes_action_and_meta_data=False,
                  number_of_documents=0, compressed_size_in_bytes=0, uncompressed_size_in_bytes=0, target_index=None,
                  target_data_stream=None, target_type=None, meta_data=None):
@@ -199,6 +199,7 @@ class Documents:
         :param source_format: The format of these documents. Mandatory.
         :param document_file: The file name of benchmark documents after decompression. Optional (e.g. for percolation we
         just need a mapping but no documents)
+        :param document_file_parts: If the document file is provided as parts, a list of dicts, each holding the filename and file size.
         :param document_archive: The file name of the compressed benchmark document name on the remote server. Optional (e.g. for
         percolation we just need a mapping but no documents)
         :param base_url: The URL from which to load data if they are not available locally. Excludes the file or object name. Optional.
@@ -223,6 +224,7 @@ class Documents:
 
         self.source_format = source_format
         self.document_file = document_file
+        self.document_file_parts = document_file_parts
         self.document_archive = document_archive
         self.base_url = base_url
         self.source_url = source_url


### PR DESCRIPTION
### Description
Permits data corpus files to be downloaded in parts.  This is not intended for performance, but rather, to work around the restriction on file size that services like CloudFront might have.

### Issues Resolved
#543 

### Testing
Lint, unit and integ tests.  Added a unit test to exercise the feature.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
