### PR TITLE
Make query randomization more flexible

### DIFF
--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -952,40 +952,40 @@ class TestModeWorkloadProcessor(WorkloadProcessor):
 
 class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
 
-    class TargetKeysInfo: 
+    class QueryRandomizationInfo: 
         # A class containing information about which values to replace when randomizing queries. 
-        # For example, TargetKeysInfo("range", [["gte", "gt"], ["lte", "lt"]], ["format"]) would find queries using the "range" keyword. 
-        # Then, it would look for entries named either "gt" or "gte", and "lt" or "lte", in the top level of the "range" object. 
-        # It would also look for the optional value "format".  
+        # For example, QueryRandomizationInfo("range", [["gte", "gt"], ["lte", "lt"]], ["format"]) would find queries using the "range" keyword. 
+        # Then, it would look for parameters named either "gt" or "gte", and "lt" or "lte" in the "range" object. 
+        # It would also look for the optional parameter "format".  
         # The values pointed to by "gt"/"gte" and "lt"/"lte" would be randomized according to the standard value source. 
         # "format" would also be modified by the standard value source, if it was present in the original query.
         # The first option for each set of options must match the name provided by the standard value source in workload.py.
-        def __init__(self, query_name, value_name_options_list, optional_values): 
+        def __init__(self, query_name, parameter_name_options_list, optional_parameters): 
             self.query_name = query_name
-            self.validate_value_name_options_list(query_name, value_name_options_list)
-            self.value_name_options_list = value_name_options_list
-            self.optional_values = optional_values
+            self.validate_parameter_name_options_list(query_name, parameter_name_options_list)
+            self.parameter_name_options_list = parameter_name_options_list
+            self.optional_parameters = optional_parameters
         
-        def validate_value_name_options_list(self, query_name, value_name_options_list): 
+        def validate_parameter_name_options_list(self, query_name, parameter_name_options_list): 
             # Check there are no duplicate values as this would cause ambiguity 
             all_values = [] 
             distinct_values = set() 
-            for value_name_options in value_name_options_list: 
-                for value_name_option in value_name_options: 
-                    if value_name_option == query_name: 
+            for parameter_name_options in parameter_name_options_list: 
+                for parameter_name_option in parameter_name_options: 
+                    if parameter_name_option == query_name: 
                         raise exceptions.ExecutorError(f"Cannot have a randomized value name {query_name} which is the same as the name of its query!")
-                    all_values.append(value_name_option)
-                    distinct_values.add(value_name_option)
+                    all_values.append(parameter_name_option)
+                    distinct_values.add(parameter_name_option)
             if len(all_values) != len(distinct_values): 
-                raise exceptions.ExecutorError(f"Duplicate option for value name in target_keys_info: {value_name_options_list}")
+                raise exceptions.ExecutorError(f"Duplicate option for value name in query_randomization_info: {parameter_name_options_list}")
             
         def check_one_of_each_name_present(self, obj): 
             # Return true if one version of the value name is present in obj for each set of value options. 
-            # For example, TargetKeysInfo("range", [["gt", "gte"], ["lt", "lte"]]) 
+            # For example, QueryRandomizationInfo("range", [["gt", "gte"], ["lt", "lte"]]) 
             # would return true if both "gte" and "lt" were present.  
-            for value_name_options in self.value_name_options_list: 
+            for parameter_name_options in self.parameter_name_options_list: 
                 option_present = False
-                for name_option in value_name_options: 
+                for name_option in parameter_name_options: 
                     if name_option in obj: 
                         option_present = True 
                         break
@@ -996,7 +996,7 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
     DEFAULT_RF = 0.3
     DEFAULT_N = 5000
     DEFAULT_ALPHA = 1
-    DEFAULT_TARGET_KEYS_INFO = TargetKeysInfo("range", [["gte", "gt"], ["lte", "lt"]], ["format"])
+    DEFAULT_QUERY_RANDOMIZATION_INFO = QueryRandomizationInfo("range", [["gte", "gt"], ["lte", "lt"]], ["format"])
     def __init__(self, cfg):
         self.randomization_enabled = cfg.opts("workload", "randomization.enabled", mandatory=False, default_value=False)
         self.rf = float(cfg.opts("workload", "randomization.repeat_frequency", mandatory=False, default_value=self.DEFAULT_RF))
@@ -1041,31 +1041,31 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
             curr = curr[value]
         return curr
 
-    def extract_fields_helper(self, root, current_path, target_keys_info):
+    def extract_fields_helper(self, root, current_path, query_randomization_info):
         # Recursively called to find the location of ranges in an OpenSearch range query.
         # Return the field and the current path if we're currently scanning the field name in a range query, otherwise return an empty list.
         fields = [] # pairs of (field, path_to_field)
         curr = self.get_dict_from_previous_path(root, current_path)
         if isinstance(curr, dict) and curr != {}:
-            if len(current_path) > 0 and current_path[-1] == target_keys_info.query_name:
+            if len(current_path) > 0 and current_path[-1] == query_randomization_info.query_name:
                 for key in curr.keys():
                     if isinstance(curr, dict):
-                        if target_keys_info.check_one_of_each_name_present(curr[key]): 
+                        if query_randomization_info.check_one_of_each_name_present(curr[key]): 
                             fields.append((key, current_path))
                 return fields
             else:
                 for key in curr.keys():
-                    fields += self.extract_fields_helper(root, current_path + [key], target_keys_info)
+                    fields += self.extract_fields_helper(root, current_path + [key], query_randomization_info)
                 return fields
         elif isinstance(curr, list) and curr != []:
             for i in range(len(curr)):
-                fields += self.extract_fields_helper(root, current_path + [i], target_keys_info)
+                fields += self.extract_fields_helper(root, current_path + [i], query_randomization_info)
             return fields
         else:
             # leaf node
             return []
 
-    def extract_fields_and_paths(self, params, target_keys_info):
+    def extract_fields_and_paths(self, params, query_randomization_info):
         # Search for fields used in range queries, and the paths to those fields
         # Return pairs of (field, path_to_field)
         # TODO: Maybe only do this the first time, and assume for a given task, the same query structure is used.
@@ -1076,30 +1076,30 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
             raise exceptions.SystemSetupError(
                 f"Cannot extract range query fields from these params: {params}\n, missing params[\"body\"][\"query\"]\n"
                 f"Make sure the operation in operations/default.json is well-formed")
-        fields_and_paths = self.extract_fields_helper(root, [], target_keys_info)
+        fields_and_paths = self.extract_fields_helper(root, [], query_randomization_info)
         return fields_and_paths
 
-    def set_range(self, params, fields_and_paths, new_values, target_key_info):
+    def set_range(self, params, fields_and_paths, new_values, query_randomization_info):
         assert len(fields_and_paths) == len(new_values)
         for field_and_path, new_value in zip(fields_and_paths, new_values):
             field = field_and_path[0]
             path = field_and_path[1]
             range_section = self.get_dict_from_previous_path(params["body"]["query"], path)[field]
             # get the section of the query corresponding to the field name
-            for value_name_options in target_key_info.value_name_options_list:
-                for option in value_name_options: 
+            for parameter_name_options in query_randomization_info.parameter_name_options_list:
+                for option in parameter_name_options: 
                     if option in range_section: 
-                        range_section[option] = new_value[value_name_options[0]]
-            for optional_value in target_key_info.optional_values: 
-                if optional_value in new_values: 
-                    range_section[optional_value] = new_values[optional_value]
+                        range_section[option] = new_value[parameter_name_options[0]]
+            for optional_parameter in query_randomization_info.optional_parameters: 
+                if optional_parameter in new_values: 
+                    range_section[optional_parameter] = new_values[optional_parameter]
         return params
 
     def get_repeated_value_index(self):
         # minus 1 for mapping [1, N] to [0, N-1] of list indices
         return self.zipf_cdf_inverse(random.random(), self.H_list) - 1
 
-    def get_randomized_values(self, input_workload, input_params, target_keys_info,
+    def get_randomized_values(self, input_workload, input_params, query_randomization_info,
                               get_standard_value=params.get_standard_value,
                               get_standard_value_source=params.get_standard_value_source, # Made these configurable for simpler unit tests
                               **kwargs):
@@ -1108,22 +1108,22 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
         if not "index" in input_params:
             input_params["index"] = params.get_target(input_workload, input_params)
 
-        fields_and_paths = self.extract_fields_and_paths(input_params, target_keys_info)
+        fields_and_paths = self.extract_fields_and_paths(input_params, query_randomization_info)
 
         if random.random() < self.rf:
             # Draw a potentially repeated value from the saved standard values
             index = self.get_repeated_value_index()
             new_values = [get_standard_value(kwargs["op_name"], field_and_path[0], index) for field_and_path in fields_and_paths]
             # Use the same index for all fields in one query, otherwise the probability of repeats in a multi-field query would be very low
-            input_params = self.set_range(input_params, fields_and_paths, new_values, target_keys_info)
+            input_params = self.set_range(input_params, fields_and_paths, new_values, query_randomization_info)
         else:
             # Generate a new random value, from the standard value source function. This will be new (a cache miss)
             new_values = [get_standard_value_source(kwargs["op_name"], field_and_path[0])() for field_and_path in fields_and_paths]
-            input_params = self.set_range(input_params, fields_and_paths, new_values, target_keys_info)
+            input_params = self.set_range(input_params, fields_and_paths, new_values, query_randomization_info)
         return input_params
 
-    def create_param_source_lambda(self, op_name, get_standard_value, get_standard_value_source, get_target_keys_info):
-        return lambda w, p, **kwargs: self.get_randomized_values(w, p, target_keys_info=get_target_keys_info(op_name),
+    def create_param_source_lambda(self, op_name, get_standard_value, get_standard_value_source, get_query_randomization_info):
+        return lambda w, p, **kwargs: self.get_randomized_values(w, p, query_randomization_info=get_query_randomization_info(op_name),
                                                                  get_standard_value=get_standard_value,
                                                                  get_standard_value_source=get_standard_value_source,
                                                                  op_name=op_name, **kwargs)
@@ -1167,10 +1167,10 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
                         param_source_name,
                         self.create_param_source_lambda(op_name, get_standard_value=kwargs["get_standard_value"],
                                                         get_standard_value_source=kwargs["get_standard_value_source"], 
-                                                        get_target_keys_info=params.get_target_keys_info)) # TODO: allow registration
+                                                        get_query_randomization_info=params.get_query_randomization_info))
                     leaf_task.operation.param_source = param_source_name
                     # Generate the right number of standard values for this field, if not already present
-                    for field_and_path in self.extract_fields_and_paths(leaf_task.operation.params, params.get_target_keys_info(op_name)):
+                    for field_and_path in self.extract_fields_and_paths(leaf_task.operation.params, params.get_query_randomization_info(op_name)):
                         if generate_new_standard_values:
                             params.generate_standard_values_if_absent(op_name, field_and_path[0], self.N)
         return input_workload
@@ -1394,8 +1394,8 @@ class WorkloadPluginReader:
         # Define a value source for parameters for a given operation name and field name, for use in randomization
         params.register_standard_value_source(op_name, field_name, standard_value_source)
 
-    def register_target_keys_info(self, op_name, query_name, value_name_options_list, optional_values): 
-        params.register_target_keys_info(op_name, query_name, value_name_options_list, optional_values)
+    def register_query_randomization_info(self, op_name, query_name, parameter_name_options_list, optional_parameters): 
+        params.register_query_randomization_info(op_name, query_name, parameter_name_options_list, optional_parameters)
 
     @property
     def meta_data(self):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -120,16 +120,19 @@ def get_standard_value(op_name, field_name, i):
         raise exceptions.SystemSetupError(
             "Standard value index {} out of range for operation {}, field name {} ({} values total)"
             .format(i, op_name, field_name, len(__STANDARD_VALUES[op_name][field_name])))
-    
-def register_query_randomization_info(op_name, query_name, parameter_name_options_list, optional_parameters): 
+
+def register_query_randomization_info(op_name, query_name, parameter_name_options_list, optional_parameters):
     # query_randomization_info is registered at the operation level
-    query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo(query_name, parameter_name_options_list, optional_parameters)
+    query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo(query_name,
+                                                                                              parameter_name_options_list,
+                                                                                              optional_parameters
+                                                                                              )
     __QUERY_RANDOMIZATION_INFOS[op_name] = query_randomization_info
 
-def get_query_randomization_info(op_name): 
-    try: 
+def get_query_randomization_info(op_name):
+    try:
         return  __QUERY_RANDOMIZATION_INFOS[op_name]
-    except KeyError: 
+    except KeyError:
         return loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO # If nothing is registered, return the default.
 
 # only intended for tests
@@ -143,7 +146,7 @@ def _clear_standard_values():
     __STANDARD_VALUES = {}
     __STANDARD_VALUE_SOURCES = {}
 
-def _clear_query_randomization_infos(): 
+def _clear_query_randomization_infos():
     __QUERY_RANDOMIZATION_INFOS = {}
 
 # Default

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -49,7 +49,7 @@ __PARAM_SOURCES_BY_NAME = {}
 
 __STANDARD_VALUE_SOURCES = {}
 __STANDARD_VALUES = {}
-__TARGET_KEYS_INFOS = {}
+__QUERY_RANDOMIZATION_INFOS = {}
 
 def param_source_for_operation(op_type, workload, params, task_name):
     try:
@@ -121,18 +121,16 @@ def get_standard_value(op_name, field_name, i):
             "Standard value index {} out of range for operation {}, field name {} ({} values total)"
             .format(i, op_name, field_name, len(__STANDARD_VALUES[op_name][field_name])))
     
-def register_target_keys_info(op_name, query_name, value_name_options_list, optional_values): 
-    # target_keys_info is registered at the operation level
-    target_keys_info = loader.QueryRandomizerWorkloadProcessor.TargetKeysInfo(query_name, value_name_options_list, optional_values)
-    __TARGET_KEYS_INFOS[op_name] = target_keys_info
+def register_query_randomization_info(op_name, query_name, parameter_name_options_list, optional_parameters): 
+    # query_randomization_info is registered at the operation level
+    query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo(query_name, parameter_name_options_list, optional_parameters)
+    __QUERY_RANDOMIZATION_INFOS[op_name] = query_randomization_info
 
-def get_target_keys_info(op_name): 
+def get_query_randomization_info(op_name): 
     try: 
-        return  __TARGET_KEYS_INFOS[op_name]
+        return  __QUERY_RANDOMIZATION_INFOS[op_name]
     except KeyError: 
-        return loader.QueryRandomizerWorkloadProcessor.DEFAULT_TARGET_KEYS_INFO # If nothing is registered, return the default.
-
-
+        return loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO # If nothing is registered, return the default.
 
 # only intended for tests
 def _unregister_param_source_for_name(name):
@@ -145,8 +143,8 @@ def _clear_standard_values():
     __STANDARD_VALUES = {}
     __STANDARD_VALUE_SOURCES = {}
 
-def _clear_target_keys_infos(): 
-    __TARGET_KEYS_INFOS = {}
+def _clear_query_randomization_infos(): 
+    __QUERY_RANDOMIZATION_INFOS = {}
 
 # Default
 class ParamSource:

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -42,12 +42,14 @@ from osbenchmark.utils import io
 from osbenchmark.utils.dataset import DataSet, get_data_set, Context
 from osbenchmark.utils.parse import parse_string_parameter, parse_int_parameter
 from osbenchmark.workload import workload
+from osbenchmark.workload import loader
 
 __PARAM_SOURCES_BY_OP = {}
 __PARAM_SOURCES_BY_NAME = {}
 
 __STANDARD_VALUE_SOURCES = {}
 __STANDARD_VALUES = {}
+__TARGET_KEYS_INFOS = {}
 
 def param_source_for_operation(op_type, workload, params, task_name):
     try:
@@ -118,6 +120,18 @@ def get_standard_value(op_name, field_name, i):
         raise exceptions.SystemSetupError(
             "Standard value index {} out of range for operation {}, field name {} ({} values total)"
             .format(i, op_name, field_name, len(__STANDARD_VALUES[op_name][field_name])))
+    
+def register_target_keys_info(op_name, query_name, value_name_options_list, optional_values): 
+    # target_keys_info is registered at the operation level
+    target_keys_info = loader.QueryRandomizerWorkloadProcessor.TargetKeysInfo(query_name, value_name_options_list, optional_values)
+    __TARGET_KEYS_INFOS[op_name] = target_keys_info
+
+def get_target_keys_info(op_name): 
+    try: 
+        return  __TARGET_KEYS_INFOS[op_name]
+    except KeyError: 
+        return loader.QueryRandomizerWorkloadProcessor.DEFAULT_TARGET_KEYS_INFO # If nothing is registered, return the default.
+
 
 
 # only intended for tests
@@ -130,6 +144,9 @@ def _unregister_param_source_for_name(name):
 def _clear_standard_values():
     __STANDARD_VALUES = {}
     __STANDARD_VALUE_SOURCES = {}
+
+def _clear_target_keys_infos(): 
+    __TARGET_KEYS_INFOS = {}
 
 # Default
 class ParamSource:

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -2091,7 +2091,8 @@ class WorkloadRandomizationTests(TestCase):
 
             # Test resulting params for operation 1
             workload = helper.get_simple_workload()
-            modified_params = processor.get_randomized_values(workload, helper.op_1_query, op_name=helper.op_name_1,
+            modified_params = processor.get_randomized_values(workload, helper.op_1_query,loader.QueryRandomizerWorkloadProcessor.DEFAULT_TARGET_KEYS_INFO, 
+                                                            op_name=helper.op_name_1,
                                                             get_standard_value=helper.get_standard_value,
                                                             get_standard_value_source=helper.get_standard_value_source)
             modified_range_1 = modified_params["body"]["query"]["bool"]["filter"]["range"][helper.field_name_1]
@@ -2109,10 +2110,10 @@ class WorkloadRandomizationTests(TestCase):
             # Test resulting params for operation 2, which uses a non-default target_keys_info
             workload = helper.get_simple_workload()
             geo_point_target_keys_info = loader.QueryRandomizerWorkloadProcessor.TargetKeysInfo("geo_bounding_box", [["top_left"], ["bottom_right"]], [])
-            modified_params = processor.get_randomized_values(workload, helper.op_2_query, op_name=helper.op_name_2,
+            modified_params = processor.get_randomized_values(workload, helper.op_2_query, geo_point_target_keys_info,
+                                                            op_name=helper.op_name_2,
                                                             get_standard_value=helper.get_standard_value,
-                                                            get_standard_value_source=helper.get_standard_value_source,
-                                                            target_keys_info=geo_point_target_keys_info)
+                                                            get_standard_value_source=helper.get_standard_value_source)
             modified_range_3 = modified_params["body"]["query"]["geo_bounding_box"][helper.field_name_3]
 
             self.assertEqual(modified_range_3["top_left"], expected_values_dict[helper.op_name_2][helper.field_name_3]["top_left"])

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -1986,7 +1986,8 @@ class WorkloadRandomizationTests(TestCase):
                 }
             }
         }
-        single_range_query_result = processor.extract_fields_and_paths(single_range_query, loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO)
+        single_range_query_result = processor.extract_fields_and_paths(
+            single_range_query, loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO)
         single_range_query_expected = [("trip_distance", ["bool", "filter", "range"])]
         self.assertEqual(single_range_query_result, single_range_query_expected)
 
@@ -2039,7 +2040,8 @@ class WorkloadRandomizationTests(TestCase):
                 }
             }
         }
-        multiple_nested_range_query_result = processor.extract_fields_and_paths(multiple_nested_range_query, loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO)
+        multiple_nested_range_query_result = processor.extract_fields_and_paths(
+            multiple_nested_range_query, loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO)
         print("Multi result: ", multiple_nested_range_query_result)
         multiple_nested_range_query_expected = [
             ("dropoff_datetime", ["range"]),
@@ -2056,7 +2058,7 @@ class WorkloadRandomizationTests(TestCase):
                 f"Cannot extract range query fields from these params: {params}\n, missing params[\"body\"][\"query\"]\n"
                 f"Make sure the operation in operations/default.json is well-formed",
                          ctx.exception.args[0])
-            
+
         # Test a non-default value for query_randomization_info
         geo_point_query = {
             "name": "bbox",
@@ -2073,7 +2075,8 @@ class WorkloadRandomizationTests(TestCase):
                 }
             }
         }
-        geo_point_query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo("geo_bounding_box", [["top_left"], ["bottom_right"]], [])
+        geo_point_query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo(
+            "geo_bounding_box", [["top_left"], ["bottom_right"]], [])
         geo_point_result = processor.extract_fields_and_paths(geo_point_query, geo_point_query_randomization_info)
         geo_point_expected = [("location", ["geo_bounding_box"])]
         self.assertEqual(geo_point_result, geo_point_expected)
@@ -2092,10 +2095,12 @@ class WorkloadRandomizationTests(TestCase):
 
             # Test resulting params for operation 1
             workload = helper.get_simple_workload()
-            modified_params = processor.get_randomized_values(workload, helper.op_1_query,loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO, 
-                                                            op_name=helper.op_name_1,
-                                                            get_standard_value=helper.get_standard_value,
-                                                            get_standard_value_source=helper.get_standard_value_source)
+            modified_params = processor.get_randomized_values(workload,
+                                                              helper.op_1_query,
+                                                              loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO,
+                                                              op_name=helper.op_name_1,
+                                                              get_standard_value=helper.get_standard_value,
+                                                              get_standard_value_source=helper.get_standard_value_source)
             modified_range_1 = modified_params["body"]["query"]["bool"]["filter"]["range"][helper.field_name_1]
             modified_range_2 = modified_params["body"]["query"]["bool"]["filter"]["must"][0]["range"][helper.field_name_2]
             self.assertEqual(modified_range_1["lt"], expected_values_dict[helper.op_name_1][helper.field_name_1]["lte"])
@@ -2110,7 +2115,8 @@ class WorkloadRandomizationTests(TestCase):
 
             # Test resulting params for operation 2, which uses a non-default query_randomization_info
             workload = helper.get_simple_workload()
-            geo_point_query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo("geo_bounding_box", [["top_left"], ["bottom_right"]], [])
+            geo_point_query_randomization_info = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo(
+                "geo_bounding_box", [["top_left"], ["bottom_right"]], [])
             modified_params = processor.get_randomized_values(workload, helper.op_2_query, geo_point_query_randomization_info,
                                                             op_name=helper.op_name_2,
                                                             get_standard_value=helper.get_standard_value,

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -34,7 +34,7 @@ from osbenchmark import exceptions
 from osbenchmark.utils import io
 from osbenchmark.utils.dataset import Context, HDF5DataSet
 from osbenchmark.utils.parse import ConfigurationError
-from osbenchmark.workload import params, workload
+from osbenchmark.workload import params, workload, loader
 from osbenchmark.workload.params import VectorDataSetPartitionParamSource, VectorSearchPartitionParamSource, \
     BulkVectorsFromDataSetParamSource
 from tests.utils.dataset_helper import create_data_set, create_attributes_data_set, create_parent_data_set
@@ -1458,6 +1458,33 @@ class StandardValueSourceRegistrationTests(TestCase):
         self.assertEqual(params.get_standard_value_source(op_name, field_name_1)(), {"gte":gte_field_1, "lte":lte_field_1})
 
         params._clear_standard_values()
+
+class TargetKeysInfoRegistrationTests(TestCase):
+    def check_result_equality(self, result, expected): 
+        self.assertEqual(result.query_name, expected.query_name)
+        self.assertEqual(result.value_name_options_list, expected.value_name_options_list)
+        self.assertEqual(result.optional_values, expected.optional_values)
+
+
+    def test_register_target_keys_info(self): 
+        params._clear_target_keys_infos()
+
+        op_name = "op-1"
+        query_name = "geo_bounding_box"
+        value_name_options_list = [["top_left"], ["lower_right"]]
+        optional_values = []
+        params.register_target_keys_info(op_name, query_name, value_name_options_list, optional_values)
+
+        target_keys_info = params.get_target_keys_info(op_name)
+        expected = loader.QueryRandomizerWorkloadProcessor.TargetKeysInfo("geo_bounding_box", [["top_left"], ["lower_right"]], [])
+        self.check_result_equality(target_keys_info, expected)
+
+        # Should get the default one for an op that has nothing registered 
+        target_keys_info = params.get_target_keys_info("unrecognized-op")
+        expected = loader.QueryRandomizerWorkloadProcessor.DEFAULT_TARGET_KEYS_INFO
+        self.check_result_equality(target_keys_info, expected)
+
+        params._clear_target_keys_infos()
 
 class SleepParamSourceTests(TestCase):
     def test_missing_duration_parameter(self):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1459,32 +1459,32 @@ class StandardValueSourceRegistrationTests(TestCase):
 
         params._clear_standard_values()
 
-class TargetKeysInfoRegistrationTests(TestCase):
+class QueryRandomizationInfoRegistrationTests(TestCase):
     def check_result_equality(self, result, expected): 
         self.assertEqual(result.query_name, expected.query_name)
-        self.assertEqual(result.value_name_options_list, expected.value_name_options_list)
-        self.assertEqual(result.optional_values, expected.optional_values)
+        self.assertEqual(result.parameter_name_options_list, expected.parameter_name_options_list)
+        self.assertEqual(result.optional_parameters, expected.optional_parameters)
 
 
-    def test_register_target_keys_info(self): 
-        params._clear_target_keys_infos()
+    def test_register_query_randomization_info(self): 
+        params._clear_query_randomization_infos()
 
         op_name = "op-1"
         query_name = "geo_bounding_box"
         value_name_options_list = [["top_left"], ["lower_right"]]
         optional_values = []
-        params.register_target_keys_info(op_name, query_name, value_name_options_list, optional_values)
+        params.register_query_randomization_info(op_name, query_name, value_name_options_list, optional_values)
 
-        target_keys_info = params.get_target_keys_info(op_name)
-        expected = loader.QueryRandomizerWorkloadProcessor.TargetKeysInfo("geo_bounding_box", [["top_left"], ["lower_right"]], [])
-        self.check_result_equality(target_keys_info, expected)
+        query_randomization_info = params.get_query_randomization_info(op_name)
+        expected = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo("geo_bounding_box", [["top_left"], ["lower_right"]], [])
+        self.check_result_equality(query_randomization_info, expected)
 
         # Should get the default one for an op that has nothing registered 
-        target_keys_info = params.get_target_keys_info("unrecognized-op")
-        expected = loader.QueryRandomizerWorkloadProcessor.DEFAULT_TARGET_KEYS_INFO
-        self.check_result_equality(target_keys_info, expected)
+        query_randomization_info = params.get_query_randomization_info("unrecognized-op")
+        expected = loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO
+        self.check_result_equality(query_randomization_info, expected)
 
-        params._clear_target_keys_infos()
+        params._clear_query_randomization_infos()
 
 class SleepParamSourceTests(TestCase):
     def test_missing_duration_parameter(self):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1460,13 +1460,13 @@ class StandardValueSourceRegistrationTests(TestCase):
         params._clear_standard_values()
 
 class QueryRandomizationInfoRegistrationTests(TestCase):
-    def check_result_equality(self, result, expected): 
+    def check_result_equality(self, result, expected):
         self.assertEqual(result.query_name, expected.query_name)
         self.assertEqual(result.parameter_name_options_list, expected.parameter_name_options_list)
         self.assertEqual(result.optional_parameters, expected.optional_parameters)
 
 
-    def test_register_query_randomization_info(self): 
+    def test_register_query_randomization_info(self):
         params._clear_query_randomization_infos()
 
         op_name = "op-1"
@@ -1479,7 +1479,7 @@ class QueryRandomizationInfoRegistrationTests(TestCase):
         expected = loader.QueryRandomizerWorkloadProcessor.QueryRandomizationInfo("geo_bounding_box", [["top_left"], ["lower_right"]], [])
         self.check_result_equality(query_randomization_info, expected)
 
-        # Should get the default one for an op that has nothing registered 
+        # Should get the default one for an op that has nothing registered
         query_randomization_info = params.get_query_randomization_info("unrecognized-op")
         expected = loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO
         self.check_result_equality(query_randomization_info, expected)


### PR DESCRIPTION
### Description
Controllable query randomization was added in https://github.com/opensearch-project/opensearch-benchmark/pull/455, and was limited to randomizing `range` queries with fields `gte`/`gt`, `lte`/`lt`, and optionally `format`. This is limiting since we might need to randomize other queries for some use cases, like benchmarking the query cache. 

This PR lets the user register different query names and parameter names to be randomized for each operation. This is done by adding `registry.register_query_randomization_info(...)` in workload.py. See an [example](https://github.com/peteralfonsi/opensearch-benchmark-workloads/blob/geopoint-nyc-taxis/nyc_taxis/workload.py#L86). 

In this example we have the operation: 
```
{
  "name": "bbox", 
  "operation-type": "search", 
  "index": "nyc_taxis",
  "body": { 
    "size": 0,
    "query": {
      "geo_bounding_box": {
        "pickup_location": {
          "top_left": [-74.27, 40.92],
          "bottom_right": [-73.68, 40.49]
        }
      }
    }
  }
}
```
And in workload.py we run `registry.register_query_randomization_info("bbox", "geo_bounding_box", [["top_left"], ["bottom_right"]], [])`. 

The first argument, `"bbox"`, is the operation name. The second argument, `"geo_bounding_box"`, is the query type name. 

The third argument is a list of lists: `[["top_left"], ["bottom_right"]]`.  Each entry in the outer list represents one parameter name that will be randomized. It's a list because we may have multiple different versions of the same name that represent roughly the same thing. For example, `"gte"` or `"gt"`. In this case there's just one option for each parameter name. At least one version of each parameter name must be present in the original query for it to be randomized. 

The last argument is a list of optional parameters. If an optional parameter is present in the random standard value source, it will be put into the randomized version of the query. If it's not in the source, it's ignored. There are no optional parameters in this example, but the typical use case would be `"format"` in a range query. 

If nothing is registered, it falls back to the default query randomization info object, which randomizes range queries as was done before this PR. This is equivalent to registering `registry.register_query_randomization_info(<operation_name>, "range", [["gte", "gt"], ["lte", "lt"]], ["format"])`. 

The dict returned by the random standard value source should match the parameter names you are trying to randomize. For example the standard value source for the above example is: 

```
def bounding_box_source(): 
    top_longitude = random.uniform(-74.27, -73.68)
    top_latitude = random.uniform(40.49, 40.92)

    bottom_longitude = random.uniform(top_longitude, -73.68)
    bottom_latitude = random.uniform(40.49, top_latitude)

    return { 
        "top_left":[top_longitude, top_latitude],
        "bottom_right":[bottom_longitude, bottom_latitude]
    }
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/711

### Testing
- [x] New functionality includes testing

Adds UTs. Also tested manually with a [workload](https://github.com/peteralfonsi/opensearch-benchmark-workloads/tree/geopoint-nyc-taxis) designed for testing the query cache, which uses a non-default QueryRandomizationInfo. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
