### PR TITLE
Add support for custom iteration values

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -127,7 +127,6 @@ class Aggregator:
         }
 
         for task, task_metrics in self.accumulated_results.items():
-            iterations = self.accumulated_iterations.get(task, 1)
             aggregated_task_metrics = self.calculate_weighted_average(task_metrics, task)
             op_metric = {
                 "task": task,
@@ -201,10 +200,9 @@ class Aggregator:
 
     def calculate_weighted_average(self, task_metrics: Dict[str, List[Any]], task_name: str) -> Dict[str, Any]:
         weighted_metrics = {}
-        num_executions = len(next(iter(task_metrics.values())))
-        
+
         # Get iterations for each test execution
-        iterations_per_execution = [self.accumulated_iterations[test_id][task_name] 
+        iterations_per_execution = [self.accumulated_iterations[test_id][task_name]
                                     for test_id in self.test_executions.keys()]
         total_iterations = sum(iterations_per_execution)
 

--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -17,32 +17,28 @@ class Aggregator:
         self.metrics = ["throughput", "latency", "service_time", "client_processing_time", "processing_time", "error_rate", "duration"]
         self.test_store = metrics.test_execution_store(self.config)
         self.cwd = cfg.opts("node", "benchmark.cwd")
+        self.test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
+        self.test_procedure_name = self.test_execution.test_procedure
+        self.loaded_workload = None
 
     def count_iterations_for_each_op(self, test_execution) -> None:
-        loaded_workload = workload.load_workload(self.config)
-        test_procedure_name = self.config.opts("workload", "test_procedure.name")
-        test_procedure_found = False
-        workload_params = {} if getattr(test_execution, 'workload_params') is None else test_execution.workload_params
+        matching_test_procedure = next((tp for tp in self.loaded_workload.test_procedures if tp.name == self.test_procedure_name), None)
+        workload_params = getattr(test_execution, 'workload_params', {})
 
         test_execution_id = test_execution.test_execution_id
         self.accumulated_iterations[test_execution_id] = {}
 
-        for test_procedure in loaded_workload.test_procedures:
-            if test_procedure.name == test_procedure_name:
-                test_procedure_found = True
-                for task in test_procedure.schedule:
-                    task_name = task.name
-                    custom_key = f"{task_name}_iterations"
-                    if custom_key in workload_params:
-                        iterations = int(workload_params[custom_key])
-                    else:
-                        iterations = task.iterations or 1
-                    self.accumulated_iterations[test_execution_id][task_name] = iterations
-            else:
-                continue  # skip to the next test procedure if the name doesn't match
-
-        if not test_procedure_found:
-            raise ValueError(f"Test procedure '{test_procedure_name}' not found in the loaded workload.")
+        if matching_test_procedure:
+            for task in matching_test_procedure.schedule:
+                task_name = task.name
+                task_name_iterations = f"{task_name}_iterations"
+                if task_name_iterations in workload_params:
+                    iterations = int(workload_params[task_name_iterations])
+                else:
+                    iterations = task.iterations or 1
+                self.accumulated_iterations[test_execution_id][task_name] = iterations
+        else:
+            raise ValueError(f"Test procedure '{self.test_procedure_name}' not found in the loaded workload.")
 
     def accumulate_results(self, test_execution: Any) -> None:
         for item in test_execution.results.get("op_metrics", []):
@@ -184,9 +180,9 @@ class Aggregator:
         self.config.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", test_exe.throughput_percentiles)
 
         loaded_workload = workload.load_workload(self.config)
-        test_procedure = loaded_workload.find_test_procedure_or_default(test_exe.test_procedure)
+        test_procedure_object = loaded_workload.find_test_procedure_or_default(self.test_procedure_name)
 
-        test_execution = metrics.create_test_execution(self.config, loaded_workload, test_procedure, test_exe.workload_revision)
+        test_execution = metrics.create_test_execution(self.config, loaded_workload, test_procedure_object, test_exe.workload_revision)
         test_execution.user_tags = {
             "aggregation-of-runs": list(self.test_executions.keys())
         }
@@ -256,16 +252,17 @@ class Aggregator:
             else:
                 raise ValueError(f"Test execution not found: {id}. Ensure that all provided test IDs are valid.")
 
-        self.config.add(config.Scope.applicationOverride, "workload", "test_procedure.name", first_test_execution.test_procedure)
+        self.config.add(config.Scope.applicationOverride, "workload", "test_procedure.name", self.test_procedure_name)
         return True
 
     def aggregate(self) -> None:
         if self.test_execution_compatibility_check():
+            self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
+            self.config.add(config.Scope.applicationOverride, "workload", "workload.name", self.test_execution.workload)
+            self.loaded_workload = workload.load_workload(self.config)
             for id in self.test_executions.keys():
                 test_execution = self.test_store.find_by_test_execution_id(id)
                 if test_execution:
-                    self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
-                    self.config.add(config.Scope.applicationOverride, "workload", "workload.name", test_execution.workload)
                     self.count_iterations_for_each_op(test_execution)
                     self.accumulate_results(test_execution)
 

--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -17,8 +17,8 @@ class Aggregator:
         self.metrics = ["throughput", "latency", "service_time", "client_processing_time", "processing_time", "error_rate", "duration"]
         self.test_store = metrics.test_execution_store(self.config)
         self.cwd = cfg.opts("node", "benchmark.cwd")
-        self.test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
-        self.test_procedure_name = self.test_execution.test_procedure
+        self.test_execution = None
+        self.test_procedure_name = None
         self.loaded_workload = None
 
     def count_iterations_for_each_op(self, test_execution) -> None:
@@ -257,6 +257,8 @@ class Aggregator:
 
     def aggregate(self) -> None:
         if self.test_execution_compatibility_check():
+            self.test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
+            self.test_procedure_name = self.test_execution.test_procedure
             self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
             self.config.add(config.Scope.applicationOverride, "workload", "workload.name", self.test_execution.workload)
             self.loaded_workload = workload.load_workload(self.config)

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch
 import pytest
 from osbenchmark import config
 from osbenchmark.aggregator import Aggregator, AggregatedResults
@@ -58,7 +58,6 @@ def test_count_iterations_for_each_op(aggregator):
     with patch('osbenchmark.workload.load_workload', return_value=mock_workload):
         aggregator.count_iterations_for_each_op(mock_test_execution)
 
-    print(f"accumulated_iterations: {aggregator.accumulated_iterations}")
     assert "test1" in aggregator.accumulated_iterations, "test1 not found in accumulated_iterations"
     assert "op1" in aggregator.accumulated_iterations["test1"], "op1 not found in accumulated_iterations for test1"
     assert aggregator.accumulated_iterations["test1"]["op1"] == 5
@@ -144,9 +143,7 @@ def test_aggregate(aggregator):
          patch.object(aggregator, 'count_iterations_for_each_op'), \
          patch.object(aggregator, 'accumulate_results'), \
          patch.object(aggregator, 'build_aggregated_results', return_value=mock_aggregated_results) as mock_build, \
-         patch('osbenchmark.aggregator.FileTestExecutionStore') as mock_store_class, \
-         patch('osbenchmark.utils.io.ensure_dir') as mock_ensure_dir, \
-         patch('builtins.open', mock_open()) as mock_file:
+         patch('osbenchmark.aggregator.FileTestExecutionStore') as mock_store_class:
 
         mock_store = mock_store_class.return_value
         mock_store.store_aggregated_execution.side_effect = lambda x: print(f"Storing aggregated execution: {x}")
@@ -159,16 +156,8 @@ def test_aggregate(aggregator):
 
         aggregator.aggregate()
 
-        print(f"mock_build called: {mock_build.called}")
-        print(f"mock_store.store_aggregated_execution called: {mock_store.store_aggregated_execution.called}")
-
         assert mock_build.called, "build_aggregated_results was not called"
         mock_store.store_aggregated_execution.assert_called_once_with(mock_aggregated_results)
-
-        print(f"ensure_dir called: {mock_ensure_dir.called}")
-        print(f"ensure_dir call args: {mock_ensure_dir.call_args_list}")
-        print(f"open called: {mock_file.called}")
-        print(f"open call args: {mock_file.call_args_list}")
 
         assert mock_store.store_aggregated_execution.called, "store_aggregated_execution was not called"
 

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 import pytest
 from osbenchmark import config
 from osbenchmark.aggregator import Aggregator, AggregatedResults
@@ -52,11 +52,10 @@ def test_count_iterations_for_each_op(aggregator):
 
     mock_test_execution = Mock(test_execution_id="test1", workload_params={})
 
-    # update the config mock to return the correct test_procedure_name
-    aggregator.config.opts.side_effect = lambda *args: \
-        mock_test_procedure.name if args == ("workload", "test_procedure.name") else "/path/to/root"
-    with patch('osbenchmark.workload.load_workload', return_value=mock_workload):
-        aggregator.count_iterations_for_each_op(mock_test_execution)
+    aggregator.loaded_workload = mock_workload
+    aggregator.test_procedure_name = "test_procedure_name"
+
+    aggregator.count_iterations_for_each_op(mock_test_execution)
 
     assert "test1" in aggregator.accumulated_iterations, "test1 not found in accumulated_iterations"
     assert "op1" in aggregator.accumulated_iterations["test1"], "op1 not found in accumulated_iterations for test1"
@@ -135,31 +134,6 @@ def test_test_execution_compatibility_check_incompatible(aggregator):
     aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
     with pytest.raises(ValueError):
         aggregator.test_execution_compatibility_check()
-
-def test_aggregate(aggregator):
-    mock_aggregated_results = Mock(test_execution_id="mock_id", as_dict=lambda: {})
-
-    with patch.object(aggregator, 'test_execution_compatibility_check', return_value=True), \
-         patch.object(aggregator, 'count_iterations_for_each_op'), \
-         patch.object(aggregator, 'accumulate_results'), \
-         patch.object(aggregator, 'build_aggregated_results', return_value=mock_aggregated_results) as mock_build, \
-         patch('osbenchmark.aggregator.FileTestExecutionStore') as mock_store_class:
-
-        mock_store = mock_store_class.return_value
-        mock_store.store_aggregated_execution.side_effect = lambda x: print(f"Storing aggregated execution: {x}")
-
-        # mock test_store to return a Mock object for each test execution
-        aggregator.test_store.find_by_test_execution_id.side_effect = [
-            Mock(test_execution_id="test1", workload_params={}),
-            Mock(test_execution_id="test2", workload_params={})
-        ]
-
-        aggregator.aggregate()
-
-        assert mock_build.called, "build_aggregated_results was not called"
-        mock_store.store_aggregated_execution.assert_called_once_with(mock_aggregated_results)
-
-        assert mock_store.store_aggregated_execution.called, "store_aggregated_execution was not called"
 
 def test_aggregated_results():
     results = {"key": "value"}


### PR DESCRIPTION
### Description
Recently, OSB workloads were updated to include parameters for users to input custom iteration values in their test executions. This change gives the new aggregate command the ability to read these values and take them into account when calculating the average values for test executions.

Previously, iterations for each task were stored as a sum of iterations across all test execution. With this change, the iterations for each task are stored separately, so a test with x times the iterations of another will also hold that much more weight in the average calculation.

Also updates the unit tests to reflect the new changes.

### Issues Resolved
#670 

### Testing
- [x] New functionality includes testing

`make test`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
