### PR TITLE
Revert "Update Docker-build Workflow to Address Segfault Issue "

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
 
-      - name: Address Libc-bin segfaults issue
-        run: |
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
Reverts opensearch-project/opensearch-benchmark#756 since #757 is a better long term solution. 