### PR TITLE
Add warning when benchmarking multiple target hosts

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -876,6 +876,19 @@ def configure_builder_params(args, cfg, command_requires_provision_config_instan
 
 
 def configure_connection_params(arg_parser, args, cfg):
+    # Check if multiple hosts are specified using comma separator
+    if args.target_hosts and "," in args.target_hosts:
+        console.warn(
+            "WARNING: Benchmark runs with multiple target hosts should be passed in as a JSON file such as:\n"
+            "{\n"
+            '  "default": [\n'
+            '    {"host": "127.0.0.1", "port": 9200} # Specify nodes for cluster 1\n'
+            "  ],\n"
+            '  "remote":[\n'
+            '    {"host": "10.127.0.3", "port": 9200} # Specify nodes for cluster 2\n'
+            "  ]\n"
+            "}"
+        )
     # Also needed by builder (-> telemetry) - duplicate by module?
     target_hosts = opts.TargetHosts(args.target_hosts)
     cfg.add(config.Scope.applicationOverride, "client", "hosts", target_hosts)


### PR DESCRIPTION
### Description
Adds a warning when benchmarking multiple target hosts. Because OSB considers node count when checking for cluster health, two single-node clusters passed in via comma separated strings in the `--target-hosts` flag will result in an unhealthy status, and the benchmark will hang. However, as @IanHoang pointed out, passing in the two clusters via a JSON file will allow this check to pass. 

Here is an example of the warning:
```
dev-dsk-mikeovi-2b-40a6f422 % opensearch-benchmark execute-test --target-hosts=localhost:9200,localhost:3200 --workload=geonames --test-mode --kill-running-processes

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: e2f9c79f-47a9-4268-8bf4-b285182b4ac0
[WARNING] WARNING: Benchmark runs with multiple target hosts should be passed in as a JSON file such as:
{
  "default": [
    {"host": "127.0.0.1", "port": 9200} # Specify nodes for cluster 1
  ],
  "remote":[
    {"host": "10.127.0.3", "port": 9200} # Specify nodes for cluster 2
  ]
}
```

### Issues Resolved
#730 

### Testing
- [x] New functionality includes testing

`make test` + `make it`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
