### PR TITLE
Skip running the Docker release workflow in forks of the authoritative repository

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   docker:
+    if: github.repository == 'opensearch-project/opensearch-benchmark'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION

### Description
Skip running the Docker release workflow in forks of the authoritative repository.

### Issues Resolved
#303 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
