### PR TITLE
Add qat_deflate and qat_lz4 as additional index codecs.

### DIFF
--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -766,6 +766,8 @@ class IndexCodec(Enum):
     BestCompression = "best_compression"
     ZSTD = "zstd"
     ZSTDNODICT = "zstd_no_dict"
+    QATDEFLATE = "qat_deflate"
+    QATLZ4 = "qat_lz4"
 
     @classmethod
     def is_codec_valid(cls, codec):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1804,7 +1804,7 @@ class CreateIndexParamSourceTests(TestCase):
 
         self.assertEqual(str(context.exception),
                          "Please set the value properly for the create-index operation. Invalid index.codec value " +
-                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstd_no_dict']")
+                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstd_no_dict', 'qat_deflate', 'qat_lz4']")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):


### PR DESCRIPTION
### Description
It's been a while since OpenSearch [added](https://opensearch.org/docs/latest/im-plugin/index-codecs/) `qat_deflate` and `qat_lz4`  as additional index codecs, but they still weren't included here. This PR adds them.

### Issues Resolved
No more "index.codec not found" error when `index.codec` is set to either `qat_deflate` or `qat_lz4`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
