### PR TITLE
Make Redline Testing Configurable

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -661,12 +661,10 @@ def create_arg_parser():
         default=0
     )
     test_execution_parser.add_argument(
-    "--redline-test",
-    help="Run a redline test on your cluster, up to a certain QPS value (default: 1000)",
-    nargs='?',
-    const=1000,  # Value to use when flag is present but no value given
-    default=0,  # Value to use when flag is not present
-    type=int
+        "--redline-test",
+        help="Runs the given workload in 'redline test mode', where OSB gradually scales active clients and backs off on errors.",
+        default=False,
+        action="store_true"
     )
 
     ###############################################################################
@@ -955,8 +953,7 @@ def configure_test(arg_parser, args, cfg):
         opts.csv_to_list(args.load_worker_coordinator_hosts))
     cfg.add(config.Scope.applicationOverride, "workload", "test.mode.enabled", args.test_mode)
     cfg.add(config.Scope.applicationOverride, "workload", "load.test.clients", int(args.load_test_qps))
-    if args.redline_test:
-        cfg.add(config.Scope.applicationOverride, "workload", "redline.test", int(args.redline_test))
+    cfg.add(config.Scope.applicationOverride, "workload", "redline.test", args.redline_test)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -211,11 +211,11 @@ class DisableFeedbackScaling:
     pass
 
 class ConfigureFeedbackScaling:
-    def __init__(self, scale_step=5, scale_down_pct=0.10, sleep_seconds=30, max_clients=None):
-        self.scale_step = scale_step
-        self.scale_down_pct = scale_down_pct
-        self.sleep_seconds = sleep_seconds
-        self.max_clients = max_clients
+    def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None):
+        self.scale_step = scale_step if scale_step is not None else 5
+        self.scale_down_pct = scale_down_pct if scale_down_pct is not None else 0.10
+        self.sleep_seconds = sleep_seconds if sleep_seconds is not None else 30
+        self.max_clients = max_clients if max_clients is not None else 1000
 
 class FeedbackState(Enum):
     """Various states for the FeedbackActor"""

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1070,13 +1070,14 @@ class WorkerCoordinator:
                     self.logger.info("Client id(s) [%s] did not yet finish.", ",".join(map(str, pending_client_ids)))
 
     def redline_config_for(self, task):
-        """returns redline-related params for a given task object."""
+        """returns redline-related params for a given task object. Defaults to None if params are missing"""
         return {
-            "scale_step": task.scale_step,
-            "scale_down_pct": task.scale_down_percentage,
-            "sleep_seconds": task.post_scaledown_sleep,
-            "max_clients": task.clients
+            "scale_step": getattr(task, "scale_step", None),
+            "scale_down_pct": getattr(task, "scale_down_percentage", None),
+            "sleep_seconds": getattr(task, "post_scaledown_sleep", None),
+            "max_clients": getattr(task, "clients", None)
         }
+
 
     def reset_relative_time(self):
         self.logger.debug("Resetting relative time of request metrics store.")

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1766,6 +1766,9 @@ class WorkloadSpecificationReader:
         default_warmup_time_period = self._r(ops_spec, "warmup-time-period", error_ctx="parallel", mandatory=False)
         default_time_period = self._r(ops_spec, "time-period", error_ctx="parallel", mandatory=False)
         default_ramp_up_time_period = self._r(ops_spec, "ramp-up-time-period", error_ctx="parallel", mandatory=False)
+        default_scale_step = self._r(ops_spec, "scale-step", error_ctx="parallel", mandatory=False)
+        default_scale_down_percentage = self._r(ops_spec, "scale-down-percentage", error_ctx="parallel", mandatory=False)
+        default_post_scaledown_sleep = self._r(ops_spec, "post-scaledown-sleep", error_ctx="parallel", mandatory=False)
         clients = self._r(ops_spec, "clients", error_ctx="parallel", mandatory=False)
         completed_by = self._r(ops_spec, "completed-by", error_ctx="parallel", mandatory=False)
 
@@ -1773,7 +1776,8 @@ class WorkloadSpecificationReader:
         tasks = []
         for task in self._r(ops_spec, "tasks", error_ctx="parallel"):
             tasks.append(self.parse_task(task, ops, test_procedure_name, default_warmup_iterations, default_iterations,
-                                         default_warmup_time_period, default_time_period, default_ramp_up_time_period, completed_by))
+                                         default_warmup_time_period, default_time_period, default_ramp_up_time_period,
+                                         default_scale_step, default_scale_down_percentage, default_post_scaledown_sleep, completed_by))
 
         for task in tasks:
             if task.ramp_up_time_period != default_ramp_up_time_period:
@@ -1799,7 +1803,7 @@ class WorkloadSpecificationReader:
 
     def parse_task(self, task_spec, ops, test_procedure_name, default_warmup_iterations=None, default_iterations=None,
                    default_warmup_time_period=None, default_time_period=None, default_ramp_up_time_period=None,
-                   completed_by_name=None):
+                   default_scale_step=None, default_scale_down_percentage=None, default_post_scaledown_sleep=None, completed_by_name=None):
 
         op_spec = task_spec["operation"]
         if isinstance(op_spec, str) and op_spec in ops:
@@ -1825,6 +1829,9 @@ class WorkloadSpecificationReader:
                           ramp_up_time_period=self._r(task_spec, "ramp-up-time-period", error_ctx=op.name,
                                                          mandatory=False, default_value=default_ramp_up_time_period),
                           clients=self._r(task_spec, "clients", error_ctx=op.name, mandatory=False, default_value=1),
+                          scale_step = self._r(task_spec, "scale-step", error_ctx=op.name, mandatory=False, default_value=default_scale_step),
+                          scale_down_percentage = self._r(task_spec, "scale-down-percentage", error_ctx=op.name, mandatory=False, default_value=default_scale_down_percentage),
+                          post_scaledown_sleep = self._r(task_spec, "post-scaledown-sleep", error_ctx=op.name, mandatory=False, default_value=default_post_scaledown_sleep),
                           completes_parent=(task_name == completed_by_name),
                           schedule=schedule,
                           # this is to provide scheduler-specific parameters for custom schedulers.

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -899,8 +899,8 @@ class Task:
     IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST = ["non-fatal"]
 
     def __init__(self, name, operation, tags=None, meta_data=None, warmup_iterations=None, iterations=None,
-                 warmup_time_period=None, time_period=None, ramp_up_time_period=None, clients=1, completes_parent=False,
-                 schedule=None, params=None):
+                 warmup_time_period=None, time_period=None, ramp_up_time_period=None, scale_step=None, scale_down_percentage=None, post_scaledown_sleep=None, 
+                 clients=1, completes_parent=False, schedule=None, params=None):
         self.name = name
         self.operation = operation
         if isinstance(tags, str):
@@ -916,6 +916,9 @@ class Task:
         self.time_period = time_period
         self.ramp_up_time_period = ramp_up_time_period
         self.clients = clients
+        self.scale_step = scale_step
+        self.scale_down_percentage = scale_down_percentage
+        self.post_scaledown_sleep = post_scaledown_sleep
         self.completes_parent = completes_parent
         self.schedule = schedule
         self.params = params if params else {}
@@ -996,17 +999,19 @@ class Task:
         # Note that we do not include `params` in __hash__ and __eq__ (the other attributes suffice to uniquely define a task)
         return hash(self.name) ^ hash(self.operation) ^ hash(self.warmup_iterations) ^ hash(self.iterations) ^ \
                hash(self.warmup_time_period) ^ hash(self.time_period) ^ hash(self.ramp_up_time_period) ^ \
-               hash(self.clients) ^ hash(self.schedule) ^ hash(self.completes_parent)
+               hash(self.clients) ^ hash(self.schedule) ^ hash(self.completes_parent) ^ hash(self.scale_step) ^ \
+               hash(self.scale_down_percentage) ^ hash(self.post_scaledown_sleep)
 
     def __eq__(self, other):
         # Note that we do not include `params` in __hash__ and __eq__ (the other attributes suffice to uniquely define a task)
         return isinstance(other, type(self)) and (self.name, self.operation, self.warmup_iterations, self.iterations,
                                                   self.warmup_time_period, self.time_period, self.ramp_up_time_period,
-                                                  self.clients, self.schedule,self.completes_parent) == (other.name,
+                                                  self.clients, self.schedule,self.completes_parent,
+                                                  self.scale_step, self.scale_down_percentage, self.post_scaledown_sleep) == (other.name,
                                                                              other.operation, other.warmup_iterations,
                                                                              other.iterations, other.warmup_time_period, other.time_period,
                                                                              self.ramp_up_time_period, other.clients, other.schedule,
-                                                                             other.completes_parent)
+                                                                             other.completes_parent, self.scale_step, self.scale_down_percentage, self.post_scaledown_sleep)
 
     def __iter__(self):
         return iter([self])

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -899,7 +899,7 @@ class Task:
     IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST = ["non-fatal"]
 
     def __init__(self, name, operation, tags=None, meta_data=None, warmup_iterations=None, iterations=None,
-                 warmup_time_period=None, time_period=None, ramp_up_time_period=None, scale_step=None, scale_down_percentage=None, post_scaledown_sleep=None, 
+                 warmup_time_period=None, time_period=None, ramp_up_time_period=None, scale_step=None, scale_down_percentage=None, post_scaledown_sleep=None,
                  clients=1, completes_parent=False, schedule=None, params=None):
         self.name = name
         self.operation = operation


### PR DESCRIPTION
### Description
Adds three new parameters for workloads, related to redline testing:
- `scale-step`: controls how many clients/sec OSB scales up
- `scale-down-percentage`: controls the percentage of clients the feedback actor scales back when encountering an error
- `post-scaledown-sleep`: controls how long the feedback actor sleeps after an error before continuing to scale up.

Users can now customize their redline test procedures with these values by modifying a test procedure or entering them as workload-params.

For example:

```
    {
       "operation": "keyword-terms",
       "warmup-time-period": {{ warmup_time | default(300) | tojson }},
       "time-period": {{ time_period | default(300) | tojson }},
       "target-throughput": {{ target_throughput | default(20) | tojson }},
       "clients": {{ search_clients | default(1000) }},
       "scale-step": {{ scale_step | default(5) }},
       "scale-down-percentage": {{ scale_down_percentage | default(0.10) }},
       "post-scaledown-sleep": {{ post_scaledown_sleep | default(30) }}
    },
    {
      "operation": "keyword-terms-low-cardinality",
      "warmup-time-period": {{ warmup_time | default(300) | tojson }},
      "time-period": {{ time_period | default(300) | tojson }},
      "target-throughput": {{ target_throughput | default(20) | tojson }},
      "clients": {{ search_clients | default(1000) }},
      "scale-step": {{ scale_step | default(10) }},
      "scale-down-percentage": {{ scale_down_percentage | default(0.20) }},
      "post-scaledown-sleep": {{ post_scaledown_sleep | default(15) }}
   }
```
OSB would run a redline test first using the configuration specified in `keyword-terms`,
- scaling up 5 clients at a time
- scaling down 10% of clients if it encounters an error
- sleeping for 30 seconds after encountering an error

then swap over to the configuration in `keyword-terms-low-cardinality` and run another redline test with that query's specifications.

The FeedbackActor is notified of new configurations by the WorkerCoordinatorActor. Once a joinpoint is reached, the WorkerCoordinatorActor checks if there is another step in the test procedure, before sending the new parameters over to the FeedbackActor.

If no values are provided, the FeedbackActor has a set of default values that it will fall back to.


The maximum number of clients is now controlled by modifying the `clients` value in the test procedure. `--redline-test=1500` will no longer change the number of clients OSB spawns.

### Issues Resolved
#828 

### Testing
- [x] New functionality includes testing

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
