### PR TITLE
remove extra print statement

### DIFF
--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -285,8 +285,10 @@ class FeedbackActor(actor.BenchmarkActor):
     def receiveMsg_DisableFeedbackScaling(self, msg, sender):
         self.logger.info("FeedbackActor: scaling disabled.")
         self.state = FeedbackState.DISABLED
+        temp_percentage = self.percentage_clients_to_scale_down # store scale down value so it doesn't stay at 100% after doing this
         self.percentage_clients_to_scale_down = 1.0
         self.scale_down()
+        self.percentage_clients_to_scale_down = temp_percentage
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
         print("Redline test finished. Maximum stable client number reached: %d" % self.max_stable_clients)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1931,7 +1931,6 @@ class AsyncExecutor:
                 # so we evaluate to a truthy value by default, allowing it to run normally in a regular benchmark
                 client_state = (self.shared_states or {}).get(self.client_id, True)
                 if client_state and was_paused:
-                    print("Client %d is now unpaused" % self.client_id)
                     now = time.perf_counter()
                     total_start = now - expected_scheduled_time
                     was_paused = False


### PR DESCRIPTION
### Description
An extra print statement was left in when merging [this PR](https://github.com/opensearch-project/opensearch-benchmark/pull/793#issue-2933104436).

Also fixes a bug where the feedback actor would continue scaling down clients by 100% after workers reach a joinpoint. The intended behavior is to scale down 100% of clients once the joinpoint is reached, then continue with the regular scale down percentage.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
