### PR TITLE
Change Topic name used by PyPI back to Benchmark from OSB (#768)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ setup(name="opensearch-benchmark",
       },
       scripts=['scripts/expand-data-corpus.py', 'scripts/pbzip2' ],
       classifiers=[
-          "Topic :: System :: OSB",
+          "Topic :: System :: Benchmark",
           "Development Status :: 5 - Production/Stable",
           "License :: OSI Approved :: Apache Software License",
           "Intended Audience :: Developers",


### PR DESCRIPTION
### Description
Change Topic name used by PyPI back to Benchmark from OSB

### Issues Resolved
#768

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
