### PR TITLE
Add `load-test-qps` parameter for dynamic client ramp up

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -648,10 +648,9 @@ def create_arg_parser():
         help="Stop executing tests if an error occurs in one of the test iterations (default: false).",
     )
     test_execution_parser.add_argument(
-        "--load-test",
-        action="store_true",
-        help="Run a load test (default: false).",
-        default=False
+        "--load-test-qps",
+        help="Run a load test on your cluster, up to a certain QPS value (default: 0)",
+        default=0
     )
 
     ###############################################################################
@@ -926,7 +925,7 @@ def configure_test(arg_parser, args, cfg):
         "load_worker_coordinator_hosts",
         opts.csv_to_list(args.load_worker_coordinator_hosts))
     cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
-    cfg.add(config.Scope.applicationOverride, "workload", "load.test.enabled", args.load_test)
+    cfg.add(config.Scope.applicationOverride, "workload", "load.test.clients", int(args.load_test_qps))
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -647,6 +647,12 @@ def create_arg_parser():
         action="store_true",
         help="Stop executing tests if an error occurs in one of the test iterations (default: false).",
     )
+    test_execution_parser.add_argument(
+        "--load-test",
+        action="store_true",
+        help="Run a load test (default: false).",
+        default=False
+    )
 
     ###############################################################################
     #
@@ -920,6 +926,7 @@ def configure_test(arg_parser, args, cfg):
         "load_worker_coordinator_hosts",
         opts.csv_to_list(args.load_worker_coordinator_hosts))
     cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
+    cfg.add(config.Scope.applicationOverride, "workload", "load.test.enabled", args.load_test)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1634,7 +1634,7 @@ class AsyncExecutor:
             await asyncio.sleep(rampup_wait_time)
 
         if rampup_wait_time:
-            console.println(f" Client id {self.client_id} is running now.")
+            self.logger.info(f" Client id {self.client_id} is running now.")
 
         self.logger.debug("Entering main loop for client id [%s].", self.client_id)
         # noinspection PyBroadException


### PR DESCRIPTION
### Description
Adds a new `--load-test-qps` parameter for OSB. This parameter, when used with an appropriate test procedure such as:
```
{
  "name": "timed-mode-test-procedure",
  "schedule": [
    {
       "operation": "range",
       "warmup-time-period": {{ warmup_time | default(300) | tojson }},
       "ramp-up-time-period": {{ ramp_up_time | default(100) | tojson }},
       "time-period": {{ time_period | default(300) | tojson }},
       "target-throughput": {{ target_throughput | default(20) | tojson }},
       "clients": {{ search_clients | default(20) }}
    }
  ]
}
```
Overrides the target-throughput and client parameters, setting them to the integer value passed in by the user. 
OSB then uses the ramp-up property introduced in #725 to ramp up the number of clients over time until the target QPS is hit.

Example command:
`opensearch-benchmark execute-test --pipeline=benchmark-only --target-hosts=<cluster address> --workload=big5 --test-procedure=timed-mode-test-procedure --kill-running-processes --load-test-qps=30 --telemetry=node-states --telemetry-params="node-stats-include-indices-metrics:'search'"`

![Screenshot 2025-01-29 at 5 02 04 PM](https://github.com/user-attachments/assets/8d9a44eb-03c6-4e9b-82ef-c6e72d160061)

### Issues Resolved
#736 

### Testing
- [x] New functionality includes testing

`make it` + `make test`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
