### PR TITLE
Interim workaround for QEMU bug that causes the Docker ARM build to fail

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        # Workaround for a memory allocation layout bug in QEMU,
+        # triggered by a kernel update to Linux machine images.
+        # Note that this is not an actual fix.
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
### Description
A recent kernel update randomized memory layout, resulting in a latent QEMU bug getting manifested, thereby causing the cross-platform ARM build to crash during `ldconfig` processing.  An older version of QEMU handles this case better, so reverting to it for now.

### Issues Resolved
#755 

### Testing
Verified the Docker build GitHub workflow completes successfully.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
