### PR TITLE
Change OSB Config directory from `~/.benchmark` to `~/.osb`

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -33,7 +33,7 @@ import datetime
 
 import pytest
 
-from osbenchmark import client, config, version
+from osbenchmark import client, config, version, paths
 from osbenchmark.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "os-it"]
@@ -150,7 +150,7 @@ def check_prerequisites():
 class ConfigFile:
     def __init__(self, config_name):
         self.user_home = os.getenv("BENCHMARK_HOME", os.path.expanduser("~"))
-        self.benchmark_home = os.path.join(self.user_home, ".benchmark")
+        self.benchmark_home = paths.benchmark_confdir()
         if config_name is not None:
             self.config_file_name = f"benchmark-{config_name}.ini"
         else:

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -22,8 +22,8 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-import sys
 from osbenchmark.utils.io import ensure_dir, ensure_symlink
+from osbenchmark.utils import console
 
 def benchmark_confdir():
     default_home = os.path.expanduser("~")
@@ -37,23 +37,12 @@ def benchmark_confdir():
         # Ensure symlink from .osb to .benchmark
         ensure_symlink(old_path, new_path)
 
-        final_path = os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
+        benchmark_confdir_path = os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
 
-        return final_path
+        return benchmark_confdir_path
 
     except Exception as e:
-        error_message = (
-            f"Error in benchmark_confdir:\n"
-            f"Error type: {type(e).__name__}\n"
-            f"Error message: {str(e)}\n"
-            f"Current user: {os.getlogin()}\n"
-            f"Current working directory: {os.getcwd()}\n"
-            f"Python version: {sys.version}\n"
-            f"Operating system: {sys.platform}\n"
-            f"Permissions of {old_path}: {oct(os.stat(old_path).st_mode) if os.path.exists(old_path) else 'N/A'}\n"
-            f"Permissions of parent of {new_path}: {oct(os.stat(os.path.dirname(new_path)).st_mode)}"
-        )
-        print(error_message)
+        console.print("Error in benchmark_confdir: ", str(e))
         raise
 
 def benchmark_root():

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -22,27 +22,29 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-
+import sys
+from osbenchmark.utils.io import ensure_dir
 
 def benchmark_confdir():
     default_home = os.path.expanduser("~")
     old_path = os.path.join(default_home, ".benchmark")
     new_path = os.path.join(default_home, ".osb")
 
-    # Create .benchmark directory if it doesn't exist
-    if not os.path.exists(old_path):
-        os.makedirs(old_path, exist_ok=True)
-
-    # Create .osb directory if it doesn't exist
-    if not os.path.exists(new_path):
-        os.makedirs(new_path, exist_ok=True)
+    # ensure both directories exist
+    ensure_dir(old_path)
+    ensure_dir(new_path)
 
     # Create symlink from .osb to .benchmark if it doesn't exist
     if not os.path.islink(new_path):
         try:
             os.symlink(old_path, new_path, target_is_directory=True)
-        except OSError:
-            print(f"Warning: Failed to create symlink from {new_path} to {old_path}")
+        except OSError as e:
+            error_message = (
+                f"OSError: Failed to create symlink from {new_path} to {old_path}\n"
+                f"Error type: {type(e).__name__}\n"
+                f"Error message: {str(e)}\n"
+            )
+            print(error_message, file=sys.stderr)
 
     return os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
 

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -28,8 +28,22 @@ def benchmark_confdir():
     default_home = os.path.expanduser("~")
     old_path = os.path.join(default_home, ".benchmark")
     new_path = os.path.join(default_home, ".osb")
-    if os.path.exists(old_path) and not os.path.exists(new_path):
-        os.symlink(old_path, new_path)
+
+    # Create .benchmark directory if it doesn't exist
+    if not os.path.exists(old_path):
+        os.makedirs(old_path, exist_ok=True)
+
+    # Create .osb directory if it doesn't exist
+    if not os.path.exists(new_path):
+        os.makedirs(new_path, exist_ok=True)
+
+    # Create symlink from .osb to .benchmark if it doesn't exist
+    if not os.path.islink(new_path):
+        try:
+            os.symlink(old_path, new_path, target_is_directory=True)
+        except OSError:
+            print(f"Warning: Failed to create symlink from {new_path} to {old_path}")
+
     return os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
 
 

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -23,31 +23,38 @@
 # under the License.
 import os
 import sys
-from osbenchmark.utils.io import ensure_dir
+from osbenchmark.utils.io import ensure_dir, ensure_symlink
 
 def benchmark_confdir():
     default_home = os.path.expanduser("~")
     old_path = os.path.join(default_home, ".benchmark")
     new_path = os.path.join(default_home, ".osb")
 
-    # ensure both directories exist
-    ensure_dir(old_path)
-    ensure_dir(new_path)
+    try:
+        # Ensure .benchmark directory exists
+        ensure_dir(old_path)
 
-    # Create symlink from .osb to .benchmark if it doesn't exist
-    if not os.path.islink(new_path):
-        try:
-            os.symlink(old_path, new_path, target_is_directory=True)
-        except OSError as e:
-            error_message = (
-                f"OSError: Failed to create symlink from {new_path} to {old_path}\n"
-                f"Error type: {type(e).__name__}\n"
-                f"Error message: {str(e)}\n"
-            )
-            print(error_message, file=sys.stderr)
+        # Ensure symlink from .osb to .benchmark
+        ensure_symlink(old_path, new_path)
 
-    return os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
+        final_path = os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
 
+        return final_path
+
+    except Exception as e:
+        error_message = (
+            f"Error in benchmark_confdir:\n"
+            f"Error type: {type(e).__name__}\n"
+            f"Error message: {str(e)}\n"
+            f"Current user: {os.getlogin()}\n"
+            f"Current working directory: {os.getcwd()}\n"
+            f"Python version: {sys.version}\n"
+            f"Operating system: {sys.platform}\n"
+            f"Permissions of {old_path}: {oct(os.stat(old_path).st_mode) if os.path.exists(old_path) else 'N/A'}\n"
+            f"Permissions of parent of {new_path}: {oct(os.stat(os.path.dirname(new_path)).st_mode)}"
+        )
+        print(error_message)
+        raise
 
 def benchmark_root():
     return os.path.dirname(os.path.realpath(__file__))

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -41,9 +41,12 @@ def benchmark_confdir():
 
         return benchmark_confdir_path
 
-    except Exception as e:
+    except FileNotFoundError as e:
         console.print("Error in benchmark_confdir: ", str(e))
         raise
+    # fallback exception
+    except Exception as e:
+        console.print("Unexpected error in benchmark_confdir: ", str(e))
 
 def benchmark_root():
     return os.path.dirname(os.path.realpath(__file__))

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -26,7 +26,11 @@ import os
 
 def benchmark_confdir():
     default_home = os.path.expanduser("~")
-    return os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".benchmark")
+    old_path = os.path.join(default_home, ".benchmark")
+    new_path = os.path.join(default_home, ".osb")
+    if os.path.exists(old_path) and not os.path.exists(new_path):
+        os.symlink(old_path, new_path)
+    return os.path.join(os.getenv("BENCHMARK_HOME", default_home), ".osb")
 
 
 def benchmark_root():

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -236,6 +236,34 @@ def ensure_dir(directory, mode=0o777):
     if directory:
         os.makedirs(directory, mode, exist_ok=True)
 
+def ensure_symlink(source, link_name):
+    """
+    Ensure that a symlink exists from link_name to source.
+    If link_name already exists, it will be updated or replaced as necessary.
+
+    :param source: The target of the symlink
+    :param link_name: The path where the symlink should be created
+    """
+    logger = logging.getLogger(__name__)
+    if os.path.exists(link_name):
+        if os.path.islink(link_name):
+            if os.readlink(link_name) != source:
+                os.remove(link_name)
+                os.symlink(source, link_name)
+                logger.info("Updated symlink: %s -> %s", link_name, source)
+            else:
+                logger.info("Symlink already correct: %s -> %s", link_name, source)
+        elif os.path.isdir(link_name):
+            shutil.rmtree(link_name)
+            os.symlink(source, link_name)
+            logger.info("Replaced directory with symlink: %s -> %s", link_name, source)
+        else:
+            os.remove(link_name)
+            os.symlink(source, link_name)
+            logger.info("Replaced file with symlink: %s -> %s", link_name, source)
+    else:
+        os.symlink(source, link_name)
+        logger.info("Created symlink: %s -> %s", link_name, source)
 
 def _zipdir(source_directory, archive):
     for root, _, files in os.walk(source_directory):


### PR DESCRIPTION
### Description
Updates OSB's config directory to ~/.osb instead of ~/.benchmark. Also adds a symlink if the old path exists but the new one does not. 'benchmark' is an overloaded term, while using ~/.osb reduces ambiguity and is more consistent with the project's name.

### Issues Resolved
#728 

### Testing
- [x] New functionality includes testing

`make test` + `make it`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
