### PR TITLE
Enhance Worker Coordinator Async Profiler

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -585,6 +585,10 @@ def create_arg_parser():
         default=False,
         action="store_true")
     test_execution_parser.add_argument(
+        "--profiling-sort-type",
+        help="Only effective if profiling worker coordinator",
+        default=None)
+    test_execution_parser.add_argument(
         "--enable-assertions",
         help="Enables assertion checks for tasks (default: false).",
         default=False,
@@ -912,6 +916,7 @@ def configure_test(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "test_execution", "pipeline", args.pipeline)
     cfg.add(config.Scope.applicationOverride, "test_execution", "user.tag", args.user_tag)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "profiling", args.enable_worker_coordinator_profiling)
+    cfg.add(config.Scope.applicationOverride, "worker_coordinator", "profiling_sort_type", args.profiling_sort_type)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "assertions", args.enable_assertions)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "on.error", args.on_error)
     cfg.add(

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -586,7 +586,7 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--profiling-sort-type",
-        help="Only effective if profiling worker coordinator",
+        help="Sort outputted profile.log by column name. Only applies if --enable-worker-coordinator-profiling is provided",
         default=None)
     test_execution_parser.add_argument(
         "--enable-assertions",

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -38,6 +38,7 @@ from osbenchmark import version, actor, config, paths, \
     test_execution_orchestrator, results_publisher, \
         metrics, workload, exceptions, log
 from osbenchmark.builder import provision_config, builder
+from osbenchmark.worker_coordinator import worker_coordinator
 from osbenchmark.workload_generator import workload_generator
 from osbenchmark.utils import io, convert, process, console, net, opts, versions
 from osbenchmark import aggregator
@@ -581,12 +582,14 @@ def create_arg_parser():
         action="store_true")
     test_execution_parser.add_argument(
         "--enable-worker-coordinator-profiling",
-        help="Enables a profiler for analyzing the performance of calls in Benchmark's worker coordinator (default: false).",
+        help="Enables a profiler for analyzing the performance of calls in OSB's worker coordinator (default: false). "
+            "Outputs to ~/.benchmark/logs/ as profile.log",
         default=False,
         action="store_true")
     test_execution_parser.add_argument(
         "--profiling-sort-type",
-        help="Sort outputted profile.log by column name. Only applies if --enable-worker-coordinator-profiling is provided",
+        help=f"Sort profile.log by sort types (column names). Only applies if --enable-worker-coordinator-profiling is provided. "
+            f"Available sort types: {worker_coordinator.AsyncProfiler.SORT_TYPES}. Default is None.",
         default=None)
     test_execution_parser.add_argument(
         "--enable-assertions",

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1378,7 +1378,7 @@ class Query(Runner):
             logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
-            request_id = str(uuid.uuid5())
+            request_id = str(uuid.uuid4())
             logger.info("Sending request with request id: %s", request_id)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1376,7 +1376,7 @@ class Query(Runner):
             doc_type = params.get("type")
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             logger = logging.getLogger(__name__)
-            logger.info("Request Cache in Vectorsearch Query: %s", request_params["request_cache"])
+            logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
             logger.info("Response from Vector Search Query that was issued: %s: ", response)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1392,6 +1392,7 @@ class Query(Runner):
 
             doc_type = params.get("type")
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
+
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
                 hits_total = props.get("hits.total.value", props.get("hits.total", 0))

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1063,6 +1063,7 @@ class Query(Runner):
     def __init__(self):
         super().__init__()
         self._extractor = SearchAfterExtractor()
+        self.logger = logging.getLogger(__name__)
 
     async def __call__(self, opensearch, params):
         request_params, headers = self._transport_request_params(params)
@@ -1276,6 +1277,7 @@ class Query(Runner):
                 Returns:
                     Recall between predictions and top k neighbors from ground truth
                 """
+                self.logger.info("CALCULATING RECALL")
                 correct = 0.0
                 if neighbors is None:
                     self.logger.info("No neighbors are provided for recall calculation")

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1378,10 +1378,8 @@ class Query(Runner):
             logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
-            headers = {}
-            request_id = str(uuid.uuid4())
-            headers['X-Request-Id'] = request_id
-            logger.info("HEADERS: %s", headers)
+            request_id = str(uuid.uuid5())
+            logger.info("Sending request with request id: %s", request_id)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
             # logger.info("Response from Vector Search Query that was issued: %s: ", response)
@@ -1401,8 +1399,8 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            logger.info("Response headers: %s", response_json["headers"])
-            self.logger.info("Response JSON from Vector Search Query: %s", response_json)
+            logger.info("Request ID %s response headers: %s", response_json["headers"])
+            self.logger.info("Request ID %s response JSON from Vector Search Query: %s", request_id, response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")
                 return result

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1399,7 +1399,7 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            logger.info("Request ID %s response headers: %s", response_json["headers"])
+            logger.info("Request ID %s response headers: %s", request_id, response_json["headers"])
             self.logger.info("Request ID %s response JSON from Vector Search Query: %s", request_id, response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1374,6 +1374,8 @@ class Query(Runner):
                 })
 
             doc_type = params.get("type")
+            logger.info("BODY FOR REQUEST: %s", body)
+            logger.info("REQUEST PARAMS: %s", request_params)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             logger = logging.getLogger(__name__)
             logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1413,6 +1413,8 @@ class Query(Runner):
                 candidates.append(field_value)
             neighbors_dataset = params["neighbors"]
 
+            logger.info("Candidates from %s and neighbors from %s", request_id, request_id)
+
             if "k" in params:
                 self.logger.info("Params before calculating K: %s", params)
                 num_neighbors = params.get("k", 1)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -31,7 +31,6 @@ import re
 import sys
 import time
 import types
-import uuid
 from collections import Counter, OrderedDict
 from copy import deepcopy
 from enum import Enum
@@ -1278,10 +1277,6 @@ class Query(Runner):
                 Returns:
                     Recall between predictions and top k neighbors from ground truth
                 """
-                self.logger.info("CALCULATING RECALL FOR REQUEST ID: %s", request_id)
-                self.logger.info("Predictions: %s", predictions)
-                self.logger.info("Neighbors: %s", neighbors)
-                self.logger.info("Top k: %s", top_k)
                 correct = 0.0
                 if neighbors is None:
                     self.logger.info("No neighbors are provided for recall calculation")
@@ -1376,13 +1371,8 @@ class Query(Runner):
 
             doc_type = params.get("type")
             logger = logging.getLogger(__name__)
-            logger.info("BODY FOR REQUEST: %s", body)
-            logger.info("REQUEST PARAMS: %s", request_params)
-            request_id = str(uuid.uuid4())
             logger.info("Sending request with request id: %s", request_id)
-            response, response_request_id = await self._raw_search(opensearch, doc_type, index, body, request_params, request_id, headers=headers)
-            # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
-            # logger.info("Response from Vector Search Query that was issued: %s: ", response)
+            response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
                 hits_total = props.get("hits.total.value", props.get("hits.total", 0))
@@ -1399,7 +1389,6 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            self.logger.info("Request ID %s response JSON from Vector Search Query: %s", response_request_id, response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")
                 return result
@@ -1413,10 +1402,7 @@ class Query(Runner):
                 candidates.append(field_value)
             neighbors_dataset = params["neighbors"]
 
-            logger.info("Candidates from %s and neighbors from %s", response_request_id, request_id)
-
             if "k" in params:
-                self.logger.info("Params before calculating K: %s", params)
                 num_neighbors = params.get("k", 1)
                 recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors, request_id)
                 recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1, request_id)
@@ -1448,13 +1434,11 @@ class Query(Runner):
                                                 "and will be removed in a future release. Use 'scroll-search' instead.")
             return await _scroll_query(opensearch, params)
         elif search_method == "vector-search":
-            logger = logging.getLogger(__name__)
-            logger.info("Starting vectorsearch query")
             return await _vector_search_query_with_recall(opensearch, params)
         else:
             return await _request_body_query(opensearch, params)
 
-    async def _raw_search(self, opensearch, doc_type, index, body, params, request_id, headers=None):
+    async def _raw_search(self, opensearch, doc_type, index, body, params, headers=None):
         components = []
         if index:
             components.append(index)
@@ -1465,7 +1449,7 @@ class Query(Runner):
         request_context_holder.on_client_request_start()
         response = await opensearch.transport.perform_request("GET", "/" + path, params=params, body=body, headers=headers)
         request_context_holder.on_client_request_end()
-        return response, request_id
+        return response
 
     def _query_headers(self, params):
         # reduces overhead due to decompression of very large responses

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1267,7 +1267,7 @@ class Query(Runner):
                         low = mid + 1
                 return low - 1
 
-            def calculate_topk_search_recall(predictions, neighbors, top_k):
+            def calculate_topk_search_recall(predictions, neighbors, top_k, request_id):
                 """
                 Calculates the recall by comparing top_k neighbors with predictions.
                 recall = Sum of matched neighbors from predictions / total number of neighbors from ground truth
@@ -1278,7 +1278,7 @@ class Query(Runner):
                 Returns:
                     Recall between predictions and top k neighbors from ground truth
                 """
-                self.logger.info("CALCULATING RECALL")
+                self.logger.info("CALCULATING RECALL FOR REQUEST ID: %s", request_id)
                 self.logger.info("Predictions: %s", predictions)
                 self.logger.info("Neighbors: %s", neighbors)
                 self.logger.info("Top k: %s", top_k)
@@ -1416,7 +1416,7 @@ class Query(Runner):
             if "k" in params:
                 self.logger.info("Params before calculating K: %s", params)
                 num_neighbors = params.get("k", 1)
-                recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors)
+                recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors, request_id)
                 recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1)
                 result.update({"recall@k": recall_top_k})
                 result.update({"recall@1": recall_top_1})

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1374,12 +1374,12 @@ class Query(Runner):
                 })
 
             doc_type = params.get("type")
+            logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
-            logger = logging.getLogger(__name__)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
-            logger.info("Response from Vector Search Query that was issued: %s: ", response)
+            # logger.info("Response from Vector Search Query that was issued: %s: ", response)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
                 hits_total = props.get("hits.total.value", props.get("hits.total", 0))

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1377,6 +1377,7 @@ class Query(Runner):
             logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
+            logger.info("HEADERS: %s", headers)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
             # logger.info("Response from Vector Search Query that was issued: %s: ", response)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1417,7 +1417,7 @@ class Query(Runner):
                 self.logger.info("Params before calculating K: %s", params)
                 num_neighbors = params.get("k", 1)
                 recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors, request_id)
-                recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1)
+                recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1, request_id)
                 result.update({"recall@k": recall_top_k})
                 result.update({"recall@1": recall_top_1})
 

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1376,6 +1376,7 @@ class Query(Runner):
             doc_type = params.get("type")
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             logger = logging.getLogger(__name__)
+            logger.info("Request Cache in Vectorsearch Query: %s", request_params["request_cache"])
             logger.info("Response from Vector Search Query that was issued: %s: ", response)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -31,6 +31,7 @@ import re
 import sys
 import time
 import types
+import uuid
 from collections import Counter, OrderedDict
 from copy import deepcopy
 from enum import Enum
@@ -1377,6 +1378,10 @@ class Query(Runner):
             logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
+            if headers is None:
+                headers = {}
+                request_id = str(uuid.uuid4())
+                headers['X-Request-Id'] = request_id
             logger.info("HEADERS: %s", headers)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
@@ -1397,6 +1402,7 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
+            logger.info("Response headers: %s", response_json["headers"])
             self.logger.info("Response JSON from Vector Search Query: %s", response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1399,7 +1399,6 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            logger.info("Request ID %s response headers: %s", request_id, response_json["headers"])
             self.logger.info("Request ID %s response JSON from Vector Search Query: %s", request_id, response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1266,7 +1266,7 @@ class Query(Runner):
                         low = mid + 1
                 return low - 1
 
-            def calculate_topk_search_recall(predictions, neighbors, top_k, request_id):
+            def calculate_topk_search_recall(predictions, neighbors, top_k):
                 """
                 Calculates the recall by comparing top_k neighbors with predictions.
                 recall = Sum of matched neighbors from predictions / total number of neighbors from ground truth
@@ -1370,8 +1370,6 @@ class Query(Runner):
                 })
 
             doc_type = params.get("type")
-            logger = logging.getLogger(__name__)
-            logger.info("Sending request with request id: %s", request_id)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
@@ -1404,8 +1402,8 @@ class Query(Runner):
 
             if "k" in params:
                 num_neighbors = params.get("k", 1)
-                recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors, request_id)
-                recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1, request_id)
+                recall_top_k = calculate_topk_search_recall(candidates, neighbors_dataset, num_neighbors)
+                recall_top_1 = calculate_topk_search_recall(candidates, neighbors_dataset, 1)
                 result.update({"recall@k": recall_top_k})
                 result.update({"recall@1": recall_top_1})
 

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1393,7 +1393,7 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            self.logger.info("Response JSON from Vector Search Query: %s")
+            self.logger.info("Response JSON from Vector Search Query: %s", response_json)
             if _is_empty_search_results(response_json):
                 self.logger.info("Vector search query returned no results.")
                 return result

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1378,10 +1378,9 @@ class Query(Runner):
             logger = logging.getLogger(__name__)
             logger.info("BODY FOR REQUEST: %s", body)
             logger.info("REQUEST PARAMS: %s", request_params)
-            if headers is None:
-                headers = {}
-                request_id = str(uuid.uuid4())
-                headers['X-Request-Id'] = request_id
+            headers = {}
+            request_id = str(uuid.uuid4())
+            headers['X-Request-Id'] = request_id
             logger.info("HEADERS: %s", headers)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1378,7 +1378,7 @@ class Query(Runner):
             logger.info("REQUEST PARAMS: %s", request_params)
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
             logger = logging.getLogger(__name__)
-            logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
+            # logger.info("Request Cache in Vectorsearch Query: %s", request_params["cache"])
             logger.info("Response from Vector Search Query that was issued: %s: ", response)
             if detailed_results:
                 props = parse(response, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1549,7 +1549,7 @@ class AsyncIoAdapter:
 
 
 class AsyncProfiler:
-    SORT_TYPES = ["ncall", "ttot"]
+    SORT_TYPES = ["ncall", "tsub", "ttot", "tavg"]
 
     def __init__(self, target, client_id, task, sort_type):
         """
@@ -1598,7 +1598,6 @@ class AsyncProfiler:
                 3: ("ttot", 8),
                 4: ("tavg", 8)
             })
-
 
             profile = f"\n=== Profile start for client id [{self.client_id}] and task [{self.task}] ===\n"
             profile += s.getvalue()

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -465,6 +465,7 @@ class WorkloadPreparationActor(actor.BenchmarkActor):
         # the workload might have been loaded on a different machine (the coordinator machine) so we force a workload
         # update to ensure we use the latest version of plugins.
         load_workload(self.cfg)
+        self.logger.info("Preparing plugins for workload now")
         load_workload_plugins(self.cfg, self.workload.name, register_workload_processor=tpr.register_workload_processor,
                            force_update=True)
         # we expect on_prepare_workload can take a long time. seed a queue of tasks and delegate to child workers

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1037,7 +1037,6 @@ class ClientAllocations:
             tasks_at_index = allocation["tasks"][task_index]
             if remove_empty and tasks_at_index is not None:
                 current_tasks.append(ClientAllocation(allocation["client_id"], tasks_at_index))
-        self.logger.info("Client Allocations: %s", self.allocations)
         return current_tasks
 
 
@@ -1527,7 +1526,6 @@ class AsyncIoAdapter:
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
             schedule = schedule_for(task, task_allocation.client_index_in_task, params_per_task[task])
-            self.logger.info("Client ID for AsyncExecutor: %s", client_id)
             async_executor = AsyncExecutor(
                 client_id, task, schedule, opensearch, self.sampler, self.cancel, self.complete,
                 task.error_behavior(self.abort_on_error))
@@ -1685,7 +1683,6 @@ class AsyncExecutor:
                 # * The runner should be rate-limited as each runner call will result in one throughput sample.
                 #
                 throughput = request_meta_data.pop("throughput", None)
-                self.logger.info("Request metadata: %s", request_meta_data)
                 # Do not calculate latency separately when we run unthrottled. This metric is just confusing then.
                 latency = request_end - absolute_expected_schedule_time if throughput_throttled else service_time
                 # If this task completes the parent task we should *not* check for completion by another client but
@@ -1911,8 +1908,6 @@ class Allocator:
                 allocations[client_index].append(next_join_point)
             join_point_id += 1
 
-        self.logger.info("Max Clients: %s", max_clients)
-        self.logger.info("ALLOCATIONS: %s", allocations)
         return allocations
 
     @property
@@ -1994,7 +1989,7 @@ def schedule_for(task, client_index, parameter_source):
         logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = parameter_source.partition(client_index, num_clients)
-    logger.info("Runner_for_op %s, params source %s", runner_for_op, parameter_source)
+
     if hasattr(sched, "parameter_source"):
         if client_index == 0:
             logger.debug("Setting parameter source [%s] for scheduler [%s]", params_for_op, sched)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1567,17 +1567,31 @@ class AsyncProfiler:
         finally:
             yappi.stop()
             s = python_io.StringIO()
-            yappi.get_func_stats().print_all(out=s, columns={
-                0: ("name", 140),
-                1: ("ncall", 8),
-                2: ("tsub", 8),
-                3: ("ttot", 8),
-                4: ("tavg", 8)
-            })
+            # yappi.get_func_stats().print_all(out=s, columns={
+            #     0: ("name", 140),
+            #     1: ("ncall", 8),
+            #     2: ("tsub", 8),
+            #     3: ("ttot", 8),
+            #     4: ("tavg", 8)
+            # })
 
-            profile = f"\n=== Profile Start for client id {self.client_id} and task {self.task} ===\n"
+            # Return stats in desc order for ncalls
+            stats = yappi.get_func_stats.sort(
+                    sort_type='ncall', sort_order='desc')
+
+            # Print all results to
+            stats.print_all(out=s, columns={
+                    0: ("name", 140),
+                    1: ("ncall", 8),
+                    2: ("tsub", 8),
+                    3: ("ttot", 8),
+                    4: ("tavg", 8)
+                }
+            )
+
+            profile = f"\n=== Profile start for client id [{self.client_id}] and task [{self.task}] ===\n"
             profile += s.getvalue()
-            profile += "=== Profile END ==="
+            profile += "\n=== Profile END ===\n"
             self.profile_logger.info(profile)
 
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1529,7 +1529,7 @@ class AsyncIoAdapter:
             async_executor = AsyncExecutor(
                 client_id, task, schedule, opensearch, self.sampler, self.cancel, self.complete,
                 task.error_behavior(self.abort_on_error))
-            final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
+            final_executor = AsyncProfiler(async_executor, client_id, task) if self.profiling_enabled else async_executor
             aws.append(final_executor())
         run_start = time.perf_counter()
         try:
@@ -1547,11 +1547,13 @@ class AsyncIoAdapter:
 
 
 class AsyncProfiler:
-    def __init__(self, target):
+    def __init__(self, target, client_id, task):
         """
         :param target: The actual executor which should be profiled.
         """
         self.target = target
+        self.client_id = client_id
+        self.task = task
         self.profile_logger = logging.getLogger("benchmark.profile")
 
     async def __call__(self, *args, **kwargs):
@@ -1573,7 +1575,7 @@ class AsyncProfiler:
                 4: ("tavg", 8)
             })
 
-            profile = "\n=== Profile START ===\n"
+            profile = f"\n=== Profile Start for client id {self.client_id} and task {self.task} ===\n"
             profile += s.getvalue()
             profile += "=== Profile END ==="
             self.profile_logger.info(profile)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1577,7 +1577,7 @@ class AsyncProfiler:
 
             if self.sort_type:
                 if self.sort_type not in self.SORT_TYPES:
-                    raise Exception(
+                    raise exceptions.SystemSetupError(
                         f"{self.sort_type} is an invalid sort type. Available sort types in Async Profiler are: {[sort_type for sort_type in self.SORT_TYPES]}"
                     )
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1550,12 +1550,13 @@ class AsyncIoAdapter:
 
 class AsyncProfiler:
     SORT_TYPES = ["ncall", "ttot"]
+
     def __init__(self, target, client_id, task, sort_type):
         """
         :param target: The actual executor which should be profiled.
         :param client_id: The client that is being profiled.
         :param task: The task in the workload that is being profiled.
-        :param sort_type: If not None, the column to sort profiled results on.
+        :param sort_type: If not None, the column to sort profiled results on. If None, output is not sorted
         """
         self.target = target
         self.client_id = client_id
@@ -1583,8 +1584,7 @@ class AsyncProfiler:
                         f"Available sort types in Async Profiler are: {self.SORT_TYPES}"
                     )
 
-                self.logger.info("Using Async Profiler and sort type: %s", self.sort_type)
-
+                self.logger.info("Using Async Profiler with sort type: %s", self.sort_type)
                 # Return stats in desc order for ncalls
                 stats = yappi.get_func_stats()
                 stats.sort(sort_type=self.sort_type, sort_order='desc')
@@ -1919,7 +1919,6 @@ class Allocator:
             for client_index in range(max_clients):
                 allocations[client_index].append(next_join_point)
             join_point_id += 1
-
         return allocations
 
     @property
@@ -2001,7 +2000,6 @@ def schedule_for(task, client_index, parameter_source):
         logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = parameter_source.partition(client_index, num_clients)
-
     if hasattr(sched, "parameter_source"):
         if client_index == 0:
             logger.debug("Setting parameter source [%s] for scheduler [%s]", params_for_op, sched)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1552,6 +1552,9 @@ class AsyncProfiler:
     def __init__(self, target, client_id, task, sort_type):
         """
         :param target: The actual executor which should be profiled.
+        :param client_id: The client that is being profiled.
+        :param task: The task in the workload that is being profiled.
+        :param sort_type: If not None, the column to sort profiled results on.
         """
         self.target = target
         self.client_id = client_id

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1528,7 +1528,7 @@ class AsyncIoAdapter:
             schedule = schedule_for(task, task_allocation.client_index_in_task, params_per_task[task])
             async_executor = AsyncExecutor(
                 client_id, task, schedule, opensearch, self.sampler, self.cancel, self.complete,
-                task.error_behavior(self.abort_on_error))
+                task.error_behavior(self.abort_on_error), self.cfg)
             final_executor = AsyncProfiler(async_executor, client_id, task, sort_type=self.profiling_sort_type) if self.profiling_enabled else async_executor
             aws.append(final_executor())
         run_start = time.perf_counter()

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1577,9 +1577,8 @@ class AsyncProfiler:
 
             # Return stats in desc order for ncalls
             stats = yappi.get_func_stats()
-            print(type(stats))
-            stats = yappi.get_func_stats.sort(
-                    sort_type='ncall', sort_order='desc')
+            # print(type(stats))
+            stats.sort(sort_type='ncall', sort_order='desc')
 
             # Print all results to
             stats.print_all(out=s, columns={

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1576,6 +1576,8 @@ class AsyncProfiler:
             # })
 
             # Return stats in desc order for ncalls
+            stats = yappi.get_func_stats()
+            print(type(stats))
             stats = yappi.get_func_stats.sort(
                     sort_type='ncall', sort_order='desc')
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -465,7 +465,7 @@ class WorkloadPreparationActor(actor.BenchmarkActor):
         # the workload might have been loaded on a different machine (the coordinator machine) so we force a workload
         # update to ensure we use the latest version of plugins.
         load_workload(self.cfg)
-        self.logger.info("Preparing plugins for workload now")
+        self.logger.info("Preparing plugins, param sources, runners, and components for workload now")
         load_workload_plugins(self.cfg, self.workload.name, register_workload_processor=tpr.register_workload_processor,
                            force_update=True)
         # we expect on_prepare_workload can take a long time. seed a queue of tasks and delegate to child workers

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1529,7 +1529,9 @@ class AsyncIoAdapter:
             async_executor = AsyncExecutor(
                 client_id, task, schedule, opensearch, self.sampler, self.cancel, self.complete,
                 task.error_behavior(self.abort_on_error), self.cfg)
-            final_executor = AsyncProfiler(async_executor, client_id, task, sort_type=self.profiling_sort_type) if self.profiling_enabled else async_executor
+            final_executor = AsyncProfiler(
+                async_executor, client_id,
+                task, self.profiling_sort_type) if self.profiling_enabled else async_executor
             aws.append(final_executor())
         run_start = time.perf_counter()
         try:
@@ -1577,7 +1579,8 @@ class AsyncProfiler:
             if self.sort_type:
                 if self.sort_type not in self.SORT_TYPES:
                     raise exceptions.SystemSetupError(
-                        f"{self.sort_type} is an invalid sort type. Available sort types in Async Profiler are: {[sort_type for sort_type in self.SORT_TYPES]}"
+                        f"{self.sort_type} is an invalid sort type. "
+                        f"Available sort types in Async Profiler are: {self.SORT_TYPES}"
                     )
 
                 self.logger.info("Using Async Profiler and sort type: %s", self.sort_type)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1019,6 +1019,7 @@ ClientAllocation = collections.namedtuple("ClientAllocation", ["client_id", "tas
 class ClientAllocations:
     def __init__(self):
         self.allocations = []
+        self.logger = logging.getLogger(__name__)
 
     def add(self, client_id, tasks):
         self.allocations.append({
@@ -1035,6 +1036,7 @@ class ClientAllocations:
             tasks_at_index = allocation["tasks"][task_index]
             if remove_empty and tasks_at_index is not None:
                 current_tasks.append(ClientAllocation(allocation["client_id"], tasks_at_index))
+        self.logger.info("Client Allocations: %s", self.allocations)
         return current_tasks
 
 
@@ -1820,6 +1822,7 @@ class Allocator:
 
     def __init__(self, schedule):
         self.schedule = schedule
+        self.logger = logging.getLogger(__name__)
 
     @property
     def allocations(self):
@@ -1872,6 +1875,9 @@ class Allocator:
             for client_index in range(max_clients):
                 allocations[client_index].append(next_join_point)
             join_point_id += 1
+
+        self.logger.info("Max Clients: %s", max_clients)
+        self.logger.info("ALLOCATIONS: %s", allocations)
         return allocations
 
     @property

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1523,6 +1523,7 @@ class AsyncIoAdapter:
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
             schedule = schedule_for(task, task_allocation.client_index_in_task, params_per_task[task])
+            self.logger.info("Client ID for AsyncExecutor: %s", client_id)
             async_executor = AsyncExecutor(
                 client_id, task, schedule, opensearch, self.sampler, self.cancel, self.complete,
                 task.error_behavior(self.abort_on_error))
@@ -1647,6 +1648,7 @@ class AsyncExecutor:
                 # * The runner should be rate-limited as each runner call will result in one throughput sample.
                 #
                 throughput = request_meta_data.pop("throughput", None)
+                self.logger.info("Request metadata: %s", request_meta_data)
                 # Do not calculate latency separately when we run unthrottled. This metric is just confusing then.
                 latency = request_end - absolute_expected_schedule_time if throughput_throttled else service_time
                 # If this task completes the parent task we should *not* check for completion by another client but
@@ -1951,6 +1953,7 @@ def schedule_for(task, client_index, parameter_source):
         logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = parameter_source.partition(client_index, num_clients)
+    logger.info("Runner_for_op %s, params source %s", runner_for_op, parameter_source)
     if hasattr(sched, "parameter_source"):
         if client_index == 0:
             logger.debug("Setting parameter source [%s] for scheduler [%s]", params_for_op, sched)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1577,6 +1577,8 @@ class AsyncProfiler:
             yappi.stop()
             s = python_io.StringIO()
 
+            stats = yappi.get_func_stats()
+
             if self.sort_type:
                 if self.sort_type not in self.SORT_TYPES:
                     raise exceptions.SystemSetupError(
@@ -1585,28 +1587,17 @@ class AsyncProfiler:
                     )
 
                 self.logger.info("Using Async Profiler with sort type: %s", self.sort_type)
-                # Return stats in desc order for ncalls
-                stats = yappi.get_func_stats()
                 stats.sort(sort_type=self.sort_type, sort_order='desc')
-
-                # Print all results
-                stats.print_all(out=s, columns={
-                        0: ("name", 140),
-                        1: ("ncall", 8),
-                        2: ("tsub", 8),
-                        3: ("ttot", 8),
-                        4: ("tavg", 8)
-                    }
-                )
             else:
-                self.logger.info("Using Async Profiler")
-                yappi.get_func_stats().print_all(out=s, columns={
-                    0: ("name", 140),
-                    1: ("ncall", 8),
-                    2: ("tsub", 8),
-                    3: ("ttot", 8),
-                    4: ("tavg", 8)
-                })
+                self.logger.info("Using Async Profiler without sort type")
+
+            stats.print_all(out=s, columns={
+                0: ("name", 140),
+                1: ("ncall", 8),
+                2: ("tsub", 8),
+                3: ("ttot", 8),
+                4: ("tavg", 8)
+            })
 
 
             profile = f"\n=== Profile start for client id [{self.client_id}] and task [{self.task}] ===\n"

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1577,7 +1577,9 @@ class AsyncProfiler:
 
             if self.sort_type:
                 if self.sort_type not in self.SORT_TYPES:
-                    raise Exception(f"{self.sort_type} not in available sort types for async profiler: [{[sort_type for sort_type in self.SORT_TYPES]}]")
+                    raise Exception(
+                        f"{self.sort_type} is an invalid sort type. Available sort types in Async Profiler are: {[sort_type for sort_type in self.SORT_TYPES]}"
+                    )
 
                 self.logger.info("Using Async Profiler and sort type: %s", self.sort_type)
 

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -858,7 +858,8 @@ class VectorSearchParamSource(SearchParamSource):
         self.corpora = self.delegate_param_source.corpora
 
     def partition(self, partition_index, total_partitions):
-        self.logger.info("Vector Search Param Source Partition Method")
+        self.logger.info("Vector Search Param Source Partition Method.")
+        self.logger.info("Partition index %s, total partitions %s", partition_index, total_partitions)
         return self.delegate_param_source.partition(partition_index, total_partitions)
 
     def params(self):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1136,6 +1136,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         if filter_type == "post_filter":
             body_params["post_filter"] = filter_body
+
         self.query_params.update({self.PARAMS_NAME_BODY: body_params})
 
     def partition(self, partition_index, total_partitions):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -542,6 +542,7 @@ class CreateComponentTemplateParamSource(CreateTemplateParamSource):
 class SearchParamSource(ParamSource):
     def __init__(self, workload, params, **kwargs):
         super().__init__(workload, params, **kwargs)
+        self.logger = logging.getLogger(__name__)
         target_name = get_target(workload, params)
         type_name = params.get("type")
         if params.get("data-stream") and type_name:
@@ -565,6 +566,8 @@ class SearchParamSource(ParamSource):
             "response-compression-enabled": response_compression_enabled,
             "body": query_body
         }
+
+        self.logger.info("Query Params: %s", self.query_params)
 
         if not target_name:
             raise exceptions.InvalidSyntax(
@@ -855,6 +858,7 @@ class VectorSearchParamSource(SearchParamSource):
         self.corpora = self.delegate_param_source.corpora
 
     def partition(self, partition_index, total_partitions):
+        self.logger.info("Vector Search Param Source Partition Method")
         return self.delegate_param_source.partition(partition_index, total_partitions)
 
     def params(self):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1171,6 +1171,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         vector = self.data_set.read(1)[0]
         neighbor = self.neighbors_data_set.read(1)[0]
         true_neighbors = list(map(str, neighbor[:self.k]))
+        self.logger.info("Updating true neighbors in query params")
         self.query_params.update({
             "neighbors": true_neighbors,
         })

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1081,7 +1081,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
-
+        self.logger = logging.getLogger(__name__)
 
         if self.PARAMS_NAME_FILTER in params:
             self.query_params.update({
@@ -1127,11 +1127,13 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         efficient_filter = filter_body if filter_type == "efficient" else None
 
         # override query params with vector search query
+        self.logger.info("BUILDING VECTORSEARCH QUERY BODY")
         body_params[self.PARAMS_NAME_QUERY] = self._build_vector_search_query_body(vector, efficient_filter, filter_type, filter_body)
+        self.logger.info("Vectorsearch query: %s", body_params[self.PARAMS_NAME_QUERY])
 
         if filter_type == "post_filter":
             body_params["post_filter"] = filter_body
-
+        self.logger.info("Running update with query params")
         self.query_params.update({self.PARAMS_NAME_BODY: body_params})
 
     def partition(self, partition_index, total_partitions):
@@ -1886,6 +1888,8 @@ class SourceOnlyIndexDataReader(IndexDataReader):
 register_param_source_for_operation(workload.OperationType.Bulk, BulkIndexParamSource)
 register_param_source_for_operation(workload.OperationType.BulkVectorDataSet, BulkVectorsFromDataSetParamSource)
 register_param_source_for_operation(workload.OperationType.Search, SearchParamSource)
+logger = logging.getLogger(__name__)
+logger.info("Registering param source for vector search")
 register_param_source_for_operation(workload.OperationType.VectorSearch, VectorSearchParamSource)
 register_param_source_for_operation(workload.OperationType.CreateIndex, CreateIndexParamSource)
 register_param_source_for_operation(workload.OperationType.DeleteIndex, DeleteIndexParamSource)

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -567,8 +567,6 @@ class SearchParamSource(ParamSource):
             "body": query_body
         }
 
-        self.logger.info("Query Params: %s", self.query_params)
-
         if not target_name:
             raise exceptions.InvalidSyntax(
                 f"'index' or 'data-stream' is mandatory and is missing for operation '{kwargs.get('operation_name')}'")
@@ -858,8 +856,6 @@ class VectorSearchParamSource(SearchParamSource):
         self.corpora = self.delegate_param_source.corpora
 
     def partition(self, partition_index, total_partitions):
-        self.logger.info("Vector Search Param Source Partition Method.")
-        self.logger.info("Partition index %s, total partitions %s", partition_index, total_partitions)
         return self.delegate_param_source.partition(partition_index, total_partitions)
 
     def params(self):
@@ -1132,13 +1128,10 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         efficient_filter = filter_body if filter_type == "efficient" else None
 
         # override query params with vector search query
-        self.logger.info("BUILDING VECTORSEARCH QUERY BODY")
         body_params[self.PARAMS_NAME_QUERY] = self._build_vector_search_query_body(vector, efficient_filter, filter_type, filter_body)
-        self.logger.info("Vectorsearch query: %s", body_params[self.PARAMS_NAME_QUERY])
 
         if filter_type == "post_filter":
             body_params["post_filter"] = filter_body
-        self.logger.info("Running update with query params")
         self.query_params.update({self.PARAMS_NAME_BODY: body_params})
 
     def partition(self, partition_index, total_partitions):
@@ -1172,7 +1165,6 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         vector = self.data_set.read(1)[0]
         neighbor = self.neighbors_data_set.read(1)[0]
         true_neighbors = list(map(str, neighbor[:self.k]))
-        self.logger.info("Updating true neighbors in query params")
         self.query_params.update({
             "neighbors": true_neighbors,
         })
@@ -1894,8 +1886,6 @@ class SourceOnlyIndexDataReader(IndexDataReader):
 register_param_source_for_operation(workload.OperationType.Bulk, BulkIndexParamSource)
 register_param_source_for_operation(workload.OperationType.BulkVectorDataSet, BulkVectorsFromDataSetParamSource)
 register_param_source_for_operation(workload.OperationType.Search, SearchParamSource)
-logger = logging.getLogger(__name__)
-logger.info("Registering param source for vector search")
 register_param_source_for_operation(workload.OperationType.VectorSearch, VectorSearchParamSource)
 register_param_source_for_operation(workload.OperationType.CreateIndex, CreateIndexParamSource)
 register_param_source_for_operation(workload.OperationType.DeleteIndex, DeleteIndexParamSource)

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1680,7 +1680,10 @@ class AsyncProfilerTests(TestCase):
             await asyncio.sleep(x)
             return x * 2
 
-        profiler = worker_coordinator.AsyncProfiler(f)
+        client_id = 2
+        task = "queries"
+        sort_type = None
+        profiler = worker_coordinator.AsyncProfiler(f, client_id, task, sort_type)
         start = time.perf_counter()
         # this should take roughly 1 second and should return something
         return_value = await profiler(1)


### PR DESCRIPTION
### Description
OSB comes with a profiler, called Async Profiler, that can analyze performance calls in OSB's worker coordinator. In order to use the Async Profiler, users can run the tests with `--enable-worker-coordinator-profiling` and profiled results will be outputted to `~/.benchmark/logs/profile.log` once the benchmark completes. Since custom runners and param sources are on a performance critical path, the profiler will come in handy to determine if they are adding any bottlenecks to OSB.

The profiler currently outputs all profiled lines to `~/.benchmark/logs/profile.log`. This PR makes it easier to interpret the profile.log by labeling which output pertains to which task and client (if using more than one client) and gives users the options to sort the outputted lines by sort types (or column names). This will also help users who are investigating performance bottlenecks in the code.

### Example profile.log that was not sorted
```
=== Profile Start for client id [2] and task [warmup-indices] ===

Clock type: CPU
Ordered by: totaltime, desc

name                                                                                                                                          ncall     tsub      ttot      tavg
...
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/__init__.py:260 TransmitIntent.tx_done      5         0.000019  0.000254  0.000051
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/__init__.py:306 TransmitIntent.expired      27        0.000087  0.000252  0.000009
/usr/lib64/python3.9/typing.py:352 _SpecialForm.__getitem__                                                                                   2/1       0.000007  0.000238  0.000119
/usr/lib64/python3.9/asyncio/selector_events.py:481 _UnixSelectorEventLoop.sock_connect                                                       1         0.000027  0.000238  0.000238
/usr/lib64/python3.9/concurrent/futures/thread.py:180 ThreadPoolExecutor._adjust_thread_count                                                 1         0.000025  0.000237  0.000237
/usr/lib64/python3.9/typing.py:472 _SpecialForm.Optional                                                                                      1         0.000009  0.000234  0.000234
..ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/TCPTransport.py:1009 TCPTransport._next_XMIT_5  4         0.000014  0.000231  0.000058
/usr/lib64/python3.9/asyncio/sslproto.py:630 SSLProtocol._on_handshake_complete                                                               1         0.000032  0.000224  0.000224
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/timing.py:179 ExpirationTimerView.__init__            165       0.000190  0.000223  0.000001
..-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/__init__.py:244 TransmitIntent.completionCallback  5         0.000036  0.000219  0.000044
/usr/lib64/python3.9/contextlib.py:114 _GeneratorContextManager.__enter__                                                                     25        0.000053  0.000219  0.000009
..ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/TCPTransport.py:670 TCPTransport._finishIntent  4         0.000059  0.000214  0.000053
/usr/lib64/python3.9/typing.py:841 _SpecialGenericAlias.copy_with                                                                             2         0.000013  0.000209  0.000105
/usr/lib64/python3.9/asyncio/base_events.py:741 _UnixSelectorEventLoop.call_soon                                                              17        0.000055  0.000202  0.000012
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/aiohttp/client_reqrep.py:279 ClientRequest.__init__                   1         0.000087  0.000197  0.000197
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/aiohttp/connector.py:908 TCPConnector._resolve_host                   1         0.000041  0.000196  0.000196
../ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/asyncTransportBase.py:43 exclusive_processing  51        0.000093  0.000187  0.000004
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/TCPTransport.py:1061 _socketFile            53        0.000120  0.000187  0.000004
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/aiohttp/client_reqrep.py:1040 RawClientResponse.start                 1         0.000033  0.000185  0.000185
/home/ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/aiohttp/connector.py:829 TCPConnector.__init__                        1         0.000081  0.000184  0.000184
..pensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/TCPTransport.py:652 TCPTransport._scheduleTransmitActual  1         0.000017  0.000180  0.000180
/usr/lib64/python3.9/typing.py:434 _SpecialForm.Union                                                                                         1         0.000010  0.000178  0.000178
../ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/TCPTransport.py:885 TCPTransport._next_XMIT_2  4         0.000030  0.000177  0.000044
/usr/lib64/python3.9/contextlib.py:123 _GeneratorContextManager.__exit__                                                                      26        0.000063  0.000177  0.000007
../ec2-user/opensearch-benchmark/.venv/lib64/python3.9/site-packages/thespian/system/transport/__init__.py:140 ResultCallback.resultCallback  10/5      0.000042  0.000170  0.000017
```

### Example of profile.log ouput sorted on ncalls field
```
=== Profile start for client id [2] and task [warmup-indices] ===

Clock type: CPU
Ordered by: ncall, desc

name                                                                                                                                          ncall     tsub      ttot      tavg
/usr/lib64/python3.9/asyncio/base_events.py:1923 _UnixSelectorEventLoop.get_debug                                                             44        0.000037  0.000037  0.000001
/usr/lib64/python3.9/asyncio/base_events.py:694 _UnixSelectorEventLoop.time                                                                   29        0.000054  0.000081  0.000003
src/propcache/_helpers_c.pyx:35 __get__                                                                                                       27/22     0.000061  0.000112  0.000004
/usr/lib64/python3.9/asyncio/base_events.py:513 _UnixSelectorEventLoop._check_closed                                                          27        0.000023  0.000023  0.000001
/usr/lib64/python3.9/asyncio/events.py:78 Handle._run                                                                                         23        0.000061  0.005928  0.000258
/usr/lib64/python3.9/asyncio/events.py:31 TimerHandle.__init__                                                                                23        0.000078  0.000106  0.000005
/usr/lib64/python3.9/typing.py:713 _GenericAlias.__setattr__                                                                                  19        0.000042  0.000113  0.000006
/usr/lib64/python3.9/typing.py:665 _is_dunder                                                                                                 19        0.000043  0.000070  0.000004
/usr/lib64/python3.9/asyncio/base_events.py:770 _UnixSelectorEventLoop._call_soon                                                             18        0.000069  0.000156  0.000009
/usr/lib64/python3.9/selectors.py:452 EpollSelector.select                                                                                    17        0.000137  0.000272  0.000016
/usr/lib64/python3.9/asyncio/base_events.py:741 _UnixSelectorEventLoop.call_soon                                                              17        0.000055  0.000205  0.000012
/usr/lib64/python3.9/asyncio/selector_events.py:592 _UnixSelectorEventLoop._process_events                                                    17        0.000036  0.000085  0.000005
/usr/lib64/python3.9/asyncio/base_events.py:1830 _UnixSelectorEventLoop._run_once                                                             16        0.000243  0.006659  0.000416
```
### Issues Resolved
#709 

### Testing
- [x] New functionality includes testing

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
