### PR TITLE
Add @time_func annotation to sleep runner

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -2000,15 +2000,13 @@ class Sleep(Runner):
     """
     Sleeps for the specified duration not issuing any request.
     """
-
+    @time_func
     async def __call__(self, opensearch, params):
         sleep_duration = mandatory(params, "duration", "sleep")
         opensearch.on_request_start()
         try:
-            request_context_holder.on_client_request_start()
             await asyncio.sleep(sleep_duration)
         finally:
-            request_context_holder.on_client_request_end()
             opensearch.on_request_end()
 
     def __repr__(self, *args, **kwargs):

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -4715,8 +4715,8 @@ class SleepTests(TestCase):
         self.assertEqual(0, opensearch.call_count)
         self.assertEqual(0, opensearch.on_request_start.call_count)
         self.assertEqual(0, opensearch.on_request_end.call_count)
-        self.assertEqual(0, on_client_request_start.call_count)
-        self.assertEqual(0, on_client_request_end.call_count)
+        self.assertEqual(1, on_client_request_start.call_count)
+        self.assertEqual(1, on_client_request_end.call_count)
         self.assertEqual(0, sleep.call_count)
 
     @mock.patch("opensearchpy.OpenSearch")


### PR DESCRIPTION
### Description
Add @time_func annotation to sleep runner's `__call__` method.

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/780 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

Tested by adding sleep operation to a workload and it works as expected now

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
