### PR TITLE
REFACTOR async def __call__(self, *args, **kwargs)

### DIFF
--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1924,23 +1924,6 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         end_time = time.perf_counter()
         self.assertLess(end_time - start_time, 0.01)
 
-    def test_handle_client_state_client_becomes_active(self):
-        """Test _handle_client_state when a paused client becomes active."""
-        with mock.patch('time.perf_counter', return_value=20.0):
-            new_was_paused, new_total_start = self.executor._handle_client_state(
-                was_paused=True, client_state=True, total_start=10.0, expected_scheduled_time=5.0
-            )
-        self.assertFalse(new_was_paused)
-        self.assertEqual(new_total_start, 15.0)  # 20.0 (now) - 5.0 (expected_scheduled_time)
-
-    def test_handle_client_state_client_becomes_inactive(self):
-        """Test _handle_client_state when an active client is paused."""
-        new_was_paused, new_total_start = self.executor._handle_client_state(
-            was_paused=False, client_state=False, total_start=10.0, expected_scheduled_time=5.0
-        )
-        self.assertTrue(new_was_paused)
-        self.assertEqual(new_total_start, 10.0)  # total_start should not change
-
     @run_async
     async def test_prepare_context_manager_for_default_operation(self):
         """Test _prepare_context_manager for a default operation."""

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1840,6 +1840,7 @@ class AsyncExecutorTests(TestCase):
 
 
 class AsyncExecutorHelperMethodsTests(TestCase):
+    # pylint: disable=protected-access
     """
     This class contains unit tests for the new helper methods of AsyncExecutor.
     Each test focuses on a single method in isolation.
@@ -2058,7 +2059,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         self.executor._prepare_context_manager = mock.AsyncMock(return_value=context_manager)
         self.executor.runner = mock.Mock()
 
-        with mock.patch('osbenchmark.worker_coordinator.worker_coordinator.execute_single') as execute_mock:
+        with mock.patch('osbenchmark.worker_coordinator.worker_coordinator.execute_single'):
             with mock.patch('asyncio.wait_for') as wait_for_mock:
                 wait_for_mock.return_value = (100, "docs", {"success": True})
 


### PR DESCRIPTION
### Description
Improved Readability and Maintainability of AsyncExecutor's `__call__` Method

The following private helper methods have been introduced to encapsulate distinct parts of the original logic:

*   **`async def _wait_for_rampup(self, rampup_wait_time)`**:
    *   Handles the logic for waiting during the ramp-up phase.
*   **`def _handle_client_state(self, was_paused, client_state, total_start, expected_scheduled_time)`**:
    *   Manages client state adjustments, particularly relevant for redline testing when clients might be paused or resumed.
*   **`async def _prepare_context_manager(self, params)`**:
    *   Determines and prepares the correct context manager for the outgoing request. This includes specific handling for "produce-stream-message" operations (using `MessageProducerFactory`) and "vector-search" operations (adding client and core counts to params).
*   **`async def _execute_request(self, params, expected_scheduled_time, total_start)`**:
    *   Encapsulates the main request execution flow:
        *   Calculates and applies throughput throttling.
        *   Manages request timing (absolute processing start, actual processing start/end).
        *   Invokes `_prepare_context_manager`.
        *   Calls `execute_single` to perform the actual operation.
        *   Initiates error reporting via `_report_error` if a request fails during redline testing.
        *   Returns a dictionary of timing and result data.
*   **`def _report_error(self, request_meta_data)`**:
    *   Handles the logic for sending error information to the `FeedbackActor` via the `error_queue` if an error occurs during redline testing.
*   **`def _process_results(self, result_data, total_start, client_state, percent_completed)`**:
    *   Takes the results from `_execute_request` and:
        *   Calculates various time metrics (service time, client processing time, processing time, latency).
        *   Calls `schedule_handle.after_request`.
        *   Determines task completion status based on runner state and `self.complete` flag.
        *   Calculates progress.
        *   Adds samples to `self.sampler` if the client is active.
        *   Returns the completion status.
*   **`async def _cleanup(self)`**:
    *   Manages the cleanup of resources after the main loop, specifically stopping the `message_producer` if it was used.

### Issues Resolved
* #842 

### Testing
I've ran redline testing to ensure that method still works

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
