### PR TITLE
Replaced occurrences of "Benchmark" with "OSB"

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -2,7 +2,7 @@ version: 2
 cli:
   server: https://app.fossa.com
   fetcher: custom
-  project: Benchmark
+  project: OSB
 analyze:
   modules:
   - name: .

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ target/
 # pyenv
 .python-version
 
-# Benchmark specific
+# OSB specific
 .benchmark_it/
 # Virtualenv for development
 .venv*/

--- a/benchmark
+++ b/benchmark
@@ -24,7 +24,7 @@ set -u
 # fail on pipeline errors, e.g. when grepping
 set -o pipefail
 
-# We assume here that this script will stay in the Benchmark git root directory (it does not make sense in any other place anyway)
+# We assume here that this script will stay in the OSB git root directory (it does not make sense in any other place anyway)
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -40,7 +40,7 @@ cd "${BENCHMARK_SRC_HOME}" >/dev/null 2>&1
 
 # set variables that are needed for run.sh
 __BENCHMARK_INTERNAL_BINARY_NAME="osbenchmark"
-__BENCHMARK_INTERNAL_HUMAN_NAME="Benchmark"
+__BENCHMARK_INTERNAL_HUMAN_NAME="OpenSearch Benchmark"
 
 source run.sh
 

--- a/benchmarkd
+++ b/benchmarkd
@@ -24,7 +24,7 @@ set -u
 # fail on pipeline errors, e.g. when grepping
 set -o pipefail
 
-# We assume here that this script will stay in the Benchmark git root directory (it does not make sense in any other place anyway)
+# We assume here that this script will stay in the OSB git root directory (it does not make sense in any other place anyway)
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -37,11 +37,11 @@ BENCHMARK_SRC_HOME="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 pushd . >/dev/null 2>&1
 cd "${BENCHMARK_SRC_HOME}" >/dev/null 2>&1
 
-# ensure the Actor system can find Benchmark sources (it is ok if PYTHONPATH is undefined yet. Hence we define an empty default).
+# ensure the Actor system can find OSB sources (it is ok if PYTHONPATH is undefined yet. Hence we define an empty default).
 export PYTHONPATH="${BENCHMARK_SRC_HOME}:${PYTHONPATH:-}"
 
 # set variables that are needed for run.sh
 __BENCHMARK_INTERNAL_BINARY_NAME="osbenchmarkd"
-__BENCHMARK_INTERNAL_HUMAN_NAME="Benchmark daemon"
+__BENCHMARK_INTERNAL_HUMAN_NAME="OpenSearch Benchmark Daemon"
 
 source run.sh

--- a/docs/api/client-options.md
+++ b/docs/api/client-options.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Client Options
-parent: Benchmark API
+parent: OSB API
 nav_order: 12
 ---

--- a/docs/api/execute-test.md
+++ b/docs/api/execute-test.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Execute Test
-parent: Benchmark API
+parent: OSB API
 nav_order: 10
 ---
 
@@ -23,10 +23,10 @@ Argument | Description | Required
 :--- | :--- |:---
 `workload` | The dataset and operations that execute during a test. See [OpenSearch Benchmark Workloads repository](https://github.com/opensearch-project/opensearch-benchmark-workloads) for more details on workloads. | Yes
 `workload-params` | Parameters defined within each workload that can be overwritten. These parameters are outlined in the README of each workload. You can find an example of the parameters for the eventdata workload [here](https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/eventdata#parameters).  | No
-`test_procedure` | Test Procedures define the sequence of operations and parameters for a specific workload. When no `test_procedure` is specified, Benchmark selects the default for the workload. You can find an example test procedure [here](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/eventdata/test_procedures/default.json). | No
+`test_procedure` | Test Procedures define the sequence of operations and parameters for a specific workload. When no `test_procedure` is specified, OSB selects the default for the workload. You can find an example test procedure [here](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/eventdata/test_procedures/default.json). | No
 `client-options` | Options for the [OpenSearch Python client](https://opensearch.org/docs/latest/clients/python/). Required if testing against a cluster with security enabled. | No
 `pipeline` | Steps required to execute a test, including provisioning an OpenSearch from source code or a specified distribution. Defaults to `from-sources` which provisions an OpenSearch cluster from source code. | No
-`distribution-version` | The OpenSearch version to use for a given test. Defining a version can be useful when using a `pipeline` that includes provisioning. When using a `pipeline` without provisioning, Benchmark will automatically determine the version | No
+`distribution-version` | The OpenSearch version to use for a given test. Defining a version can be useful when using a `pipeline` that includes provisioning. When using a `pipeline` without provisioning, OSB will automatically determine the version | No
 `target-hosts` | The OpenSearch endpoint(s) to execute a test against. This should only be specified with  `--pipeline=benchmark-only`  | No
 `test-mode` | Run a single iteration of each operation in the test procedure. The test provides a quick way for sanity checking a testing configuration. Therefore, do not use `test-mode` for actual benchmarking. | No
 `kill-running-processes` | Kill any running OpenSearch Benchmark processes on the local machine before the test executes. | No
@@ -62,14 +62,14 @@ Argument | Description | Required
 :--- | :--- |:---
 `distribution-version` | Define the version of the OpenSearch distribution to download. Check https://opensearch.org/docs/version-history/ for released versions. | No
 `provision-config-path` | Define the path to the provision_config_instance and plugin configurations to use. | No
-`provision-config-repository` | Define repository from where Benchmark will load provision_configs and provision_config_instances (default: `default`). | No
-`provision-config-revision` | Define a specific revision in the provision_config repository that Benchmark should use. | No
+`provision-config-repository` | Define repository from where OSB will load provision_configs and provision_config_instances (default: `default`). | No
+`provision-config-revision` | Define a specific revision in the provision_config repository that OSB should use. | No
 `test-execution-id` | Define a unique id for this test_execution. | No
 `pipeline` | Select the pipeline to run. | No
 `revision` | Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is, 'latest' fetches the latest version on main. It is also possible to specify a commit id or an ISO timestamp. The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, e.g. "@2013-07-27T10:37:00Z" (default: `current`). | No
-`workload-repository` | Define the repository from where Benchmark will load workloads (default: `default`). | No
+`workload-repository` | Define the repository from where OSB will load workloads (default: `default`). | No
 `workload-path` | Define the path to a workload. | No
-`workload-revision` | Define a specific revision in the workload repository that Benchmark should use. | No
+`workload-revision` | Define a specific revision in the workload repository that OSB should use. | No
 `workload` | Define the workload to use. List possible workloads with `opensearch-benchmark list workloads`. | No
 `workload-params` | Define a comma-separated list of key:value pairs that are injected verbatim to the workload as variables. | No
 `test-procedure` | Define the test_procedure to use. List possible test_procedures for workloads with `opensearch-benchmark list workloads`. | No
@@ -81,7 +81,7 @@ Argument | Description | Required
 `target-hosts` | Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' (default: `localhost:9200`). | No
 `load-worker-coordinator-hosts` | Define a comma-separated list of hosts which should generate load (default: `localhost`). | No
 `client-options` | Define a comma-separated list of client options to use. The options will be passed to the OpenSearch Python client (default: `timeout:60`). | No
-`on-error` | Controls how Benchmark behaves on response errors. Options are `continue` and `abort` (default: `continue`). | No
+`on-error` | Controls how OSB behaves on response errors. Options are `continue` and `abort` (default: `continue`). | No
 `telemetry` | Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices with `opensearch-benchmark list telemetry`. | No
 `telemetry-params` | Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters. | No
 `distribution-repository` | Define the repository from where the OpenSearch distribution should be downloaded (default: `release`). | No
@@ -94,9 +94,9 @@ Argument | Description | Required
 `results-file` | Write the command line results also to the provided file. | No
 `preserve-install` | Keep the benchmark candidate and its index. (default: false). | No
 `test-mode` | Runs the given workload in 'test mode'. Meant to check a workload for errors but not for real benchmarks (default: false). | No
-`enable-worker-coordinator-profiling` | Enables a profiler for analyzing the performance of calls in Benchmark's worker coordinator (default: false). | No
+`enable-worker-coordinator-profiling` | Enables a profiler for analyzing the performance of calls in OSB's worker coordinator (default: false). | No
 `enable-assertions` | Enables assertion checks for tasks (default: false). | No
-`kill-running-processes` | If any processes is running, it is going to kill them and allow Benchmark to continue to run. | No
+`kill-running-processes` | If any processes is running, it is going to kill them and allow OSB to continue to run. | No
 `quiet` | Suppress as much as output as possible (default: false). | No
-`offline` | Assume that Benchmark has no connection to the Internet (default: false). | No
+`offline` | Assume that OSB has no connection to the Internet (default: false). | No
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Benchmark API
+title: OSB API
 nav_order: 2
 has_children: true
 ---

--- a/docs/api/kill-running-process.md
+++ b/docs/api/kill-running-process.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Kill Running Process
-parent: Benchmark API
+parent: OSB API
 nav_order: 14
 ---

--- a/docs/api/pipeline.md
+++ b/docs/api/pipeline.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Pipeline
-parent: Benchmark API
+parent: OSB API
 nav_order: 11
 ---

--- a/docs/api/target-hosts.md
+++ b/docs/api/target-hosts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Target Hosts
-parent: Benchmark API
+parent: OSB API
 nav_order: 15
 ---

--- a/docs/api/test-mode.md
+++ b/docs/api/test-mode.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Test Mode
-parent: Benchmark API
+parent: OSB API
 nav_order: 13
 ---

--- a/docs/api/workload.md
+++ b/docs/api/workload.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Execute Test
-parent: Benchmark API
+parent: OSB API
 nav_order: 16
 ---

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Get Started
-parent: Benchmark
+parent: OSB
 nav_order: 1
 ---

--- a/docs/user-guides/create-pipeline.md
+++ b/docs/user-guides/create-pipeline.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Create and manage pipelines
-parent: Benchmark Use Cases
+parent: OSB Use Cases
 nav_order: 20
 ---
 

--- a/osbenchmark/__init__.py
+++ b/osbenchmark/__init__.py
@@ -30,7 +30,7 @@ import pkg_resources
 
 __version__ = pkg_resources.require("opensearch-benchmark")[0].version
 
-# Allow an alternative program name be set in case Benchmark is invoked a wrapper script
+# Allow an alternative program name be set in case OSB is invoked a wrapper script
 PROGRAM_NAME = os.getenv("BENCHMARK_ALTERNATIVE_BINARY_NAME", os.path.basename(sys.argv[0]))
 
 DOC_LINK = "https://opensearch.org/docs"
@@ -80,7 +80,7 @@ $$$$$$$$$$""""           ""$$$$$$$$$$$"
 
 def check_python_version():
     if sys.version_info.major != 3 or sys.version_info.minor < 8:
-        raise RuntimeError("Benchmark requires at least Python 3.8 but you are using:\n\nPython %s" % str(sys.version))
+        raise RuntimeError("OSB requires at least Python 3.8 but you are using:\n\nPython %s" % str(sys.version))
 
 
 def doc_link(path=None):

--- a/osbenchmark/actor.py
+++ b/osbenchmark/actor.py
@@ -67,7 +67,7 @@ def no_retry(f, actor_name):
 
     Decorator intended for Thespian message handlers with the signature ``receiveMsg_$MSG_NAME(self, msg, sender)``. Thespian will
     assume that a message handler that raises an exception can be retried. It will then retry once and give up afterwards just leaving
-    a trace of that in the actor system's internal log file. However, this is usually *not* what we want in Benchmark. If handling of a
+    a trace of that in the actor system's internal log file. However, this is usually *not* what we want in OSB. If handling of a
     message fails we instead want to notify a node higher up in the actor hierarchy.
 
     We achieve that by sending a ``BenchmarkFailure`` message to the original sender. Note that this might as well be the current
@@ -232,7 +232,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
                 local_ip = None
         else:
             if system_base not in ("multiprocTCPBase", "multiprocUDPBase"):
-                raise exceptions.SystemSetupError("Benchmark requires a network-capable system base but got [%s]." % system_base)
+                raise exceptions.SystemSetupError("OSB requires a network-capable system base but got [%s]." % system_base)
             if not coordinator_ip:
                 raise exceptions.SystemSetupError("coordinator IP is required")
             if not local_ip:

--- a/osbenchmark/async_connection.py
+++ b/osbenchmark/async_connection.py
@@ -174,7 +174,7 @@ class AIOHttpConnection(opensearchpy.AIOHttpConnection):
                          http_auth=http_auth,
                          use_ssl=use_ssl,
                          ssl_assert_fingerprint=ssl_assert_fingerprint,
-                         # provided to the base class via `maxsize` to keep base class state consistent despite Benchmark
+                         # provided to the base class via `maxsize` to keep base class state consistent despite OSB
                          # calling the attribute differently.
                          maxsize=max(256, kwargs.get("max_connections", 0)),
                          headers=headers,
@@ -251,7 +251,7 @@ class AsyncHttpConnection(opensearchpy.AsyncHttpConnection):
                          http_auth=http_auth,
                          use_ssl=use_ssl,
                          ssl_assert_fingerprint=ssl_assert_fingerprint,
-                         # provided to the base class via `maxsize` to keep base class state consistent despite Benchmark
+                         # provided to the base class via `maxsize` to keep base class state consistent despite OSB
                          # calling the attribute differently.
                          maxsize=max(256, kwargs.get("max_connections", 0)),
                          headers=headers,

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -77,7 +77,7 @@ def create_arg_parser():
         workload_source_group = subparser.add_mutually_exclusive_group()
         workload_source_group.add_argument(
             "--workload-repository",
-            help="Define the repository from where Benchmark will load workloads (default: default).",
+            help="Define the repository from where OSB will load workloads (default: default).",
             # argparse is smart enough to use this default only if the user did not use --workload-path and also did not specify anything
             default="default"
         )
@@ -86,7 +86,7 @@ def create_arg_parser():
             help="Define the path to a workload.")
         subparser.add_argument(
             "--workload-revision",
-            help="Define a specific revision in the workload repository that Benchmark should use.",
+            help="Define a specific revision in the workload repository that OSB should use.",
             default=None)
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
@@ -99,7 +99,7 @@ def create_arg_parser():
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n A benchmarking tool for OpenSearch",
-                                     epilog="Find out more about Benchmark at {}".format(console.format.link(doc_link())),
+                                     epilog="Find out more about OSB at {}".format(console.format.link(doc_link())),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-v', '--version', action='version', version="%(prog)s " + version.version())
 
@@ -118,7 +118,7 @@ def create_arg_parser():
     list_parser.add_argument(
         "configuration",
         metavar="configuration",
-        help="The configuration for which Benchmark should show the available options. "
+        help="The configuration for which OSB should show the available options. "
              "Possible values are: telemetry, workloads, pipelines, test_executions, provision_config_instances, opensearch-plugins",
         choices=["telemetry", "workloads", "pipelines", "test_executions", "aggregated_results",
                  "provision_config_instances", "opensearch-plugins"])
@@ -157,7 +157,7 @@ def create_arg_parser():
         "--exclude-tasks",
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a test_procedure are run.")
 
-    create_workload_parser = subparsers.add_parser("create-workload", help="Create a Benchmark workload from existing data")
+    create_workload_parser = subparsers.add_parser("create-workload", help="Create a OSB workload from existing data")
     create_workload_parser.add_argument(
         "--workload",
         "-w",
@@ -254,11 +254,11 @@ def create_arg_parser():
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
     download_parser.add_argument(
         "--provision-config-repository",
-        help="Define the repository from where Benchmark will load provision_configs and provision_config_instances (default: default).",
+        help="Define the repository from where OSB will load provision_configs and provision_config_instances (default: default).",
         default="default")
     download_parser.add_argument(
         "--provision-config-revision",
-        help="Define a specific revision in the provision_config repository that Benchmark should use.",
+        help="Define a specific revision in the provision_config repository that OSB should use.",
         default=None)
     download_parser.add_argument(
         "--provision-config-path",
@@ -309,11 +309,11 @@ def create_arg_parser():
         default="tar")
     install_parser.add_argument(
         "--provision-config-repository",
-        help="Define the repository from where Benchmark will load provision_configs and provision_config_instances (default: default).",
+        help="Define the repository from where OSB will load provision_configs and provision_config_instances (default: default).",
         default="default")
     install_parser.add_argument(
         "--provision-config-revision",
-        help="Define a specific revision in the provision_config repository that Benchmark should use.",
+        help="Define a specific revision in the provision_config repository that OSB should use.",
         default=None)
     install_parser.add_argument(
         "--provision-config-path",
@@ -437,11 +437,11 @@ def create_arg_parser():
             help="Define the path to the provision_config_instance and plugin configurations to use.")
         p.add_argument(
             "--provision-config-repository",
-            help="Define repository from where Benchmark will load provision_configs and provision_config_instances (default: default).",
+            help="Define repository from where OSB will load provision_configs and provision_config_instances (default: default).",
             default="default")
         p.add_argument(
             "--provision-config-revision",
-            help="Define a specific revision in the provision_config repository that Benchmark should use.",
+            help="Define a specific revision in the provision_config repository that OSB should use.",
             default=None)
 
     test_execution_parser.add_argument(
@@ -521,7 +521,7 @@ def create_arg_parser():
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
     test_execution_parser.add_argument("--on-error",
                              choices=["continue", "abort"],
-                             help="Controls how Benchmark behaves on response errors (default: continue).",
+                             help="Controls how OSB behaves on response errors (default: continue).",
                              default="continue")
     test_execution_parser.add_argument(
         "--telemetry",
@@ -581,7 +581,7 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--enable-worker-coordinator-profiling",
-        help="Enables a profiler for analyzing the performance of calls in Benchmark's worker coordinator (default: false).",
+        help="Enables a profiler for analyzing the performance of calls in OSB's worker coordinator (default: false).",
         default=False,
         action="store_true")
     test_execution_parser.add_argument(
@@ -594,7 +594,7 @@ def create_arg_parser():
         "-k",
         action="store_true",
         default=False,
-        help="If any processes is running, it is going to kill them and allow Benchmark to continue to run."
+        help="If any processes is running, it is going to kill them and allow OSB to continue to run."
     )
     test_execution_parser.add_argument(
         "--latency-percentiles",
@@ -653,7 +653,7 @@ def create_arg_parser():
     # The options below are undocumented and can be removed or changed at any time.
     #
     ###############################################################################
-    # This option is intended to tell Benchmark to assume a different start date than 'now'. This is effectively just useful for things like
+    # This option is intended to tell OSB to assume a different start date than 'now'. This is effectively just useful for things like
     # backtesting or a benchmark run across environments (think: comparison of EC2 and bare metal) but never for the typical user.
     test_execution_parser.add_argument(
         "--effective-start-date",
@@ -681,7 +681,7 @@ def create_arg_parser():
             action="store_true")
         p.add_argument(
             "--offline",
-            help="Assume that Benchmark has no connection to the Internet (default: false).",
+            help="Assume that OSB has no connection to the Internet (default: false).",
             default=False,
             action="store_true")
 
@@ -723,23 +723,23 @@ def execute_test(cfg, kill_running_processes=False):
     logger = logging.getLogger(__name__)
 
     if kill_running_processes:
-        logger.info("Killing running Benchmark processes")
+        logger.info("Killing running OSB processes")
 
-        # Kill any lingering Benchmark processes before attempting to continue - the actor system needs to be a singleton on this machine
+        # Kill any lingering OSB processes before attempting to continue - the actor system needs to be a singleton on this machine
         # noinspection PyBroadException
         try:
             process.kill_running_benchmark_instances()
         except BaseException:
             logger.exception(
-                "Could not terminate potentially running Benchmark instances correctly. Attempting to go on anyway.")
+                "Could not terminate potentially running OSB instances correctly. Attempting to go on anyway.")
     else:
         other_benchmark_processes = process.find_all_other_benchmark_processes()
         if other_benchmark_processes:
             pids = [p.pid for p in other_benchmark_processes]
 
-            msg = f"There are other Benchmark processes running on this machine (PIDs: {pids}) but only one Benchmark " \
+            msg = f"There are other OSB processes running on this machine (PIDs: {pids}) but only one OSB " \
                   f"benchmark is allowed to run at the same time.\n\nYou can use --kill-running-processes flag " \
-                  f"to kill running processes automatically and allow Benchmark to continue to run a new benchmark. " \
+                  f"to kill running processes automatically and allow OSB to continue to run a new benchmark. " \
                   f"Otherwise, you need to manually kill them."
             raise exceptions.BenchmarkError(msg)
 
@@ -797,7 +797,7 @@ def with_actor_system(runnable, cfg):
                 except KeyboardInterrupt:
                     times_interrupted += 1
                     logger.warning("User interrupted shutdown of internal actor system.")
-                    console.info("Please wait a moment for Benchmark's internal components to shutdown.")
+                    console.info("Please wait a moment for OSB's internal components to shutdown.")
             if not shutdown_complete and times_interrupted > 0:
                 logger.warning("Terminating after user has interrupted actor system shutdown explicitly for [%d] times.",
                                times_interrupted)
@@ -810,7 +810,7 @@ def with_actor_system(runnable, cfg):
                 console.println("")
             elif not shutdown_complete:
                 console.warn("Could not terminate all internal processes within timeout. Please check and force-terminate "
-                             "all Benchmark processes.")
+                             "all OSB processes.")
 
 
 
@@ -1090,7 +1090,7 @@ def main():
 
     logger.info("OS [%s]", str(platform.uname()))
     logger.info("Python [%s]", str(sys.implementation))
-    logger.info("Benchmark version [%s]", version.version())
+    logger.info("OSB version [%s]", version.version())
     logger.debug("Command line arguments: %s", args)
     # Configure networking
     net.init()

--- a/osbenchmark/benchmarkd.py
+++ b/osbenchmark/benchmarkd.py
@@ -81,8 +81,8 @@ def main():
     console.init(assume_tty=False)
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
-                                     description=BANNER + "\n\n Benchmark daemon to support remote benchmarks",
-                                     epilog="Find out more about Benchmark at {}".format(console.format.link(doc_link())),
+                                     description=BANNER + "\n\n OSB daemon to support remote benchmarks",
+                                     epilog="Find out more about OSB at {}".format(console.format.link(doc_link())),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 
@@ -92,8 +92,8 @@ def main():
         help="")
     subparsers.required = True
 
-    start_command = subparsers.add_parser("start", help="Starts the Benchmark daemon")
-    restart_command = subparsers.add_parser("restart", help="Restarts the Benchmark daemon")
+    start_command = subparsers.add_parser("start", help="Starts the OSB daemon")
+    restart_command = subparsers.add_parser("restart", help="Restarts the OSB daemon")
     for p in [start_command, restart_command]:
         p.add_argument(
             "--node-ip",
@@ -104,8 +104,8 @@ def main():
             required=True,
             help="The IP of the coordinator node."
         )
-    subparsers.add_parser("stop", help="Stops the Benchmark daemon")
-    subparsers.add_parser("status", help="Shows the current status of the local Benchmark daemon")
+    subparsers.add_parser("stop", help="Stops the OSB daemon")
+    subparsers.add_parser("status", help="Shows the current status of the local OSB daemon")
 
     args = parser.parse_args()
 

--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -288,7 +288,7 @@ def to_ip_port(hosts):
         host_or_ip = host.pop("host")
         port = host.pop("port", 9200)
         if host:
-            raise exceptions.SystemSetupError("When specifying nodes to be managed by Benchmark you can only supply "
+            raise exceptions.SystemSetupError("When specifying nodes to be managed by OSB you can only supply "
                                               "hostname:port pairs (e.g. 'localhost:9200'), any additional options cannot "
                                               "be supported.")
         ip = net.resolve(host_or_ip)
@@ -353,7 +353,7 @@ class BuilderActor(actor.BenchmarkActor):
         self.logger.info("BuilderActor#receiveMessage poison(msg = [%s] sender = [%s])", str(msg.poisonMessage), str(sender))
         # something went wrong with a child actor (or another actor with which we have communicated)
         if isinstance(msg.poisonMessage, StartEngine):
-            failmsg = "Could not start benchmark candidate. Are Benchmark daemons on all targeted machines running?"
+            failmsg = "Could not start benchmark candidate. Are OSB daemons on all targeted machines running?"
         else:
             failmsg = msg.details
         self.logger.error(failmsg)
@@ -375,14 +375,14 @@ class BuilderActor(actor.BenchmarkActor):
 
         self.externally_provisioned = msg.external
         if self.externally_provisioned:
-            self.logger.info("Cluster will not be provisioned by Benchmark.")
+            self.logger.info("Cluster will not be provisioned by OSB.")
             self.status = "nodes_started"
             self.received_responses = []
             self.on_all_nodes_started()
             self.status = "cluster_started"
         else:
             console.info("Preparing for test execution ...", flush=True)
-            self.logger.info("Cluster consisting of %s will be provisioned by Benchmark.", hosts)
+            self.logger.info("Cluster consisting of %s will be provisioned by OSB.", hosts)
             msg.hosts = hosts
             # Initialize the children array to have the right size to
             # ensure waiting for all responses
@@ -499,12 +499,12 @@ class Dispatcher(actor.BenchmarkActor):
 
     def receiveMsg_ActorSystemConventionUpdate(self, convmsg, sender):
         if not convmsg.remoteAdded:
-            self.logger.warning("Remote Benchmark node [%s] exited during NodeBuilderActor startup process.", convmsg.remoteAdminAddress)
+            self.logger.warning("Remote OSB node [%s] exited during NodeBuilderActor startup process.", convmsg.remoteAdminAddress)
             self.start_sender(actor.BenchmarkFailure(
-                "Remote Benchmark node [%s] has been shutdown prematurely." % convmsg.remoteAdminAddress))
+                "Remote OSB node [%s] has been shutdown prematurely." % convmsg.remoteAdminAddress))
         else:
             remote_ip = convmsg.remoteCapabilities.get('ip', None)
-            self.logger.info("Remote Benchmark node [%s] has started.", remote_ip)
+            self.logger.info("Remote OSB node [%s] has started.", remote_ip)
 
             for eachmsg in self.remotes[remote_ip]:
                 self.pending.append((self.createActor(NodeBuilderActor,
@@ -652,7 +652,7 @@ def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_i
                                   all_node_names, test_execution_root_path, node_name))
         l = launcher.ProcessLauncher(cfg)
     elif external:
-        raise exceptions.BenchmarkAssertionError("Externally provisioned clusters should not need to be managed by Benchmark's builder")
+        raise exceptions.BenchmarkAssertionError("Externally provisioned clusters should not need to be managed by OSB's builder")
     elif docker:
         if len(plugins) > 0:
             raise exceptions.SystemSetupError("You cannot specify any plugins for Docker clusters. Please remove "

--- a/osbenchmark/builder/downloaders/repositories/source_repository_provider.py
+++ b/osbenchmark/builder/downloaders/repositories/source_repository_provider.py
@@ -81,7 +81,7 @@ class SourceRepositoryProvider:
         self.logger.info("Skip fetching sources for %s.", self.repository_name)
 
     def _update_repository_to_timestamp(self, host, revision, target_dir):
-        # convert timestamp annotated for Benchmark to something git understands -> we strip leading and trailing " and the @.
+        # convert timestamp annotated for OSB to something git understands -> we strip leading and trailing " and the @.
         git_timestamp_revision = revision[1:]
         self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for "
                          "%s.", git_timestamp_revision, self.repository_name)

--- a/osbenchmark/builder/installers/preparers/opensearch_preparer.py
+++ b/osbenchmark/builder/installers/preparers/opensearch_preparer.py
@@ -79,9 +79,9 @@ class OpenSearchPreparer(Preparer):
             "data_paths": node.data_paths[0],
             "log_path": node.log_path,
             "heap_dump_path": node.heap_dump_path,
-            # this is the node's IP address as specified by the user when invoking Benchmark
+            # this is the node's IP address as specified by the user when invoking OSB
             "node_ip": host.address,
-            # this is the IP address that the node will be bound to. Benchmark will bind to the node's IP address (but not to 0.0.0.0). The
+            # this is the IP address that the node will be bound to. OSB will bind to the node's IP address (but not to 0.0.0.0). The
             "network_host": host.address,
             "http_port": str(node.port),
             "transport_port": str(node.port + 100),

--- a/osbenchmark/builder/launcher.py
+++ b/osbenchmark/builder/launcher.py
@@ -184,7 +184,7 @@ class ProcessLauncher:
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
             # This property is the higher priority starting in ES 7.12.0, and is the only supported java home in >=8.0
             env["OPENSEARCH_JAVA_HOME"] = java_home
-            # TODO remove this when ES <8.0 becomes unsupported by Benchmark
+            # TODO remove this when ES <8.0 becomes unsupported by OSB
             env["JAVA_HOME"] = java_home
             self.logger.info("JAVA HOME: %s", env["JAVA_HOME"])
         if not env.get("OPENSEARCH_JAVA_OPTS"):
@@ -223,7 +223,7 @@ class ProcessLauncher:
     @staticmethod
     def _start_process(binary_path, env):
         if os.name == "posix" and os.geteuid() == 0:
-            raise exceptions.LaunchError("Cannot launch OpenSearch as root. Please run Benchmark as a non-root user.")
+            raise exceptions.LaunchError("Cannot launch OpenSearch as root. Please run OSB as a non-root user.")
         os.chdir(binary_path)
         cmd = [io.escape_path(os.path.join(".", "bin", "opensearch"))]
         cmd.extend(["-d", "-p", "pid"])

--- a/osbenchmark/builder/launchers/local_process_launcher.py
+++ b/osbenchmark/builder/launchers/local_process_launcher.py
@@ -79,7 +79,7 @@ class LocalProcessLauncher(Launcher):
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
             # This property is the higher priority starting in ES 7.12.0, and is the only supported java home in >=8.0
             env["OPENSEARCH_JAVA_HOME"] = java_home
-            # TODO remove this when ES <8.0 becomes unsupported by Benchmark
+            # TODO remove this when ES <8.0 becomes unsupported by OSB
             env["JAVA_HOME"] = java_home
             self.logger.info("JAVA HOME: %s", env["JAVA_HOME"])
         if not env.get("OPENSEARCH_JAVA_OPTS"):
@@ -103,7 +103,7 @@ class LocalProcessLauncher(Launcher):
 
     def _start_process(self, host, binary_path, env):
         if os.name == "posix" and os.geteuid() == 0:
-            raise LaunchError("Cannot launch OpenSearch as root. Please run Benchmark as a non-root user.")
+            raise LaunchError("Cannot launch OpenSearch as root. Please run OSB as a non-root user.")
 
         cmd = [io.escape_path(os.path.join(binary_path, "bin", "opensearch"))]
         cmd.extend(["-d", "-p", "pid"])

--- a/osbenchmark/builder/provision_config.py
+++ b/osbenchmark/builder/provision_config.py
@@ -482,7 +482,7 @@ class BootstrapHookHandler:
         """
         self.component = component
         # Don't allow the loader to recurse. The subdirectories may contain OpenSearch specific files which we do not want to add to
-        # Benchmark's Python load path. We may need to define a more advanced strategy in the future.
+        # OSB's Python load path. We may need to define a more advanced strategy in the future.
         self.loader = loader_class(root_path=self.component.root_path, component_entry_point=self.component.entry_point, recurse=False)
         self.hooks = {}
         self.logger = logging.getLogger(__name__)
@@ -516,7 +516,7 @@ class BootstrapHookHandler:
             self.logger.info("Invoking phase [%s] for component [%s] in config [%s]", phase, self.component.name, self.component.config)
             for hook in self.hooks[phase]:
                 self.logger.info("Invoking bootstrap hook [%s].", hook.__name__)
-                # hooks should only take keyword arguments to be forwards compatible with Benchmark!
+                # hooks should only take keyword arguments to be forwards compatible with OSB!
                 hook(config_names=self.component.config, **kwargs)
         else:
             self.logger.debug("Component [%s] in config [%s] has no hook registered for phase [%s].",

--- a/osbenchmark/builder/provisioner.py
+++ b/osbenchmark/builder/provisioner.py
@@ -294,9 +294,9 @@ class OpenSearchInstaller:
             "data_paths": self.data_paths,
             "log_path": self.node_log_dir,
             "heap_dump_path": self.heap_dump_dir,
-            # this is the node's IP address as specified by the user when invoking Benchmark
+            # this is the node's IP address as specified by the user when invoking OSB
             "node_ip": self.node_ip,
-            # this is the IP address that the node will be bound to. Benchmark will bind to the node's IP address (but not to 0.0.0.0). The
+            # this is the IP address that the node will be bound to. OSB will bind to the node's IP address (but not to 0.0.0.0). The
             "network_host": network_host,
             "http_port": str(self.http_port),
             "transport_port": str(self.http_port + 100),

--- a/osbenchmark/builder/supplier.py
+++ b/osbenchmark/builder/supplier.py
@@ -182,7 +182,7 @@ def _supply_requirements(sources, distribution, plugins, revisions, distribution
             # allow catch-all only if we're generally building from sources. If it is mixed, the user should tell explicitly.
             if plugin.name in revisions or ("all" in revisions and sources):
                 # be a bit more lenient when checking for plugin revisions. This allows users to specify `--revision="current"` and
-                # rely on Benchmark to do the right thing.
+                # rely on OSB to do the right thing.
                 try:
                     plugin_revision = revisions[plugin.name]
                 except KeyError:
@@ -205,7 +205,7 @@ def _src_dir(cfg, mandatory=True):
         return cfg.opts("node", "src.root.dir", mandatory=mandatory)
     except exceptions.ConfigError:
         raise exceptions.SystemSetupError("You cannot benchmark OpenSearch from sources. Did you install Gradle? Please install"
-                                          " all prerequisites and reconfigure Benchmark with %s configure" % PROGRAM_NAME)
+                                          " all prerequisites and reconfigure OSB with %s configure" % PROGRAM_NAME)
 
 
 def _prune(root_path, max_age_days):
@@ -349,7 +349,7 @@ class CachedSourceSupplier:
     def fetch(self):
         # Can we already resolve the artifact without fetching the source tree at all? This is the case when a specific
         # revision (instead of a meta-revision like "current") is provided and the artifact is already cached. This is
-        # also needed if an external process pushes artifacts to Benchmark's cache which might have been built from a
+        # also needed if an external process pushes artifacts to OSB's cache which might have been built from a
         # fork. In that case the provided commit hash would not be present in any case in the main OS repo.
         maybe_an_artifact = os.path.join(self.distributions_root, self.file_name)
         if os.path.exists(maybe_an_artifact):
@@ -414,7 +414,7 @@ class OpenSearchSourceSupplier:
                                 self.template_renderer.render(self.provision_config_instance.mandatory_var("system.artifact_path_pattern")))
             return glob.glob(path)[0]
         except IndexError:
-            raise SystemSetupError("Couldn't find a tar.gz distribution. Please run Benchmark with the pipeline 'from-sources'.")
+            raise SystemSetupError("Couldn't find a tar.gz distribution. Please run OSB with the pipeline 'from-sources'.")
 
 
 class PluginFileNameResolver:
@@ -483,7 +483,7 @@ class ExternalPluginSourceSupplier:
             name = glob.glob("%s/%s/*.zip" % (self.plugin_src_dir, artifact_path))[0]
             return "file://%s" % name
         except IndexError:
-            raise SystemSetupError("Couldn't find a plugin zip file for [%s]. Please run Benchmark with the pipeline 'from-sources'." %
+            raise SystemSetupError("Couldn't find a plugin zip file for [%s]. Please run OSB with the pipeline 'from-sources'." %
                                    self.plugin.name)
 
 
@@ -514,7 +514,7 @@ class CorePluginSourceSupplier:
             name = glob.glob("%s/plugins/%s/build/distributions/*.zip" % (self.os_src_dir, self.plugin.name))[0]
             return "file://%s" % name
         except IndexError:
-            raise SystemSetupError("Couldn't find a plugin zip file for [%s]. Please run Benchmark with the pipeline 'from-sources'." %
+            raise SystemSetupError("Couldn't find a plugin zip file for [%s]. Please run OSB with the pipeline 'from-sources'." %
                                    self.plugin.name)
 
 
@@ -623,7 +623,7 @@ class SourceRepository:
         self.logger = logging.getLogger(__name__)
 
     def fetch(self, revision):
-        # if and only if we want to benchmark the current revision, Benchmark may skip repo initialization (if it is already present)
+        # if and only if we want to benchmark the current revision, OSB may skip repo initialization (if it is already present)
         self._try_init(may_skip_init=revision == "current")
         return self._update(revision)
 
@@ -647,7 +647,7 @@ class SourceRepository:
         elif revision == "current":
             self.logger.info("Skip fetching sources for %s.", self.name)
         elif self.has_remote() and revision.startswith("@"):
-            # convert timestamp annotated for Benchmark to something git understands -> we strip leading and trailing " and the @.
+            # convert timestamp annotated for OSB to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision)

--- a/osbenchmark/config.py
+++ b/osbenchmark/config.py
@@ -292,7 +292,7 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
         return
     if current_version < Config.EARLIEST_SUPPORTED_VERSION:
         raise exceptions.ConfigError(f"The config file in {config_file.location} is too old. Please delete it "
-                                     f"and reconfigure Benchmark from scratch with {PROGRAM_NAME} configure.")
+                                     f"and reconfigure OSB from scratch with {PROGRAM_NAME} configure.")
 
     logger.info("Upgrading configuration from version [%s] to [%s].", current_version, target_version)
     # Something is really fishy. We don't want to downgrade the configuration.

--- a/osbenchmark/exceptions.py
+++ b/osbenchmark/exceptions.py
@@ -25,7 +25,7 @@
 
 class BenchmarkError(Exception):
     """
-    Base class for all Benchmark exceptions
+    Base class for all OSB exceptions
     """
 
     def __init__(self, message, cause=None):

--- a/osbenchmark/log.py
+++ b/osbenchmark/log.py
@@ -45,7 +45,7 @@ def configure_utc_formatter(*args, **kwargs):
 
 def log_config_path():
     """
-    :return: The absolute path to Benchmark's log configuration file.
+    :return: The absolute path to OSB's log configuration file.
     """
     # print("PATH: ", os.path.join(paths.benchmark_confdir(), "logging.json"))
     return os.path.join(paths.benchmark_confdir(), "logging.json")

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -283,7 +283,7 @@ class OsClientFactory:
 
 class IndexTemplateProvider:
     """
-    Abstracts how the Benchmark index template is retrieved. Intended for testing.
+    Abstracts how the OSB index template is retrieved. Intended for testing.
     """
 
     def __init__(self, cfg):
@@ -542,7 +542,7 @@ class MetricsStore:
 
     def _clear_meta_info(self):
         """
-        Clears all internally stored meta-info. This is considered Benchmark internal API and not intended for normal client consumption.
+        Clears all internally stored meta-info. This is considered OSB internal API and not intended for normal client consumption.
         """
         self._meta_info = {
             MetaInfoScope.cluster: {},
@@ -2186,11 +2186,11 @@ class GlobalStats:
             )
 
     def tasks(self):
-        # ensure we can read test_execution.json files before Benchmark 0.8.0
+        # ensure we can read test_execution.json files before OSB 0.8.0
         return [v.get("task", v["operation"]) for v in self.op_metrics]
 
     def metrics(self, task):
-        # ensure we can read test_execution.json files before Benchmark 0.8.0
+        # ensure we can read test_execution.json files before OSB 0.8.0
         for r in self.op_metrics:
             if r.get("task", r["operation"]) == task:
                 return r

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -57,6 +57,6 @@ def install_root(cfg=None):
 # pylint: disable=invalid-docstring-quote
 def logs():
     """
-    :return: The absolute path to the directory that contains Benchmark's log file.
+    :return: The absolute path to the directory that contains OSB's log file.
     """
     return os.path.join(benchmark_confdir(), "logs")

--- a/osbenchmark/resources/provision_configs/1.0/plugins/v1/core-plugins.txt
+++ b/osbenchmark/resources/provision_configs/1.0/plugins/v1/core-plugins.txt
@@ -1,6 +1,6 @@
 ########################################################################
 #
-# This config file is used for Benchmark >= 0.7.3.
+# This config file is used for OSB >= 0.7.3.
 #
 # It contains the names of all plugins that are part of OpenSearch
 # core. Some of them require custom configuration and will not work

--- a/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_azure/README.md
+++ b/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_azure/README.md
@@ -2,7 +2,7 @@ This directory contains the (optional) keystore configuration for the `repositor
 
 ### Parameters
 
-This plugin allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-azure"`:
+This plugin allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-azure"`:
 
 * `azure_client_name`: A string specifying the clientname to associate the above credentials with (mandatory).
 * `azure_account`: A string specifying the Azure account name (mandatory).
@@ -24,4 +24,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-azure" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-azure" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_gcs/README.md
+++ b/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_gcs/README.md
@@ -2,7 +2,7 @@ This directory contains the (optional) keystore configuration for the `repositor
 
 ### Parameters
 
-This configuration allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-gcs"`:
+This configuration allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-gcs"`:
 
 * `gcs_credentials_file`: A string specifying the full path to the service account json file (mandatory).
 * `gcs_client_name`: A string specifying the clientname to associate the service account file under (mandatory).
@@ -24,4 +24,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-gcs" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-gcs" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_s3/README.md
+++ b/osbenchmark/resources/provision_configs/1.0/plugins/v1/repository_s3/README.md
@@ -2,7 +2,7 @@ This directory contains the (optional) keystore configuration for the `repositor
 
 ### Parameters
 
-This plugin allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-s3"`:
+This plugin allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-s3"`:
 
 * `s3_client_name`: A string specifying the clientname to associate the above credentials with (mandatory).
 * `s3_access_key`: A string specifying the AWS access key (mandatory).
@@ -26,4 +26,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-s3" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-s3" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/1.0/provision_config_instances/v1/vanilla/README.md
+++ b/osbenchmark/resources/provision_configs/1.0/provision_config_instances/v1/vanilla/README.md
@@ -2,7 +2,7 @@ This directory contains the OpenSearch base configuration.
 
 ### Parameters
 
-This configuration allows to set the following parameters with Benchmark 0.10.0 using `--provision-config-instance-params`:
+This configuration allows to set the following parameters with OSB 0.10.0 using `--provision-config-instance-params`:
 
 * `data_paths` (default: "data" (relative to the OpenSearch root directory)): A string specifying the OpenSearch data path.
 * `indexing_pressure_memory_limit` (default: not set): A percentage value defining the cluster setting `indexing_pressure.memory.limit`.
@@ -26,4 +26,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--provision-config-instance-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--provision-config-instance-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/main/plugins/v1/core-plugins.txt
+++ b/osbenchmark/resources/provision_configs/main/plugins/v1/core-plugins.txt
@@ -1,6 +1,6 @@
 ########################################################################
 #
-# This config file is used for Benchmark >= 0.7.3.
+# This config file is used for OSB >= 0.7.3.
 #
 # It contains the names of all plugins that are part of OpenSearch
 # core. Some of them require custom configuration and will not work

--- a/osbenchmark/resources/provision_configs/main/plugins/v1/repository_azure/README.md
+++ b/osbenchmark/resources/provision_configs/main/plugins/v1/repository_azure/README.md
@@ -2,7 +2,7 @@ This directory contains the (optional) keystore configuration for the `repositor
 
 ### Parameters
 
-This plugin allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-azure"`:
+This plugin allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-azure"`:
 
 * `azure_client_name`: A string specifying the clientname to associate the above credentials with (mandatory).
 * `azure_account`: A string specifying the Azure account name (mandatory).
@@ -24,4 +24,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-azure" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-azure" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/main/plugins/v1/repository_gcs/README.md
+++ b/osbenchmark/resources/provision_configs/main/plugins/v1/repository_gcs/README.md
@@ -2,7 +2,7 @@ This directory contains the (optional) keystore configuration for the `repositor
 
 ### Parameters
 
-This configuration allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-gcs"`:
+This configuration allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-gcs"`:
 
 * `gcs_credentials_file`: A string specifying the full path to the service account json file (mandatory).
 * `gcs_client_name`: A string specifying the clientname to associate the service account file under (mandatory).
@@ -24,4 +24,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-gcs" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-gcs" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/main/plugins/v1/repository_s3/README.md
+++ b/osbenchmark/resources/provision_configs/main/plugins/v1/repository_s3/README.md
@@ -3,7 +3,7 @@ For more details on secure settings for the repository-s3 plugin please refer to
 
 ### Parameters
 
-This plugin allows to set the following parameters with Benchmark using `--plugin-params` in combination with `--opensearch-plugins="repository-s3"`:
+This plugin allows to set the following parameters with OSB using `--plugin-params` in combination with `--opensearch-plugins="repository-s3"`:
 
 * `s3_client_name`: A string specifying the clientname to associate the above credentials with (mandatory).
 * `s3_access_key`: A string specifying the AWS access key (mandatory).
@@ -27,4 +27,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins="repository-s3" --plugin-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--opensearch-plugins="repository-s3" --plugin-params="/path/to/params.json"`.

--- a/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md
+++ b/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md
@@ -26,4 +26,4 @@ Example:
 }
 ```
 
-Save it as `params.json` and provide it to Benchmark with `--provision-config-instance-params="/path/to/params.json"`.
+Save it as `params.json` and provide it to OSB with `--provision-config-instance-params="/path/to/params.json"`.

--- a/osbenchmark/resources/workload-schema.json
+++ b/osbenchmark/resources/workload-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "workload",
-  "description": "Specification of workloads for Benchmark",
+  "description": "Specification of workloads for OSB",
   "type": "object",
   "definitions": {
     "schedule": {
@@ -87,7 +87,7 @@
                     },
                     "schedule": {
                       "type": "string",
-                      "description": "Defines the scheduling strategy that is used for throughput throttled operations. Out of the box, Benchmark supports 'deterministic' (default) and 'poisson' but you can implement your own schedules."
+                      "description": "Defines the scheduling strategy that is used for throughput throttled operations. Out of the box, OSB supports 'deterministic' (default) and 'poisson' but you can implement your own schedules."
                     },
                     "target-throughput": {
                       "anyOf": [
@@ -99,7 +99,7 @@
                           "type": "string"
                         }
                       ],
-                      "description": "Defines the number of operations per second that Benchmark should attempt to run."
+                      "description": "Defines the number of operations per second that OSB should attempt to run."
                     },
                     "target-interval": {
                       "type": "number",
@@ -166,7 +166,7 @@
                 "type": "string"
               }
             ],
-            "description": "Defines the number of operations per second that Benchmark should attempt to run."
+            "description": "Defines the number of operations per second that OSB should attempt to run."
           },
           "target-interval": {
             "type": "number",
@@ -187,7 +187,7 @@
         },
         "default": {
           "type": "boolean",
-          "description": "If true, Benchmark should select this test_procedure as the default test_procedure if the user does not specify one on the command line."
+          "description": "If true, OSB should select this test_procedure as the default test_procedure if the user does not specify one on the command line."
         },
         "meta": {
           "type": "object",
@@ -368,11 +368,11 @@
           "base-url": {
             "type": "string",
             "format": "uri",
-            "description": "The default base URL for this document corpus. Has to be a publicly accessible http or https URL. If not specified, Benchmark will not attempt to download data and assume that it will be available locally."
+            "description": "The default base URL for this document corpus. Has to be a publicly accessible http or https URL. If not specified, OSB will not attempt to download data and assume that it will be available locally."
           },
           "source-format": {
             "type": "string",
-            "description": "Defines in which format Benchmark should interpret the data file specified by 'source-file'. Currently, only 'bulk' is supported."
+            "description": "Defines in which format OSB should interpret the data file specified by 'source-file'. Currently, only 'bulk' is supported."
           },
           "includes-action-and-meta-data": {
             "type": "boolean",
@@ -436,7 +436,7 @@
                 },
                 "source-format": {
                   "type": "string",
-                  "description": "Defines in which format Benchmark should interpret the data file specified by 'source-file'. Currently, only 'bulk' is supported."
+                  "description": "Defines in which format OSB should interpret the data file specified by 'source-file'. Currently, only 'bulk' is supported."
                 },
                 "document-count": {
                   "type": "integer",
@@ -450,7 +450,7 @@
                 "compressed-bytes": {
                   "type": "integer",
                   "minimum": 1,
-                  "description": "The size in bytes of the compressed document file. This number is used to show users how much data will be downloaded by Benchmark and also to check whether the download is complete."
+                  "description": "The size in bytes of the compressed document file. This number is used to show users how much data will be downloaded by OSB and also to check whether the download is complete."
                 },
                 "uncompressed-bytes": {
                   "type": "integer",
@@ -545,15 +545,15 @@
           },
           "cache": {
             "type": "boolean",
-            "description": "[Only for type 'search']: Whether to use the query request cache. By default, Benchmark will define no value thus the default depends on the benchmark candidate settings and OpenSearch version."
+            "description": "[Only for type 'search']: Whether to use the query request cache. By default, OSB will define no value thus the default depends on the benchmark candidate settings and OpenSearch version."
           },
           "index": {
             "type": "string",
-            "description": "[Only for type 'search']: The index or index pattern against which the query should be executed. This property is only necessary if there is more than one index or the index contains more than one type. Otherwise, Benchmark will derive the index and type by itself."
+            "description": "[Only for type 'search']: The index or index pattern against which the query should be executed. This property is only necessary if there is more than one index or the index contains more than one type. Otherwise, OSB will derive the index and type by itself."
           },
           "type": {
             "type": "string",
-            "description": "[Only for type 'search']: The type against which the query should be executed. This property is only necessary if there is more than one index or the index contains more than one type. Otherwise, Benchmark will derive the index and type by itself."
+            "description": "[Only for type 'search']: The type against which the query should be executed. This property is only necessary if there is more than one index or the index contains more than one type. Otherwise, OSB will derive the index and type by itself."
           },
           "pages": {
             "type": "integer",

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -187,7 +187,7 @@ class FlightRecorder(TelemetryDevice):
             console.println("You are using Java flight recorder which requires that you comply with\nthe licensing terms stated in:\n")
             console.println(console.format.link("http://www.oracle.com/technetwork/java/javase/terms/license/index.html"))
             console.println("\nBy using this feature you confirm that you comply with these license terms.\n")
-            console.println("Otherwise, please abort and rerun Benchmark without the \"jfr\" telemetry device.")
+            console.println("Otherwise, please abort and rerun OSB without the \"jfr\" telemetry device.")
             console.println("\n***************************************************************************\n")
 
             time.sleep(3)
@@ -1208,7 +1208,7 @@ class DiskIo(InternalTelemetryDevice):
                 else:
                     disk_end = sysstats.disk_io_counters()
                     if self.node_count_on_host > 1:
-                        self.logger.info("There are [%d] nodes on this host and Benchmark fell back to disk I/O counters. "
+                        self.logger.info("There are [%d] nodes on this host and OSB fell back to disk I/O counters. "
                                          "Attributing [1/%d] of total I/O to [%s].",
                                          self.node_count_on_host, self.node_count_on_host, node.node_name)
 
@@ -1305,7 +1305,7 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         for node in nodes_info:
             node_name = node["name"]
             # while we could determine this for bare-metal nodes that are
-            # provisioned by Benchmark, there are other cases (Docker, externally
+            # provisioned by OSB, there are other cases (Docker, externally
             # provisioned clusters) where it's not that easy.
             self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_vendor", extract_value(node, ["jvm", "vm_vendor"]))
             self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_version", extract_value(node, ["jvm", "version"]))

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -241,7 +241,7 @@ class BenchmarkCoordinator:
         self.metrics_store.bulk_add(new_metrics)
 
     def on_benchmark_complete(self, new_metrics):
-        self.logger.info("Benchmark is complete.")
+        self.logger.info("OSB is complete.")
         self.logger.info("Bulk adding request metrics to metrics store.")
         self.metrics_store.bulk_add(new_metrics)
         self.metrics_store.flush()
@@ -264,7 +264,7 @@ def execute_test(cfg, sources=False, distribution=False, external=False, docker=
     try:
         result = actor_system.ask(benchmark_actor, Setup(cfg, sources, distribution, external, docker))
         if isinstance(result, Success):
-            logger.info("Benchmark has finished successfully.")
+            logger.info("OSB has finished successfully.")
         # may happen if one of the load generators has detected that the user has cancelled the benchmark.
         elif isinstance(result, actor.BenchmarkCancelled):
             logger.info("User has cancelled the benchmark (detected by actor).")
@@ -364,8 +364,8 @@ def run(cfg):
         # in this case only benchmarking remote OpenSearch clusters makes sense
         if name != "benchmark-only":
             raise exceptions.SystemSetupError(
-                "Only the [benchmark-only] pipeline is supported by the Benchmark Docker image.\n"
-                "Add --pipeline=benchmark-only in your Benchmark arguments and try again.\n"
+                "Only the [benchmark-only] pipeline is supported by the OSB Docker image.\n"
+                "Add --pipeline=benchmark-only in your OSB arguments and try again.\n"
                 "For more details read the docs for the benchmark-only pipeline in {}\n".format(
                     doc_link("")))
 

--- a/osbenchmark/utils/console.py
+++ b/osbenchmark/utils/console.py
@@ -99,7 +99,7 @@ def init(quiet=False, assume_tty=True):
     """
     Initialize console out.
 
-    :param quiet: Flag indicating whether Benchmark should not print anything except when forced explicitly. Default: False.
+    :param quiet: Flag indicating whether OSB should not print anything except when forced explicitly. Default: False.
     :param assume_tty: Flag indicating whether to assume a tty is attached without checking. Default: True.
     """
     global QUIET, ASSUME_TTY, BENCHMARK_RUNNING_IN_DOCKER, PLAIN, format
@@ -129,8 +129,8 @@ def init(quiet=False, assume_tty=True):
 
 def set_assume_tty(assume_tty):
     """
-    Change whether Benchmark should assume a tty. If ``True`` is provided, output will be printed. If ``False`` is provided,
-    Benchmark will explicitly check whether it is attached to a tty before attempting to print anything.
+    Change whether OSB should assume a tty. If ``True`` is provided, output will be printed. If ``False`` is provided,
+    OSB will explicitly check whether it is attached to a tty before attempting to print anything.
 
     :param assume_tty: Flag indicating whether to assume a tty is attached without checking.
     """

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -248,7 +248,7 @@ def _zipdir(source_directory, archive):
 def is_archive(name):
     """
     :param name: File name to check. Can be either just the file name or optionally also an absolute path.
-    :return: True iff the given file name is an archive that is also recognized for decompression by Benchmark.
+    :return: True iff the given file name is an archive that is also recognized for decompression by OSB.
     """
     _, ext = splitext(name)
     return ext in [".zip", ".bz2", ".gz", ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".zst"]

--- a/osbenchmark/utils/modules.py
+++ b/osbenchmark/utils/modules.py
@@ -34,7 +34,7 @@ from osbenchmark.utils import io
 class ComponentLoader:
     """
     Loads a dynamically defined component. A component in this terminology
-    is any piece of code that is not part of the Benchmark core code base
+    is any piece of code that is not part of the OSB core code base
     but extends it. Examples include custom runners or parameter sources for workloads or install hooks for OpenSearch plugins.
 
     A component has always a well-defined entry point. This is the

--- a/osbenchmark/utils/repo.py
+++ b/osbenchmark/utils/repo.py
@@ -32,7 +32,7 @@ from osbenchmark.utils import io, git, console, versions
 
 class BenchmarkRepository:
     """
-    Manages Benchmark resources (e.g. provision_configs or workloads).
+    Manages OSB resources (e.g. provision_configs or workloads).
     """
 
     default = "default-provision-config"

--- a/osbenchmark/version.py
+++ b/osbenchmark/version.py
@@ -37,7 +37,7 @@ __BENCHMARK_VERSION_PATTERN = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:.(.+
 
 def revision():
     """
-    :return: The current git revision if Benchmark is installed in development mode or ``None``.
+    :return: The current git revision if OSB is installed in development mode or ``None``.
     """
     # noinspection PyBroadException
     try:
@@ -51,14 +51,14 @@ def revision():
 
 def version():
     """
-    :return: The release version string and an optional suffix for the current git revision if Benchmark is installed in development mode.
+    :return: The release version string and an optional suffix for the current git revision if OSB is installed in development mode.
     """
     release = __version__
     benchmark_revision = revision()
     if benchmark_revision:
         return "%s (git revision: %s)" % (release, benchmark_revision.strip())
     else:
-        # cannot determine head revision so user has probably installed Benchmark via pip instead of git clone
+        # cannot determine head revision so user has probably installed OSB via pip instead of git clone
         return release
 
 
@@ -76,6 +76,6 @@ def release_version():
 
 def minimum_os_version():
     """
-    :return: A string identifying the minimum version of OpenSearch that is supported by Benchmark.
+    :return: A string identifying the minimum version of OpenSearch that is supported by OSB.
     """
     return resources.read_text("osbenchmark", "min-os-version.txt").strip()

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -195,7 +195,7 @@ class Runner:
         return False
 
     def _default_kw_params(self, params):
-        # map of API kwargs to Benchmark config parameters
+        # map of API kwargs to OSB config parameters
         kw_dict = {
             "body": "body",
             "headers": "headers",
@@ -1048,7 +1048,7 @@ class Query(Runner):
     The following meta data are always returned:
 
     * ``weight``: operation-agnostic representation of the "weight" of an
-                  operation (used internally by Benchmark for throughput calculation).
+                  operation (used internally by OSB for throughput calculation).
                   Always 1 for normal queries and the number of retrieved pages for scroll queries.
     * ``unit``: The unit in which to interpret ``weight``. Always "ops".
     * ``hits``: Total number of hits for this operation.
@@ -2500,7 +2500,7 @@ class CompositeContext:
 
 class Composite(Runner):
     """
-    Executes a complex request structure which is measured by Benchmark as one composite operation.
+    Executes a complex request structure which is measured by OSB as one composite operation.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/osbenchmark/worker_coordinator/scheduler.py
+++ b/osbenchmark/worker_coordinator/scheduler.py
@@ -35,7 +35,7 @@ from osbenchmark import exceptions
 __SCHEDULERS = {}
 
 """
-The scheduler module defines an API to determine *when* Benchmark should issue a request. There are two types of schedulers:
+The scheduler module defines an API to determine *when* OSB should issue a request. There are two types of schedulers:
 
 # Simple Schedulers
 
@@ -51,7 +51,7 @@ A simple scheduler has the following signature::
 In ``__init__`` the current task and the precalculated target throughput denoted in requests per second is provided.
 
 The implementation of ``next`` gets passed the previous point in time in seconds, starting from zero and needs to
-return the next point in time when Benchmark should issue a request.
+return the next point in time when OSB should issue a request.
 
 # Regular Schedulers
 
@@ -72,16 +72,16 @@ class MyScheduler:
 
 * In ``__init__`` the current task is provided. Implementations need to calculate the target throughput themselves based
   on the task's properties.
-* ``before_request`` is invoked by Benchmark before a request is executed. ``now`` provides the current timestamp in seconds.
-* Similarly, ``after_request`` is invoked by Benchmark after a response has been received. ``now`` is the current timestamp,
-  ``weight``, ``unit`` and ``request_meta_data`` are passed from the respective runner. For a bulk request, Benchmark
+* ``before_request`` is invoked by OSB before a request is executed. ``now`` provides the current timestamp in seconds.
+* Similarly, ``after_request`` is invoked by OSB after a response has been received. ``now`` is the current timestamp,
+  ``weight``, ``unit`` and ``request_meta_data`` are passed from the respective runner. For a bulk request, OSB
   passes e.g. ``weight=5000, unit="docs"`` or for a search request ``weight=1, unit="ops"``. Note that when a request
   has finished with an error, the ``weight`` might be zero (depending on the type of error).
 * ``next`` needs to behave identical to simple schedulers.
 
 ``before_request`` and ``after_request`` can be used to adjust the target throughput based on feedback from the runner.
 
-If the scheduler also needs access to the parameter source, provide a ``parameter_source`` property. Benchmark injects the
+If the scheduler also needs access to the parameter source, provide a ``parameter_source`` property. OSB injects the
 task's parameter source into this property.
 """
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -58,7 +58,7 @@ class PrepareBenchmark:
 
     def __init__(self, config, workload):
         """
-        :param config: Benchmark internal configuration object.
+        :param config: OSB internal configuration object.
         :param workload: The workload to use.
         """
         self.config = config
@@ -76,7 +76,7 @@ class PrepareWorkload:
     """
     def __init__(self, cfg, workload):
         """
-        :param cfg: Benchmark internal configuration object.
+        :param cfg: OSB internal configuration object.
         :param workload: The workload to use.
         """
         self.config = cfg
@@ -131,7 +131,7 @@ class StartWorker:
     def __init__(self, worker_id, config, workload, client_allocations):
         """
         :param worker_id: Unique (numeric) id of the worker.
-        :param config: Benchmark internal configuration object.
+        :param config: OSB internal configuration object.
         :param workload: The workload to use.
         :param client_allocations: A structure describing which clients need to run which tasks.
         """
@@ -651,7 +651,7 @@ class WorkerCoordinator:
         self.target.prepare_workload([h["host"] for h in self.load_worker_coordinator_hosts], self.config, self.workload)
 
     def start_benchmark(self):
-        self.logger.info("Benchmark is about to start.")
+        self.logger.info("OSB is about to start.")
         # ensure relative time starts when the benchmark starts.
         self.reset_relative_time()
         self.logger.info("Attaching cluster-level telemetry devices.")
@@ -663,7 +663,7 @@ class WorkerCoordinator:
         self.number_of_steps = len(allocator.join_points) - 1
         self.tasks_per_join_point = allocator.tasks_per_joinpoint
 
-        self.logger.info("Benchmark consists of [%d] steps executed by [%d] clients.",
+        self.logger.info("OSB consists of [%d] steps executed by [%d] clients.",
                          self.number_of_steps, len(self.allocations))
         # avoid flooding the log if there are too many clients
         if allocator.clients < 128:
@@ -1645,7 +1645,7 @@ class AsyncExecutor:
                 processing_time = processing_end - processing_start
                 time_period = request_end - total_start
                 self.schedule_handle.after_request(processing_end, total_ops, total_ops_unit, request_meta_data)
-                # Allow runners to override the throughput calculation in very specific circumstances. Usually, Benchmark
+                # Allow runners to override the throughput calculation in very specific circumstances. Usually, OSB
                 # assumes that throughput is the "amount of work" (determined by the "weight") per unit of time
                 # (determined by the elapsed time period). However, in certain cases (e.g. shard recovery or other
                 # long running operations where there is a dedicated stats API to determine progress), it is

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -52,7 +52,7 @@ class WorkloadSyntaxError(exceptions.InvalidSyntax):
 class WorkloadProcessor:
     def on_after_load_workload(self, input_workload, **kwargs):
         """
-        This method is called by Benchmark after a workload has been loaded. Implementations are expected to modify the
+        This method is called by OSB after a workload has been loaded. Implementations are expected to modify the
         provided workload object in place.
 
         :param workload: The current workload.
@@ -60,7 +60,7 @@ class WorkloadProcessor:
 
     def on_prepare_workload(self, workload, data_root_dir):
         """
-        This method is called by Benchmark after the "after_load_workload" phase. Here, any data that is necessary for
+        This method is called by OSB after the "after_load_workload" phase. Here, any data that is necessary for
         benchmark execution should be prepared, e.g. by downloading data or generating it. Implementations should
         be aware that this method might be called on a different machine than "on_after_load_workload" and they cannot
         share any state in between phases.
@@ -1193,7 +1193,7 @@ class WorkloadFileReader:
 
         self.logger.info("Reading workload specification file [%s].", workload_spec_file)
         # render the workload to a temporary file instead of dumping it into the logs. It is easier to check for error messages
-        # involving lines numbers and it also does not bloat Benchmark's log file so much.
+        # involving lines numbers and it also does not bloat OSB's log file so much.
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
         try:
             rendered = render_template_from_file(
@@ -1260,11 +1260,11 @@ class WorkloadFileReader:
                 workload_name, str(raw_version)))
         if WorkloadFileReader.MINIMUM_SUPPORTED_TRACK_VERSION > workload_version:
             raise exceptions.BenchmarkError("Workload {} is on version {} but needs to be updated at least to version {} to work with the "
-                                        "current version of Benchmark.".format(workload_name, workload_version,
+                                        "current version of OSB.".format(workload_name, workload_version,
                                                                            WorkloadFileReader.MINIMUM_SUPPORTED_TRACK_VERSION))
         if WorkloadFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION < workload_version:
-            raise exceptions.BenchmarkError("Workload {} requires a newer version of Benchmark. "
-                        "Please upgrade Benchmark (supported workload version: {}, "
+            raise exceptions.BenchmarkError("Workload {} requires a newer version of OSB. "
+                        "Please upgrade OSB (supported workload version: {}, "
                                         "required workload version: {}).".format(
                                             workload_name,
                                             WorkloadFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION,
@@ -1800,7 +1800,7 @@ class WorkloadSpecificationReader:
             params = {}
         else:
             meta_data = self._r(op_spec, "meta", error_ctx=error_ctx, mandatory=False)
-            # Benchmark's core operations will still use enums then but we'll allow users to define arbitrary operations
+            # OSB's core operations will still use enums then but we'll allow users to define arbitrary operations
             op_type_name = self._r(op_spec, "operation-type", error_ctx=error_ctx)
             # fallback to use the operation type as the operation name
             op_name = self._r(op_spec, "name", error_ctx=error_ctx, mandatory=False, default_value=op_type_name)

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -51,7 +51,7 @@ __STANDARD_VALUES = {}
 
 def param_source_for_operation(op_type, workload, params, task_name):
     try:
-        # we know that this can only be a Benchmark core parameter source
+        # we know that this can only be a OSB core parameter source
         return __PARAM_SOURCES_BY_OP[op_type](workload, params, operation_name=task_name)
     except KeyError:
         return ParamSource(workload, params, operation_name=task_name)
@@ -135,9 +135,9 @@ def _clear_standard_values():
 class ParamSource:
     """
     A `ParamSource` captures the parameters for a given operation.
-     Benchmark will create one global ParamSource for each operation and will then
+     OSB will create one global ParamSource for each operation and will then
      invoke `#partition()` to get a `ParamSource` instance for each client. During the benchmark, `#params()` will be called repeatedly
-     before Benchmark invokes the corresponding runner (that will actually execute the operation against OpenSearch).
+     before OSB invokes the corresponding runner (that will actually execute the operation against OpenSearch).
     """
 
     def __init__(self, workload, params, **kwargs):
@@ -153,7 +153,7 @@ class ParamSource:
 
     def partition(self, partition_index, total_partitions):
         """
-        This method will be invoked by Benchmark at the beginning of the lifecycle. It splits a parameter source per client. If the
+        This method will be invoked by OSB at the beginning of the lifecycle. It splits a parameter source per client. If the
         corresponding operation is idempotent, return `self` (e.g. for queries). If the corresponding operation has side-effects and it
         matters which client executes which part (e.g. an index operation from a source file), return the relevant part.
 
@@ -175,12 +175,12 @@ class ParamSource:
     # Deprecated
     def size(self):
         """
-        Benchmark has two modes in which it can run:
+        OSB has two modes in which it can run:
 
         * It will either run an operation for a pre-determined number of times or
         * It can run until the parameter source is exhausted.
 
-        In the former case, you should determine the number of times that `#params()` will be invoked. With that number, Benchmark can show
+        In the former case, you should determine the number of times that `#params()` will be invoked. With that number, OSB can show
         the progress made so far to the user. In the latter case, return ``None``.
 
         :return:  The "size" of this parameter source or ``None`` if should run eternally.
@@ -198,7 +198,7 @@ class ParamSource:
         """
         For use when a ParamSource does not propagate self._params but does use opensearch client under the hood
 
-        :return: all applicable parameters that are global to Benchmark and apply to the opensearch-py client
+        :return: all applicable parameters that are global to OSB and apply to the opensearch-py client
         """
         return {
             "request-timeout": self._params.get("request-timeout"),

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@
 
 ##########################################################################################
 #
-# Internal helper script to actually run either Benchmark or Benchmark daemon.
+# Internal helper script to actually run either OSB or OSB daemon.
 #
 # Do not invoke directly but rather use the `benchmark` and `benchmarkd` scripts.
 #
@@ -29,7 +29,7 @@ readonly BINARY_NAME="${__BENCHMARK_INTERNAL_BINARY_NAME}"
 readonly HUMAN_NAME="${__BENCHMARK_INTERNAL_HUMAN_NAME}"
 
 install_osbenchmark_with_setuptools () {
-    # Check if optional parameter with Benchmark binary path, points to an existing executable file.
+    # Check if optional parameter with OSB binary path, points to an existing executable file.
     if [[ $# -ge 1 && -n $1 ]]; then
         if [[ -f $1 && -x $1 ]]; then return; fi
     fi
@@ -43,7 +43,7 @@ install_osbenchmark_with_setuptools () {
     fi
 }
 
-# Attempt to update Benchmark itself by default but allow user to skip it.
+# Attempt to update OSB itself by default but allow user to skip it.
 SELF_UPDATE=YES
 # Assume that the "main remote" is called "origin"
 REMOTE="origin"
@@ -72,14 +72,14 @@ case ${i} in
     SELF_UPDATE=NO
     shift # past argument with no value
     ;;
-    # inspect Benchmark's command line options and skip update also if the user has specified --offline.
+    # inspect OSB's command line options and skip update also if the user has specified --offline.
     #
-    # Note that we do NOT consume this option as it needs to be passed to Benchmark.
+    # Note that we do NOT consume this option as it needs to be passed to OSB.
     --offline)
     SELF_UPDATE=NO
     # DO NOT CONSUME!!
     ;;
-    # Do not consume unknown parameters; they should still be passed to the actual Benchmark script
+    # Do not consume unknown parameters; they should still be passed to the actual OSB script
     #*)
 esac
 done
@@ -89,7 +89,7 @@ then
     # see http://unix.stackexchange.com/a/155077
     if output=$(git status --porcelain) && [ -z "$output" ] && on_master=$(git rev-parse --abbrev-ref HEAD) && [ "$on_master" == "master" ]
     then
-      # Working directory clean -> we assume this is a user that is not actively developing Benchmark and just upgrade it every time it is invoked
+      # Working directory clean -> we assume this is a user that is not actively developing OSB and just upgrade it every time it is invoked
       set +e
       # this will fail if the user is offline
       git fetch ${REMOTE} --quiet >/dev/null 2>&1
@@ -97,7 +97,7 @@ then
       set -e
       if [[ $exit_code == 0 ]]
       then
-        echo "Auto-updating Benchmark from ${REMOTE}"
+        echo "Auto-updating OSB from ${REMOTE}"
         git rebase ${REMOTE}/master --quiet
         install_osbenchmark_with_setuptools
       #else

--- a/samples/ccr/docker-compose-metricstore.yml
+++ b/samples/ccr/docker-compose-metricstore.yml
@@ -1,4 +1,4 @@
-# Creates an Opensearch cluster to publish the Opensearch Benchmark metrics.
+# Creates an Opensearch cluster to publish the OpenSearch Benchmark metrics.
 version: '3'
 services:
   metricstore-node:

--- a/samples/ccr/start.sh
+++ b/samples/ccr/start.sh
@@ -8,7 +8,7 @@
 # 1. Sets up 2 single node (leader and follower) clusters.
 # 2. Starts a single node cluster for metrics store. We can use Kibana attached to the metric store cluster to see the metrics..
 # 3. Configures the seed nodes on the follower cluster and starts replication using autofollow pattern.
-# 4. Runs the eventdata benchmark on the replication setup. Benchmark metrics can be seen on the Kiabana.
+# 4. Runs the eventdata benchmark on the replication setup. OSB metrics can be seen on the Kiabana.
 # 5. To tear down everything, execute ./stop.sh.
 set -e
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -26,8 +26,8 @@
 # test_execution.json files (it's a summary of the results of
 # a single test_execution which is
 # stored in ~/.benchmark/benchmarks/test_executions/TEST_EXECUTION_TS/).
-# There is no specific integration into Benchmark and it is also not
-# installed with Benchmark.
+# There is no specific integration into OSB and it is also not
+# installed with OSB.
 #
 # It requires matplotlib (install with pip3 install matplotlib).
 #

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ tests_require = [
     "pytest-asyncio==0.14.0"
 ]
 
-# These packages are only required when developing Benchmark
+# These packages are only required when developing OSB
 develop_require = [
     "tox==3.14.0",
     "coverage==5.5",
@@ -155,7 +155,7 @@ setup(name="opensearch-benchmark",
           exclude=("tests*", "benchmarks*", "it*")
       ),
       include_package_data=True,
-      # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Benchmark on an unsupported
+      # supported Python versions. This will prohibit pip (> 9.0.0) from even installing OSB on an unsupported
       # Python version.
       # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
       #
@@ -184,7 +184,7 @@ setup(name="opensearch-benchmark",
       },
       scripts=['scripts/expand-data-corpus.py', 'scripts/pbzip2' ],
       classifiers=[
-          "Topic :: System :: Benchmark",
+          "Topic :: System :: OSB",
           "Development Status :: 5 - Production/Stable",
           "License :: OSI Approved :: Apache Software License",
           "Intended Audience :: Developers",

--- a/tests/builder/data/provision_config_instances/v1/hook2/config.py
+++ b/tests/builder/data/provision_config_instances/v1/hook2/config.py
@@ -22,4 +22,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Empty placeholder. We just need this file to verify that Benchmark will recognize it as an install hook entry point.
+# Empty placeholder. We just need this file to verify that OSB will recognize it as an install hook entry point.

--- a/tests/builder/data/provision_config_instances/v1/with_hook/config.py
+++ b/tests/builder/data/provision_config_instances/v1/with_hook/config.py
@@ -22,4 +22,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Empty placeholder. We just need this file to verify that Benchmark will recognize it as an install hook entry point.
+# Empty placeholder. We just need this file to verify that OSB will recognize it as an install hook entry point.

--- a/tests/builder/mechanic_test.py
+++ b/tests/builder/mechanic_test.py
@@ -60,7 +60,7 @@ class HostHandlingTests(TestCase):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             builder.to_ip_port(hosts)
         self.assertEqual("When specifying nodes to be managed by "
-        "Benchmark you can only supply hostname:port pairs (e.g. 'localhost:9200'), "
+        "OSB you can only supply hostname:port pairs (e.g. 'localhost:9200'), "
                          "any additional options cannot be supported.", ctx.exception.args[0])
 
     def test_groups_nodes_by_host(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -296,7 +296,7 @@ class ConfigMigrationTests(TestCase):
 
         config_file.store(sample_config)
         with self.assertRaisesRegex(exceptions.ConfigError,
-                                    "The config file.*is too old. Please delete it and reconfigure Benchmark from scratch"):
+                                    "The config file.*is too old. Please delete it and reconfigure OSB from scratch"):
             config.migrate(config_file, config.Config.EARLIEST_SUPPORTED_VERSION - 1, config.Config.CURRENT_CONFIG_VERSION, out=null_output)
 
     # catch all test, migrations are checked in more detail in the other tests

--- a/tests/test_execution_orchestrator_test.py
+++ b/tests/test_execution_orchestrator_test.py
@@ -97,8 +97,8 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
     with pytest.raises(
             exceptions.SystemSetupError,
             match=re.escape(
-                "Only the [benchmark-only] pipeline is supported by the Benchmark Docker image.\n"
-                "Add --pipeline=benchmark-only in your Benchmark arguments and try again.\n"
+                "Only the [benchmark-only] pipeline is supported by the OSB Docker image.\n"
+                "Add --pipeline=benchmark-only in your OSB arguments and try again.\n"
                 "For more details read the docs for the benchmark-only pipeline in "
                 "https://opensearch.org/docs\n"
             )):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -33,7 +33,7 @@ from osbenchmark.utils import git
 class GitTests(TestCase):
     def test_is_git_working_copy(self):
         test_dir = os.path.dirname(os.path.dirname(__file__))
-        # this test is assuming that nobody stripped the git repo info in their Benchmark working copy
+        # this test is assuming that nobody stripped the git repo info in their OSB working copy
         self.assertFalse(git.is_working_copy(test_dir))
         self.assertTrue(git.is_working_copy(os.path.dirname(test_dir)))
 

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -61,7 +61,7 @@ class IoTests(TestCase):
     def test_archive(self):
         self.assertTrue(io.is_archive("/tmp/some-archive.tar.gz"))
         self.assertTrue(io.is_archive("/tmp/some-archive.tgz"))
-        # Benchmark does not recognize .7z
+        # OSB does not recognize .7z
         self.assertFalse(io.is_archive("/tmp/some-archive.7z"))
         self.assertFalse(io.is_archive("/tmp/some.log"))
         self.assertFalse(io.is_archive("some.log"))

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -825,7 +825,7 @@ class SchedulerTests(TestCase):
     class CustomComplexScheduler:
         def __init__(self, task):
             self.task = task
-            # will be injected by Benchmark
+            # will be injected by OSB
             self.parameter_source = None
 
         def before_request(self, now):


### PR DESCRIPTION
### Description
There are several occurrences in the code base where  the term "Benchmark" is used in lieu of the more appropriate "OSB".  This is an historical artifact dating back to the time the code was forked from Rally.  This PR simply fixes this cosmetic issue.

### Testing
Unit and integ tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
