### PR TITLE
add relative standard deviation to aggregated test execution metrics

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -214,7 +214,7 @@ class Aggregator:
 
         return weighted_metrics
 
-    def calculate_rsd(self, values, metric_name: str):
+    def calculate_rsd(self, values: List[Union[int, float]], metric_name: str):
         if not values:
             raise ValueError(f"Cannot calculate RSD for metric '{metric_name}': empty list of values")
         if len(values) == 1:

--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -133,13 +133,13 @@ class Aggregator:
                     # Calculate RSD for the mean values across all test executions
                     # We use mean here as it's more sensitive to outliers, which is desirable for assessing variability
                     mean_values = [v['mean'] for v in task_metrics[metric]]
-                    rsd = self.calculate_rsd(mean_values)
+                    rsd = self.calculate_rsd(mean_values, f"{task}.{metric}.mean")
                     op_metric[metric]['mean_rsd'] = rsd
 
                 # Handle derived metrics (like error_rate, duration) which are stored as simple values
                 else:
                     # Calculate RSD directly from the metric values across all test executions
-                    rsd = self.calculate_rsd(task_metrics[metric])
+                    rsd = self.calculate_rsd(task_metrics[metric], f"{task}.{metric}")
                     op_metric[f"{metric}_rsd"] = rsd
 
             aggregated_results["op_metrics"].append(op_metric)
@@ -214,9 +214,9 @@ class Aggregator:
 
         return weighted_metrics
 
-    def calculate_rsd(self, values):
+    def calculate_rsd(self, values, metric_name: str):
         if not values:
-            raise ValueError("Cannot calculate RSD for an empty list of values")
+            raise ValueError(f"Cannot calculate RSD for metric '{metric_name}': empty list of values")
         if len(values) == 1:
             return "NA"  # RSD is not applicable for a single value
         mean = statistics.mean(values)


### PR DESCRIPTION
### Description
Adds relative standard deviation to aggregated test result metrics. Users can now see the spread of their OSB test results. (RSD is currently only calculated for the mean)

Example:
```
   {
    "task": "wait-until-merges-finish",
    "operation": "wait-until-merges-finish",
    "throughput": {
     "min": 74.41136845553248,
     "mean": 74.41136845553248,
     "median": 74.41136845553248,
     "max": 74.41136845553248,
     "unit": "ops/s",
     "mean_rsd": 5.7260883182218825
    },
    "latency": {
     "100_0": 12.996128527447581,
     "mean": 12.996128527447581,
     "unit": "ms",
     "mean_rsd": 5.875897232448762
    },
    "service_time": {
     "100_0": 12.996128527447581,
     "mean": 12.996128527447581,
     "unit": "ms",
     "mean_rsd": 5.875897232448762
    },
    "client_processing_time": {
     "100_0": 0.6900834268890321,
     "mean": 0.6900834268890321,
     "unit": "ms",
     "mean_rsd": 1.172341871616217
    },
    "processing_time": {
     "100_0": 13.791589008178562,
     "mean": 13.791589008178562,
     "unit": "ms",
     "mean_rsd": 5.595395107897675
    },
    "error_rate": 0.0,
    "error_rate_rsd": 0,
    "duration": 3.3562859753146768,
    "duration_rsd": 1.6848600926145232
   },
```

### Issues Resolved
#662 

### Testing
- [x] New functionality includes testing

`make test`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
