### PR TITLE
Update OpenSearch version used for integ tests to 2.17

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -37,7 +37,7 @@ from osbenchmark import client, config, version, paths
 from osbenchmark.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "os-it"]
-DISTRIBUTIONS = ["1.3.9", "2.5.0"]
+DISTRIBUTIONS = ["1.3.9", "2.17.1"]
 WORKLOADS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 BASE_COMMANDS = ["opensearch-benchmark", "osb"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
### Description
Update OpenSearch version used for integ tests to 2.17.

### Issues Resolved
#776 

### Testing
Ran integ tests.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
