### PR TITLE
Add operations for create/delete ml connector and register remote model

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -752,7 +752,6 @@ class CreateMlConnector(Runner):
         return "create-ml-connector"
 
 class DeleteMlConnector(Runner):
-
     @time_func
     async def __call__(self, opensearch, params):
         body = {
@@ -764,16 +763,13 @@ class DeleteMlConnector(Runner):
         }
 
         connector_id = None
-        try:
-            resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/connectors/_search', body=body)
-            for item in resp['hits']['hits']:
-                doc = item.get('_source')
-                if doc:
-                    connector_id = doc.get('_id')
-                    if connector_id:
-                        break
-        except:
-            pass
+        resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/connectors/_search', body=body)
+        for item in resp['hits']['hits']:
+            doc = item.get('_source')
+            if doc:
+                connector_id = doc.get('_id')
+                if connector_id:
+                    break
 
         if connector_id:
             await opensearch.transport.perform_request('DELETE', '_plugins/_ml/connectors/' + connector_id)
@@ -804,7 +800,7 @@ class RegisterRemoteMlModel(Runner):
             state = resp.get('state')
         if state == 'FAILED':
             raise exceptions.BenchmarkError("Failed to register remote ml-model. Model name: {}".format(body['name']))
-        if state == 'CREATED':
+        elif state == 'CREATED':
             raise TimeoutError("Timeout when registering remote ml-model. Model name: {}".format(body['name']))
         model_id = resp.get('model_id')
 

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -111,6 +111,9 @@ def register_default_runners():
     register_runner(workload.OperationType.DeleteKnnModel, Retry(DeleteKnnModel()), async_runner=True)
     register_runner(workload.OperationType.UpdateConcurrentSegmentSearchSettings,
                     Retry(UpdateConcurrentSegmentSearchSettings()), async_runner=True)
+    register_runner(workload.OperationType.CreateMlConnector, Retry(CreateMlConnector()), async_runner=True)
+    register_runner(workload.OperationType.DeleteMlConnector, Retry(DeleteMlConnector()), async_runner=True)
+    register_runner(workload.OperationType.RegisterRemoteMlModel, Retry(RegisterRemoteMlModel()), async_runner=True)
 
 def runner_for(operation_type):
     try:
@@ -732,6 +735,85 @@ class DeleteKnnModel(Runner):
     def __repr__(self, *args, **kwargs):
         return self.NAME
 
+
+class CreateMlConnector(Runner):
+    @time_func
+    async def __call__(self, opensearch, params):
+        body = mandatory(params, "body", self)
+
+        resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/connectors/_create', body=body)
+        connector_id = resp.get('connector_id')
+
+        with open('connector_id.json', 'w') as f:
+            d = {'connector_id': connector_id}
+            f.write(json.dumps(d))
+
+    def __repr__(self, *args, **kwargs):
+        return "create-ml-connector"
+
+class DeleteMlConnector(Runner):
+
+    @time_func
+    async def __call__(self, opensearch, params):
+        body = {
+            "query": {
+                "term": {
+                    "name.keyword": params.get('connector_name')
+                }
+            }
+        }
+
+        connector_id = None
+        try:
+            resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/connectors/_search', body=body)
+            for item in resp['hits']['hits']:
+                doc = item.get('_source')
+                if doc:
+                    connector_id = doc.get('_id')
+                    if connector_id:
+                        break
+        except:
+            pass
+
+        if connector_id:
+            await opensearch.transport.perform_request('DELETE', '_plugins/_ml/connectors/' + connector_id)
+
+    def __repr__(self, *args, **kwargs):
+        return "delete-ml-connector"
+
+class RegisterRemoteMlModel(Runner):
+    @time_func
+    async def __call__(self, opensearch, params):
+
+        body = mandatory(params, "body", self)
+
+        if "connector_id" not in body:
+            with open('connector_id.json', 'r') as f:
+                d = json.loads(f.read())
+                connector_id = d['connector_id']
+                body['connector_id'] = connector_id
+
+        resp = await opensearch.transport.perform_request('POST', '_plugins/_ml/models/_register', body=body)
+        task_id = resp.get('task_id')
+        timeout = 120
+        end = time.time() + timeout
+        state = 'CREATED'
+        while state == 'CREATED' and time.time() < end:
+            await asyncio.sleep(5)
+            resp = await opensearch.transport.perform_request('GET', '_plugins/_ml/tasks/' + task_id)
+            state = resp.get('state')
+        if state == 'FAILED':
+            raise exceptions.BenchmarkError("Failed to register remote ml-model. Model name: {}".format(body['name']))
+        if state == 'CREATED':
+            raise TimeoutError("Timeout when registering remote ml-model. Model name: {}".format(body['name']))
+        model_id = resp.get('model_id')
+
+        with open('model_id.json', 'w') as f:
+            d = { 'model_id': model_id }
+            f.write(json.dumps(d))
+
+    def __repr__(self, *args, **kwargs):
+        return "register-remote-ml-model"
 
 class TrainKnnModel(Runner):
     """

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -639,6 +639,9 @@ class OperationType(Enum):
     RegisterMlModel = 1042
     DeployMlModel = 1043
     UpdateConcurrentSegmentSearchSettings = 1044
+    CreateMlConnector = 1045
+    DeleteMlConnector = 1046
+    RegisterRemoteMlModel = 1047
 
     @property
     def admin_op(self):
@@ -756,6 +759,12 @@ class OperationType(Enum):
             return OperationType.TrainKnnModel
         elif v == "delete-knn-model":
             return OperationType.DeleteKnnModel
+        elif v == "create-ml-connector":
+            return OperationType.CreateMlConnector
+        elif v == "delete-ml-connector":
+            return OperationType.DeleteMlConnector
+        elif v == "register-remote-ml-model":
+            return OperationType.RegisterRemoteMlModel
         elif v == "update-concurrent-segment-search-settings":
             return OperationType.UpdateConcurrentSegmentSearchSettings
         elif v == "produce-stream-message":


### PR DESCRIPTION
### Description
This PR adds operations for remote model supports. Currently OSB only supports [pretrained models](https://docs.opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/). If we want to add workloads that require using some models that not in the pretrained model list, we had to use remote models. In order to use these remote models, we need to create ML connectors and using the connector id to register the model. See instruction [here](https://docs.opensearch.org/docs/latest/ml-commons-plugin/remote-models/index/).

In this PR, we are adding three operations: CreateMlConnector, DeleteMlConnector and RegisterRemoteMlModel so that we can use remote models

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
