### PR TITLE
update integ-test + unit-test yaml files

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -11,6 +11,12 @@ jobs:
           - "3.11"
     runs-on: ubuntu-latest
     steps:
+      - name: Install bz2 development package
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbz2-dev
+
       - uses: actions/setup-python@v4
 
       - uses: KengoTODA/actions-setup-docker-compose@v1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Install bz2 development package
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbz2-dev
+
       - name: Check out repository code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
### Description
Seems there was a missing dependency causing integ tests + unit tests for ubuntu to fail. This change adds a step to update + install libbz2-dev which should resolve this issue.

### Testing
- [x] New functionality includes testing

Running github actions with new yaml files

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
