### PR TITLE
Revise Docker Build Post PR Releases

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -1,4 +1,4 @@
-name: Docker Build
+name: Docker Push Release
 on:
   push:
     branches:
@@ -12,9 +12,6 @@ jobs:
   docker:
     if: github.repository == 'opensearch-project/opensearch-benchmark'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: ['linux/amd64', 'linux/arm64']
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -49,10 +46,10 @@ jobs:
           username: ${{ secrets.BENCHMARK_DOCKERHUB_USERNAME }}
           password: ${{ steps.retrieve-password.outputs.dockerhub-password }}
 
-      - name: Docker Build ${{ matrix.platform }}
+      - name: Docker Build Multi-Platform
         run: |
             docker buildx version
-            tag=osb-`echo ${{ matrix.platform }} | tr '/' '-'`
+            tag=osb-latest-development
             set -x
-            docker buildx build --platform ${{ matrix.platform }} --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
+            docker buildx build  --platform linux/amd64,linux/arm64 --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
             set +x

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Docker Build Multi-Platform
         run: |
             docker buildx version
-            tag=latest-main
+            tag=main-latest
             set -x
             docker buildx build  --platform linux/amd64,linux/arm64 --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
             set +x

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Docker Build Multi-Platform
         run: |
             docker buildx version
-            tag=osb-latest-development
+            tag=latest-main
             set -x
             docker buildx build  --platform linux/amd64,linux/arm64 --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
             set +x


### PR DESCRIPTION
### Description
After each PR is merged in, Github Actions is run to release a new development version of OSB. The Github Actions workflow currently produces two images with different architectures (ARM64 and AMD64). To make it easy to copy-over to OSB's production Dockerhub repository, we should produce a single multi-platform image. 

This PR streamlines the current docker-push-release workflow by:
- Revising it to produce a single image containing both ARM64 and AMD64 architectures
- Revising the tag to be `latest-main`
- Renames the workflow to `Docker Push Release` since there are two `Docker Build` Github Action Workflows which can be confusing to users. The other `Docker Build` workflow is related to `docker-build.yml`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
