### PR TITLE
Bump twine version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ tests_require = [
 develop_require = [
     "tox==3.14.0",
     "coverage==5.5",
-    "twine==1.15.0",
+    "twine==6.0.1",
     "wheel>=0.38.4",
     "github3.py==1.3.0",
     "pylint==2.6.0",


### PR DESCRIPTION
Pypi release is blocked by the following error in Jenkins:
```
[31mERROR   [0m InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.       
```

Applying this short-term solution: https://github.com/pypi/warehouse/issues/15611#issuecomment-2793628089

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
