### PR TITLE
Onboard OSB to use GHA for PyPi Release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -32,6 +36,9 @@ jobs:
         run: |
           make build
           tar zcvf artifacts.tar.gz dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
### Description
OSB needs to onboard to use Github Actions to release to PyPI. Changes in this PR are related to this effort. 

### Issues Resolved
#451 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
