### PR TITLE
Push image to Docker Hub staging repository on a successful build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,11 +29,29 @@ jobs:
           version: 'v0.9.1'
       - uses: actions/checkout@v4
 
+      - name: Configure Role to Acquire Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BENCHMARK_DOCKERHUB_ROLE }}
+          aws-region: us-east-1
+
+      - name: Retrieve Password
+        id: retrieve-password
+        run: |
+          DOCKERHUB_PASSWORD=`aws secretsmanager get-secret-value --secret-id jenkins-staging-dockerhub-credential --query SecretString --output text`
+          echo "::add-mask::$DOCKERHUB_PASSWORD"
+          echo "dockerhub-password=$DOCKERHUB_PASSWORD" >> $GITHUB_OUTPUT
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.BENCHMARK_DOCKERHUB_USERNAME }}
+          password: ${{ steps.retrieve-password.outputs.dockerhub-password }}
+
       - name: Docker Build ${{ matrix.platform }}
         run: |
             docker buildx version
             tag=osb/osb-`echo ${{ matrix.platform }} | tr '/' '-'`
             set -x
-            docker buildx build --platform ${{ matrix.platform }} --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t "$tag" -o type=docker .
+            docker buildx build --platform ${{ matrix.platform }} --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t "$tag" --push .
             set +x
-            docker images | grep "$tag"


### PR DESCRIPTION
### Description
Push Docker images on successful builds to the `opensearchstaging` Docker repository, so that users can run with or test out the latest changes.

### Issues Resolved
#303 

### Testing
Tested the workflow with a personal repository.  However, the credential acquisition step will necessarily have to tested once the PR is merged.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
