### PR TITLE
Fix repo specification for push to Docker Hub

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Docker Build ${{ matrix.platform }}
         run: |
             docker buildx version
-            tag=osb/osb-`echo ${{ matrix.platform }} | tr '/' '-'`
+            tag=osb-`echo ${{ matrix.platform }} | tr '/' '-'`
             set -x
-            docker buildx build --platform ${{ matrix.platform }} --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t "$tag" --push .
+            docker buildx build --platform ${{ matrix.platform }} --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
             set +x


### PR DESCRIPTION
### Description
Use correct repo:tag specification for push to Docker Hub.

### Issues Resolved
#717 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
