### PR TITLE
Add Sample Frequency to Create-Workload

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -195,6 +195,13 @@ def create_arg_parser():
         metavar="KEY:VAL",
         help="Map of index name and integer doc count to extract. Ensure that index name also exists in --indices parameter. " +
         "To specify several indices and doc counts, use format: <index1>:<doc_count1> <index2>:<doc_count2> ...")
+    create_workload_parser.add_argument(
+        "--sample-frequency",
+        action=opts.StoreKeyPairAsDict,
+        nargs='+',
+        metavar="KEY:VAL",
+        help="Map of index name and an integer, representing the sample frequency of docs that should be extracted per index. Ensure that index name also exists in --indices parameter. " +
+        "To specify several indices and doc counts, use format: <index1>:<sample-frequency-1> <index2>:<sample-frequency-2> ...")
 
     compare_parser = subparsers.add_parser("compare", help="Compare two test_executions")
     compare_parser.add_argument(
@@ -1049,6 +1056,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
             cfg.add(config.Scope.applicationOverride, "workload", "workload.name", args.workload)
             cfg.add(config.Scope.applicationOverride, "workload", "custom_queries", args.custom_queries)
+            cfg.add(config.Scope.applicationOverride, "generator", "sample_frequency", args.sample_frequency)
             configure_connection_params(arg_parser, args, cfg)
 
             workload_generator.create_workload(cfg)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -200,7 +200,8 @@ def create_arg_parser():
         action=opts.StoreKeyPairAsDict,
         nargs='+',
         metavar="KEY:VAL",
-        help="Map of index name and an integer, representing the sample frequency of docs that should be extracted per index. Ensure that index name also exists in --indices parameter. " +
+        help="Map of index name and an integer, representing the sample frequency of docs that should be extracted per index. " +
+        "Ensure that index name also exists in --indices parameter. " +
         "To specify several indices and doc counts, use format: <index1>:<sample-frequency-1> <index2>:<sample-frequency-2> ...")
 
     compare_parser = subparsers.add_parser("compare", help="Compare two test_executions")

--- a/osbenchmark/workload_generator/config.py
+++ b/osbenchmark/workload_generator/config.py
@@ -12,7 +12,7 @@ from typing import List
 @dataclass
 class Index:
     name: str = None
-    document_frequency: int = 1
+    sample_frequency: int = 1
     number_of_docs: int = None
     settings_and_mappings: dict = field(default_factory=dict)
 

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -208,7 +208,6 @@ class SequentialCorpusExtractor(CorpusExtractor):
         if total_documents > 0:
             self.logger.info("[%d] total docs in index [%s]. Extracting [%s] docs with sample frequency [%s]", total_documents, index, total_documents, sample_frequency)
 
-            # docs_path = self._get_doc_outpath(output_path, index)
             self.dump_documents(
                 self.client,
                 index,
@@ -216,7 +215,6 @@ class SequentialCorpusExtractor(CorpusExtractor):
                 min(total_documents, self.DEFAULT_TEST_MODE_DOC_COUNT),
                 " for test mode")
 
-            # console.info(timeit.timeit(lambda: dump_documents_with_sample_frequency(client, index, docs_path, number_of_docs_in_index, sample_frequency), setup="pass", number=1))
             docs_path = self._get_doc_outpath(self.custom_workload.workload_path, index)
             self.dump_documents_with_sample_frequency(total_documents, sample_frequency, docs_path, index)
 
@@ -270,11 +268,6 @@ class SequentialCorpusExtractor(CorpusExtractor):
 
                 progress_bar = tqdm(range(number_of_docs_to_fetch), desc=progress_message, ascii=' >=', bar_format='{l_bar}{bar:10}{r_bar}{bar:-10b}')
 
-                # lst = [doc for doc in helpers.scan(client, query=query, index=index)]
-                # logger.info("List from scan: [%s]", lst)
-                # sleep(200)
-
-                # bytes_bar = tqdm(unit = 'B', ascii = True, unit_scale = True)
                 for n, doc in enumerate(helpers.scan(self.client, query=query, index=index), start=1):
                     if (n % sample_frequency) != 0:
                         continue

--- a/osbenchmark/workload_generator/extractors.py
+++ b/osbenchmark/workload_generator/extractors.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from time import sleep
 
 from tqdm import tqdm
 import opensearchpy.exceptions

--- a/osbenchmark/workload_generator/helpers.py
+++ b/osbenchmark/workload_generator/helpers.py
@@ -125,11 +125,11 @@ class QueryProcessor:
 
         return processed_queries
 
-def process_indices(indices, document_frequency, indices_docs_mapping):
+def process_indices(indices, sample_frequency_mapping, indices_docs_mapping):
     processed_indices = []
     for index_name in indices:
         try:
-            #Setting number_of_docs_for_index to None means OSB will grab all docs available in index
+            # Setting number_of_docs_for_index to None means OSB will grab all docs available in index
             number_of_docs_for_index = None
             if indices_docs_mapping and index_name in indices_docs_mapping:
                 number_of_docs_for_index = int(indices_docs_mapping[index_name])
@@ -137,9 +137,17 @@ def process_indices(indices, document_frequency, indices_docs_mapping):
                     raise exceptions.SystemSetupError(
                         "Values specified with --number-of-docs must be greater than 0")
 
+            # Do this if sample frequency is specified
+            sample_frequency_for_index = None
+            if sample_frequency_mapping and index_name in sample_frequency_mapping:
+                sample_frequency_for_index = int(sample_frequency_mapping[index_name])
+                if sample_frequency_for_index <= 1:
+                    raise exceptions.SystemSetupError(
+                        "Values specified with --sample-frequency must be greater than 1")
+
             index = Index(
                 name=index_name,
-                document_frequency=document_frequency,
+                sample_frequency=sample_frequency_for_index,
                 number_of_docs=number_of_docs_for_index
             )
             processed_indices.append(index)
@@ -167,4 +175,23 @@ def validate_index_documents_map(indices, indices_docs_map):
             raise exceptions.SystemSetupError(
                 f"Index {index_name} provided in --number-of-docs was not found in --indices. " +
                 "Ensure that all indices in --number-of-docs are present in --indices."
+            )
+
+def validate_sample_frequency_mapping(indices, sample_frequency_mapping):
+    sample_frequency_enabled = sample_frequency_mapping is not None and len(sample_frequency_mapping) > 0
+
+    if not sample_frequency_enabled:
+        return
+
+    if len(indices) < len(sample_frequency_mapping):
+        raise exceptions.SystemSetupError(
+            "Number of <index>:<doc_count> pairs exceeds number of indices in --indices. " +
+            "Ensure number of <index>:<doc_count> pairs is less than or equal to number of indices in --indices."
+        )
+
+    for index_name in sample_frequency_mapping:
+        if index_name not in indices:
+            raise exceptions.SystemSetupError(
+                "Index from <index>:<sample-frequency> pair was not found in --indices. " +
+                "Ensure that indices from all <index>:<sample-frequency> pairs exist in --indices."
             )

--- a/osbenchmark/workload_generator/helpers.py
+++ b/osbenchmark/workload_generator/helpers.py
@@ -75,6 +75,15 @@ class CustomWorkloadWriter:
         io.ensure_dir(self.custom_workload.operations_path)
         io.ensure_dir(self.custom_workload.test_procedures_path)
 
+    def write_custom_workload_record(self, template_vars):
+        filename = f"{self.custom_workload.workload_path}/{self.custom_workload.workload_name}_record.json"
+        try:
+            self.logger.info("Writing custom workload record to filepath [%s]", filename)
+            with open(filename, 'w') as file:
+                json.dump(template_vars, file)
+        except Exception as e:
+            self.logger.error("Could not write to file as CustomWorkloadWriter encountered an error: [%s]", e)
+
     def _has_write_permission(self, directory):
         """
         Verify if output directory for workload has write permissions
@@ -106,6 +115,7 @@ class CustomWorkloadWriter:
         env = Environment(loader=FileSystemLoader(self.templates_path), autoescape=select_autoescape(['html', 'xml']))
 
         return env.get_template(template_file_name)
+
 
 class QueryProcessor:
     def __init__(self, queries: str):

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -89,8 +89,11 @@ def create_workload(cfg):
     }
     logger.info("Template vars [%s]", template_vars)
 
+    custom_workload_writer.write_custom_workload_record(template_vars)
+
+    logger.info("Rendering templates")
     # Render all templates
     custom_workload_writer.render_templates(template_vars, custom_workload.queries)
 
     console.println("")
-    console.info(f"Workload {workload_name} has been created. Run it with: {PROGRAM_NAME} --workload-path={custom_workload.workload_path}")
+    console.info(f"Workload {workload_name} has been created. Run it with: {PROGRAM_NAME} execute-test --workload-path={custom_workload.workload_path}")

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -30,7 +30,6 @@ def create_workload(cfg):
     unprocessed_queries: dict = cfg.opts("workload", "custom_queries")
     templates_path: str = os.path.join(cfg.opts("node", "benchmark.root"), "resources")
 
-    # TODO: Move this to argparse
     if number_of_docs and sample_frequency_mapping:
         raise exceptions.SystemSetupError("Parameters --number-of-docs and --sample-frequency cannot be used simultaneously. Choose one or the other.")
 

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -12,7 +12,7 @@ import os
 from osbenchmark import PROGRAM_NAME, exceptions
 from osbenchmark.client import OsClientFactory
 from osbenchmark.workload_generator.config import CustomWorkload
-from osbenchmark.workload_generator.helpers import QueryProcessor, CustomWorkloadWriter, process_indices, validate_index_documents_map
+from osbenchmark.workload_generator.helpers import QueryProcessor, CustomWorkloadWriter, process_indices, validate_index_documents_map, validate_sample_frequency_mapping
 from osbenchmark.workload_generator.extractors import IndexExtractor, SequentialCorpusExtractor
 from osbenchmark.utils import io, opts, console
 
@@ -25,21 +25,24 @@ def create_workload(cfg):
     output_path: str = cfg.opts("generator", "output.path")
     target_hosts: opts.TargetHosts = cfg.opts("client", "hosts")
     client_options: opts.ClientOptions = cfg.opts("client", "options")
-    # document_frequency: int = cfg.opts("generator", "document_frequency") # Enable later
-    document_frequency: int = 0
+    sample_frequency_mapping: int = cfg.opts("generator", "sample_frequency")
     number_of_docs: dict = cfg.opts("generator", "number_of_docs")
     unprocessed_queries: dict = cfg.opts("workload", "custom_queries")
     templates_path: str = os.path.join(cfg.opts("node", "benchmark.root"), "resources")
 
-    # Validation
+    # TODO: Move this to argparse
+    if number_of_docs and sample_frequency_mapping:
+        raise exceptions.SystemSetupError("Parameters --number-of-docs and --sample-frequency cannot be used simultaneously. Choose one or the other.")
+
     validate_index_documents_map(indices, number_of_docs)
+    validate_sample_frequency_mapping(indices, sample_frequency_mapping)
 
     client = OsClientFactory(hosts=target_hosts.all_hosts[opts.TargetHosts.DEFAULT],
                              client_options=client_options.all_client_options[opts.TargetHosts.DEFAULT]).create()
     info = client.info()
     console.info(f"Connected to OpenSearch cluster [{info['name']}] version [{info['version']['number']}].\n", logger=logger)
 
-    processed_indices = process_indices(indices, document_frequency, number_of_docs)
+    processed_indices = process_indices(indices, sample_frequency_mapping, number_of_docs)
     logger.info("Processed Indices: %s", processed_indices)
 
     custom_workload = CustomWorkload(
@@ -71,7 +74,7 @@ def create_workload(cfg):
 
     # Extract Corpora
     for index in custom_workload.indices:
-        index_corpora = corpus_extractor.extract_documents(index.name, index.number_of_docs)
+        index_corpora = corpus_extractor.extract_documents(index.name, index.number_of_docs, sample_frequency=index.sample_frequency)
         custom_workload.corpora.append(index_corpora)
     logger.info("Extracted all corpora [%s]", custom_workload.corpora)
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ install_requires = [
     # License: Apache 2.0
     # Required for Kafka message producer
     "aiokafka>=0.11.0",
+    "tqdm"
 ]
 
 tests_require = [


### PR DESCRIPTION
### Description
OSB's Create-Workload feature is used to extract large volumes of documents from an index. Many users want to be able to extract a fraction of documents from throughout the index.  This PR allows users to do this. 

```
--sample-frequency="example_index:2"
```
If the index contains 5,000,000 documents, the above parameter would sample every other document and the resulting workload corpora will contain 2,500,000 documents.

These are rudimentary changes. Plan to evolve this feature eventually. A separate flag could be introduced later to randomly sample the index instead of specifying a sample frequency. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/395

### Testing
- [x] New functionality includes testing

Performed end-to-end testing on a large scale workload with indices. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
