### PR TITLE
Fix workload parameter processing when a key is mapped to a JSON file

### DIFF
--- a/osbenchmark/utils/opts.py
+++ b/osbenchmark/utils/opts.py
@@ -84,7 +84,7 @@ def kv_to_map(kvs):
 
 
 def to_dict(arg, default_parser=kv_to_map):
-    if io.has_extension(arg, ".json"):
+    if io.has_extension(arg, ".json") and ',' not in arg and ':' not in arg:
         with open(io.normalize_path(arg), mode="rt", encoding="utf-8") as f:
             return json.load(f)
     elif arg.startswith("{"):

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1278,7 +1278,11 @@ class WorkloadFileReader:
                         ve.instance, indent=4, sort_keys=True),
                         ve.absolute_path, ve.absolute_schema_path))
 
-        current_workload = self.read_workload(workload_name, workload_spec, mapping_dir)
+        try:
+            current_workload = self.read_workload(workload_name, workload_spec, mapping_dir)
+        except Exception as e:
+            console.error(e)
+            raise
 
         unused_user_defined_workload_params = self.complete_workload_params.unused_user_defined_workload_params()
         if len(unused_user_defined_workload_params) > 0:

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -25,6 +25,7 @@
 import os
 from unittest import TestCase
 
+import unittest.mock as mock
 from osbenchmark.utils import opts
 
 
@@ -140,6 +141,26 @@ class GenericHelperFunctionTests(TestCase):
                 ["number_of_shards", "number_of-replicas"],
                 [])
         )
+
+    def test_to_dict_str(self):
+        json = '{ "field": 2 }'
+        rsl = opts.to_dict(json)
+        self.assertEqual(rsl, {"field": 2})
+
+        rsl = opts.to_dict('a:1,b:2')
+        self.assertEqual(rsl, {'a': 1, 'b': 2})
+
+    @mock.patch("json.loads")
+    def test_to_dict_file(self, json_loads):
+        mo = mock.mock_open()
+        with mock.patch("builtins.open", mo):
+            opts.to_dict('params.json')
+        mo.assert_called()
+
+        mo = mock.mock_open()
+        with mock.patch("builtins.open", mo):
+            opts.to_dict('index_body:idx.json')
+        mo.assert_not_called()
 
 
 class TestTargetHosts(TestCase):


### PR DESCRIPTION
### Description
When the argument passed to the `workload-params` option includes a key-value pair, where the value is a JSON file, there parser may treat the entire option string incorrectly as a filename. 

### Issues Resolved
#502 

### Testing
Unit and integ tests.  Added unit tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
