### PR TITLE
update to JDK 21 for integ tests

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -12,6 +12,21 @@ function setup {
 
   # Init pyenv.
   PATH=$HOME/.pyenv/shims:$PATH:$HOME/.pyenv/bin
+
+  # OpenSearch has different JDK requirements:
+  # - Gradle builds need JDK 21 (after Apache Lucene 10 upgrade)
+  # - OpenSearch runtime operations need JDK 17
+  # Store the current JAVA_HOME (Java 21) for Gradle
+  export GRADLE_JAVA_HOME=$JAVA_HOME
+  
+  # Set JAVA_HOME to Java 17 for OpenSearch
+  if [ -n "$JAVA17_HOME" ]; then
+    echo "Setting JAVA_HOME to Java 17 for OpenSearch"
+    export JAVA_HOME=$JAVA17_HOME
+    java -version
+  else
+    echo "WARNING: JAVA17_HOME is not set!"
+  fi
 }
 
 function build_and_unit_test {
@@ -28,8 +43,23 @@ function run_it {
 
   docker pull ubuntu/squid:latest
 
-  # make it38, it39, etc. so they run as concurrent GHA jobs
+  # Temporarily switch to Java 21 for Gradle builds if needed
+  if [ -n "$GRADLE_JAVA_HOME" ]; then
+    OLD_JAVA_HOME=$JAVA_HOME
+    export JAVA_HOME=$GRADLE_JAVA_HOME
+    echo "Switched to Java 21 for Gradle build"
+    java -version
+  fi
+
+  # Run the integration test
   make "it${1//./}"
+
+  # Switch back to Java 17 if we changed it
+  if [ -n "$OLD_JAVA_HOME" ]; then
+    export JAVA_HOME=$OLD_JAVA_HOME
+    echo "Switched back to Java 17"
+    java -version
+  fi
 }
 
 $@

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -40,12 +40,31 @@ jobs:
       - name: Install pyenv
         run: git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
+      - name: Install JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '21'
+      - run: |
+          echo "JAVA21_HOME=$JAVA_HOME" >> $GITHUB_ENV
+          echo "BUILD_JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+
       - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '17'
-      - run: echo "JAVA17_HOME=$JAVA_HOME" >> $GITHUB_ENV
+      - run: |
+          echo "JAVA17_HOME=$JAVA_HOME" >> $GITHUB_ENV
+          echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV  # Set JDK 17 as default
 
       - name: Run the CI build script
-        run: bash .ci/build.sh run_it ${{ matrix.python-version }}
+        run: |
+          # For build operations that need JDK 21
+          if [ -n "$BUILD_JAVA_HOME" ]; then
+            export ORIG_JAVA_HOME=$JAVA_HOME
+            export JAVA_HOME=$BUILD_JAVA_HOME
+            # do build operations here
+            export JAVA_HOME=$ORIG_JAVA_HOME
+          fi
+          bash .ci/build.sh run_it ${{ matrix.python-version }}


### PR DESCRIPTION
### Description
Integration tests were failing due to recent changes in OpenSearch that require Java 21 for gradle builds:
```
* What went wrong:
	A problem occurred evaluating project ':buildSrc'.
	> At least Java 21 is required to build opensearch gradle tools
```
([reference to the failing tests](https://github.com/opensearch-project/opensearch-benchmark/actions/runs/12936541840/job/36084369757?pr=720#step:9:410)). 

[Reference to the OpenSearch PR that updates the JDK version](https://github.com/opensearch-project/OpenSearch/commit/7c46f8f14e1beefdd24eb2fe61792c6737fe9023#diff-bc7a42af0a917334e95bb43c1ac3408e14a03a45ef844e044089d4dc233d5b74R77-R78).  

To fix this, I added a JDK 21 installation to the integ tests for the gradle builds. However, a JDK version between 11 and 17 is still needed for the integration tests. So, I also modified the `build.sh` file to just use JDK 21 if necessary for the gradle operations, otherwise using JDK 17.

I'm open to alternatives if there is a more elegant solution.

### Testing
- [x] New functionality includes testing

`make it`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
