### PR TITLE
Update Docker-build Workflow to Address Segfault Issue 

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Address Libc-bin segfaults issue
+        run: |
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
### Description

There's a conflict that happens when ARM64 Docker image is built. Started to randomly happen as of this 2/18/2025. 

Issue is a segfault issue that occurs when installing Qemu. Seems to be specific to how Qemu is installed and interacts with Docker and Ubuntu 20.04.

This is a temporary workaround to allow PRs to merge in. 
### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/755

### Testing
- Ran Dockerfile on Ubuntu 20.04
- Ran with Github Actions Workflow https://github.com/IanHoang/opensearch-benchmark/actions/runs/13461950670/job/37619149746


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
