### PR TITLE
Add configurable values for redline testing

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -661,12 +661,36 @@ def create_arg_parser():
         default=0
     )
     test_execution_parser.add_argument(
-    "--redline-test",
-    help="Run a redline test on your cluster, up to a certain QPS value (default: 1000)",
-    nargs='?',
-    const=1000,  # Value to use when flag is present but no value given
-    default=0,  # Value to use when flag is not present
-    type=int
+        "--redline-test",
+        help="Run a redline test on your cluster, up to a certain QPS value (default: 1000)",
+        nargs='?',
+        const=1000,  # Value to use when flag is present but no value given
+        default=0,  # Value to use when flag is not present
+        type=int
+    )
+    test_execution_parser.add_argument(
+        "--redline-scale-step",
+        type=int,
+        help="How many clients to add per scaling iteration in redline testing (default: 5).",
+        default=5
+    )
+    test_execution_parser.add_argument(
+        "--redline-scale-down-percentage",
+        type=float,
+        help="What percentage of clients to remove when errors occur (default: 0.10).",
+        default=0.10
+    )
+    test_execution_parser.add_argument(
+        "--redline-post-scaledown-sleep",
+        type=int,
+        help="How many seconds to wait before scaling up again after a scale down (default: 30).",
+        default=30
+    )
+    test_execution_parser.add_argument(
+        "--redline-max-clients",
+        type=int,
+        help="Maximum number of clients to allow during redline testing. If not set, will default to clients defined in the test procedure.",
+        default=None
     )
 
     ###############################################################################
@@ -957,6 +981,10 @@ def configure_test(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "workload", "load.test.clients", int(args.load_test_qps))
     if args.redline_test:
         cfg.add(config.Scope.applicationOverride, "workload", "redline.test", int(args.redline_test))
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_step", args.redline_scale_step)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_down_pct", args.redline_scale_down_percentage)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.sleep_seconds", args.redline_post_scaledown_sleep)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.max_clients", args.redline_max_clients)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -41,7 +41,7 @@ from osbenchmark.builder import provision_config, builder
 from osbenchmark.workload_generator import workload_generator
 from osbenchmark.utils import io, convert, process, console, net, opts, versions
 from osbenchmark import aggregator
-
+from osbenchmark.worker_coordinator.worker_coordinator import ConfigureFeedbackScaling
 
 def create_arg_parser():
     def positive_number(v):
@@ -671,20 +671,20 @@ def create_arg_parser():
     test_execution_parser.add_argument(
         "--redline-scale-step",
         type=int,
-        help="How many clients to add per scaling iteration in redline testing (default: 5).",
-        default=5
+        help="How many clients to add while scaling up during redline testing (default: 5).",
+        default=ConfigureFeedbackScaling.DEFAULT_SCALE_STEP
     )
     test_execution_parser.add_argument(
-        "--redline-scale-down-percentage",
+        "--redline-scaledown-percentage",
         type=float,
-        help="What percentage of clients to remove when errors occur (default: 0.10).",
-        default=0.10
+        help="What percentage of clients to remove when errors occur (default: 10%).",
+        default=ConfigureFeedbackScaling.DEFAULT_SCALEDOWN_PCT
     )
     test_execution_parser.add_argument(
         "--redline-post-scaledown-sleep",
         type=int,
         help="How many seconds to wait before scaling up again after a scale down (default: 30).",
-        default=30
+        default=ConfigureFeedbackScaling.DEFAULT_SLEEP_SECONDS
     )
     test_execution_parser.add_argument(
         "--redline-max-clients",
@@ -982,7 +982,7 @@ def configure_test(arg_parser, args, cfg):
     if args.redline_test:
         cfg.add(config.Scope.applicationOverride, "workload", "redline.test", int(args.redline_test))
         cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_step", args.redline_scale_step)
-        cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_down_pct", args.redline_scale_down_percentage)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_down_pct", args.redline_scaledown_percentage)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.sleep_seconds", args.redline_post_scaledown_sleep)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.max_clients", args.redline_max_clients)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -205,10 +205,14 @@ class TaskFinished:
         self.next_task_scheduled_in = next_task_scheduled_in
 
 class ConfigureFeedbackScaling:
+    DEFAULT_SLEEP_SECONDS = 30
+    DEFAULT_SCALE_STEP = 5
+    DEFAULT_SCALEDOWN_PCT = 0.10
+
     def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None):
-        self.scale_step = scale_step if scale_step is not None else 5
-        self.scale_down_pct = scale_down_pct if scale_down_pct is not None else 0.10
-        self.sleep_seconds = sleep_seconds if sleep_seconds is not None else 30
+        self.scale_step = scale_step if scale_step is not None else self.DEFAULT_SCALE_STEP
+        self.scale_down_pct = scale_down_pct if scale_down_pct is not None else self.DEFAULT_SCALEDOWN_PCT
+        self.sleep_seconds = sleep_seconds if sleep_seconds is not None else self.DEFAULT_SLEEP_SECONDS
         self.max_clients = max_clients
 
 class EnableFeedbackScaling:
@@ -234,7 +238,6 @@ class StartFeedbackActor:
 # pylint: disable=too-many-public-methods
 class FeedbackActor(actor.BenchmarkActor):
     POST_SCALEDOWN_SECONDS = 30
-    STARTUP_TIMEOUT = 30
     WAKEUP_INTERVAL = 1
 
     def __init__(self) -> None:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -204,17 +204,12 @@ class TaskFinished:
         self.metrics = metrics
         self.next_task_scheduled_in = next_task_scheduled_in
 
-class ClusterErrorMessage:
-    """Message sent from the client when a request fails during load testing"""
-    def __init__(self, client_id, request_metadata):
-        self.client_id = client_id
-        self.request_metadata = request_metadata
-
-class SharedClientStateMessage:
-    """Message sent from the Worker to the FeedbackActor to share client state dictionaries"""
-    def __init__(self, worker_id=None, worker_clients_map=None):
-        self.worker_id = worker_id
-        self.worker_clients_map = worker_clients_map
+class ConfigureFeedbackScaling:
+    def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None):
+        self.scale_step = scale_step if scale_step is not None else 5
+        self.scale_down_pct = scale_down_pct if scale_down_pct is not None else 0.10
+        self.sleep_seconds = sleep_seconds if sleep_seconds is not None else 30
+        self.max_clients = max_clients
 
 class EnableFeedbackScaling:
     pass
@@ -289,6 +284,15 @@ class FeedbackActor(actor.BenchmarkActor):
         self.percentage_clients_to_scale_down = 1.0
         self.scale_down()
         self.percentage_clients_to_scale_down = temp_percentage
+    
+    def receiveMsg_ConfigureFeedbackScaling(self, msg, sender):
+        self.num_clients_to_scale_up = msg.scale_step
+        self.percentage_clients_to_scale_down = msg.scale_down_pct
+        self.POST_SCALEDOWN_SECONDS = msg.sleep_seconds
+        self.logger.info(
+        "Feedback Actor has received the following configuration: Max clients = %s, scale step = %d, scale down percentage = %f, sleep time = %d",
+        self.max_clients, self.num_clients_to_scale_up, self.percentage_clients_to_scale_down, self.POST_SCALEDOWN_SECONDS
+        )
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
         print("Redline test finished. Maximum stable client number reached: %d" % self.max_stable_clients)
@@ -396,15 +400,19 @@ class FeedbackActor(actor.BenchmarkActor):
                     inactive_clients = [(client_id, status) for client_id, status in client_states.items() if not status]
                     if inactive_clients:
                         inactive_clients_by_worker[worker_id] = inactive_clients
-                for worker_id in inactive_clients_by_worker:
-                    if clients_activated >= self.num_clients_to_scale_up:
-                        break
-                    if inactive_clients_by_worker[worker_id]:
-                        client_id, _ = inactive_clients_by_worker[worker_id][0]
+
+                for worker_id, inactive_clients in inactive_clients_by_worker.items():
+                    for client_id, _ in inactive_clients:
+                        if clients_activated >= self.num_clients_to_scale_up:
+                            break
                         self.shared_client_states[worker_id][client_id] = True
                         self.total_active_client_count += 1
                         clients_activated += 1
                         self.logger.info("Unpaused client %d on worker %d", client_id, worker_id)
+
+                    if clients_activated >= self.num_clients_to_scale_up:
+                        break
+
                 if clients_activated < self.num_clients_to_scale_up:
                     self.logger.info("Not enough inactive clients to activate. Activated %d clients", clients_activated)
                     break
@@ -894,15 +902,27 @@ class WorkerCoordinator:
         self.logger.info("Cluster-level telemetry devices are now attached.")
         # if redline testing or load testing is enabled, modify the client + throughput number for the task(s)
         # target throughput + clients will then be equal to the qps passed in through --redline-test or --load-test
-        load_test_clients = self.config.opts("workload", "redline.test", mandatory=False) or self.config.opts("workload", "load.test.clients", mandatory=False)
-        if load_test_clients:
+        redline_enabled = self.config.opts("workload", "redline.test", mandatory=False, default_value=False)
+        load_test_clients = self.config.opts("workload", "load.test.clients", mandatory=False)
+        if redline_enabled:
+            max_clients = self.config.opts("workload", "redline.max_clients", mandatory=False, default_value=None)
             self.target.feedback_actor = self.target.createActor(FeedbackActor)
             self.error_queue = self.manager.Queue(maxsize=1000)
+            self.logger.info("Redline test mode enabled. Clients will be managed dynamically per task")
+            if max_clients is None:
+                max_clients = self.test_procedure.schedule[0][0].clients
+            else:
+                for task in self.test_procedure.schedule:
+                    for subtask in task:
+                        subtask.params["target-throughput"] = max_clients
+        elif load_test_clients:
+            self.logger.info("Load test mode enabled - set max client count to %d", load_test_clients)
             for task in self.test_procedure.schedule:
                 for subtask in task:
                     subtask.clients = load_test_clients
                     subtask.params["target-throughput"] = load_test_clients
             self.logger.info("Load test mode enabled - set max client count to %d", load_test_clients)
+
         allocator = Allocator(self.test_procedure.schedule)
         self.allocations = allocator.allocations
         self.number_of_steps = len(allocator.join_points) - 1
@@ -931,7 +951,7 @@ class WorkerCoordinator:
                         client_allocations.add(client_id, self.allocations[client_id])
                         self.clients_per_worker[client_id] = worker_id
                     # if load testing is enabled, create a shared state dictionary for this worker
-                    if load_test_clients:
+                    if redline_enabled or load_test_clients:
                         self.shared_client_dict[worker_id] = self.manager.dict()
                         for client_id in clients:
                             self.shared_client_dict[worker_id][client_id] = False
@@ -942,8 +962,18 @@ class WorkerCoordinator:
                         self.target.start_worker(worker, worker_id, self.config, self.workload, client_allocations)
                     self.workers.append(worker)
                     worker_id += 1
-        if load_test_clients:
+        if redline_enabled:
+            scale_step = self.config.opts("workload", "redline.scale_step", default_value=5)
+            scale_down_pct = self.config.opts("workload", "redline.scale_down_pct", default_value=0.10)
+            sleep_seconds = self.config.opts("workload", "redline.sleep_seconds", default_value=30)
+            self.target.send(self.target.feedback_actor, ConfigureFeedbackScaling(
+            scale_step=scale_step,
+            scale_down_pct=scale_down_pct,
+            sleep_seconds=sleep_seconds,
+            max_clients=max_clients
+            ))
             self.target.start_feedbackActor(self.shared_client_dict)
+
         self.update_progress_message()
 
     def joinpoint_reached(self, worker_id, worker_local_timestamp, task_allocations):

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -284,14 +284,14 @@ class FeedbackActor(actor.BenchmarkActor):
         self.percentage_clients_to_scale_down = 1.0
         self.scale_down()
         self.percentage_clients_to_scale_down = temp_percentage
-    
+
     def receiveMsg_ConfigureFeedbackScaling(self, msg, sender):
         self.num_clients_to_scale_up = msg.scale_step
         self.percentage_clients_to_scale_down = msg.scale_down_pct
         self.POST_SCALEDOWN_SECONDS = msg.sleep_seconds
         self.logger.info(
-        "Feedback Actor has received the following configuration: Max clients = %s, scale step = %d, scale down percentage = %f, sleep time = %d",
-        self.max_clients, self.num_clients_to_scale_up, self.percentage_clients_to_scale_down, self.POST_SCALEDOWN_SECONDS
+        "Feedback actor has received the following configuration: Max clients = %s, scale step = %d, scale down percentage = %f, sleep time = %d",
+        self.total_client_count, self.num_clients_to_scale_up, self.percentage_clients_to_scale_down, self.POST_SCALEDOWN_SECONDS
         )
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
@@ -910,11 +910,12 @@ class WorkerCoordinator:
             self.error_queue = self.manager.Queue(maxsize=1000)
             self.logger.info("Redline test mode enabled. Clients will be managed dynamically per task")
             if max_clients is None:
-                max_clients = self.test_procedure.schedule[0][0].clients
+                max_clients = self.test_procedure.schedule[0].clients
             else:
                 for task in self.test_procedure.schedule:
                     for subtask in task:
                         subtask.params["target-throughput"] = max_clients
+                        subtask.clients = max_clients
         elif load_test_clients:
             self.logger.info("Load test mode enabled - set max client count to %d", load_test_clients)
             for task in self.test_procedure.schedule:


### PR DESCRIPTION
### Description
Adds CLI arguments related to redline testing. These include:
`--redline-scale-step`: controls how many clients to unpause per scaling iteration
`--redline-scaledown-percentage`: controls what percentage of clients to pause when an error occurs
`--redline-post-scaledown-sleep`: controls how many seconds the feedback actor waits before scaling up again after a scale down
`--redline-max-clients`: controls the max number of clients to allow during redline testing. If this one is unset, OSB will default to the number of clients defined in the test procedure

An example test run could look like:
```
opensearch-benchmark execute-test --pipeline=benchmark-only --target-hosts=localhost:9200 --workload-path=big5 --test-procedure=timed-mode-test-procedure --kill-running-processes --redline-test --redline-max-clients=2000 --redline-scale-step=20 --redline-scaledown-percentage=0.50 --redline-post-scaledown-sleep=5
```

### Issues Resolved
#828 

### Testing
- [x] Tested with all configurable values set
- [x] Tested with various subsets of configurable values set
- [x] Tested with none of the configurable values set

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
