### PR TITLE
Updates to Redline Testing

### DIFF
--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -301,7 +301,7 @@ class FeedbackActor(actor.BenchmarkActor):
         )
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
-        print("Redline test finished. Maximum stable client number reached: %d" % self.max_error_threshold)
+        print("Redline test finished. Maximum stable client number reached: %d" % self.total_active_client_count)
         self.logger.info("FeedbackActor received ActorExitRequest and will shutdown")
         if hasattr(self, 'shared_client_states'):
             self.shared_client_states.clear()
@@ -2018,7 +2018,6 @@ class AsyncExecutor:
                 # Execute with the appropriate context manager
                 async with context_manager as request_context:
                     if self.redline_enabled:
-                        all_client_options = self.cfg.opts("client", "options").all_client_options
                         request_start, request_end, client_request_start, client_request_end, \
                         request_meta_data, total_ops, total_ops_unit = await self.handle_redline(runner, params, client_state, request_context)
                     else:
@@ -2130,7 +2129,7 @@ class AsyncExecutor:
                 }
                 self.report_error(error_info)
         return request_start, request_end, client_request_start, client_request_end, request_meta_data, total_ops, total_ops_unit
-    
+
     async def handle_benchmark(self, runner, params, request_context):
         total_ops, total_ops_unit, request_meta_data = await execute_single(runner,
                                                                             opensearch=self.opensearch,
@@ -2156,7 +2155,6 @@ async def execute_single(runner, opensearch, params, on_error, redline_enabled=F
     # pylint: disable=import-outside-toplevel
     import opensearchpy
     fatal_error = False
-    before = time.perf_counter()
     if client_enabled:
         try:
             async with runner:
@@ -2233,7 +2231,6 @@ async def execute_single(runner, opensearch, params, on_error, redline_enabled=F
                         console.error(request_meta_data["error-description"])
                 if not redline_enabled:
                     logging.getLogger(__name__).error(request_meta_data["error-description"])
-        now = time.perf_counter()
     else:
         request_context_holder.on_client_request_start()
         request_context_holder.on_request_start()

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1982,8 +1982,16 @@ class AsyncExecutor:
         if rampup_wait_time:
             self.logger.info("Client id [%s] is running now.", self.client_id)
 
-        # timeout for client requests
-        client_options = self.cfg.opts("client", "options").all_client_options
+        # grab the client options; if user passed no client options then default to empty dict
+        try:
+            if self.cfg is not None:
+                client_options_obj = self.cfg.opts("client", "options")
+                client_options = getattr(client_options_obj, "all_client_options", {}) or {}
+            else:
+                client_options = {}
+        except exceptions.ConfigError:
+            client_options = {}
+
         base_timeout = int(1.5 * client_options.get("default", {}).get("timeout", 30))
 
         self.logger.debug("Entering main loop for client id [%s].", self.client_id)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2147,7 +2147,7 @@ class AsyncExecutor:
 request_context_holder = client.RequestContextHolder()
 
 
-async def execute_single(runner, opensearch, params, on_error, redline_enabled, client_enabled):
+async def execute_single(runner, opensearch, params, on_error, redline_enabled=False, client_enabled=True):
     """
     Invokes the given runner once and provides the runner's return value in a uniform structure.
 

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1935,7 +1935,8 @@ class FeedbackActorTests(TestCase):
 
         self.monkeypatch.setattr(self.actor, "check_for_errors", lambda: [])
 
-        self.actor.handle_state()
+        self.actor.handle_state() # once to set to SCALING_UP
+        self.actor.handle_state() # once to scale up
 
         assert self.actor.state == worker_coordinator.FeedbackState.NEUTRAL
         assert self.actor.total_active_client_count > 0


### PR DESCRIPTION
### Description
Changes a few items related to redline testing:
- Change if/else statements in `handle_state` of the feedback actor so the proper choices are made depending on Actor state
- Removes logic to scale clients down to 0 once a joinpoint is hit
- Adds an 'error threshold', FeedbackActor treats this as a ceiling during redline testing so it does not recklessly scale past this ceiling
- Adds logic to probe past the ceiling during testing: Every interval, if we're at the ceiling, there is a small chance of adding an extra client to probe past it. After 10 intervals, an extra client is added by default. This results in a more careful scale up and more precise max client count
- Request handling in the `AsyncExecutor` class has been abstracted into two separate functions, `handle_redline` and `handle_benchmark`
- A timeout has been added to the call to `execute_single` inside `handle_redline`. This is related to #856 
- `handle_redline` as the name implies, handles all the logic related to redline testing. It calls `execute_single` and handles timed out requests, as well as reporting failed requests to the FeedbackActor.
- `handle_benchmark` sends a normal benchmark request
- `execute_single` has been modified to also take a client_state value. `handle_redline` passes in a ‘True’ value while `handle_benchmark` passes in a ‘False’ value. If the client state is true, it sends a regular benchmark request. Otherwise, it populates a dummy metadata dictionary and essentially sends a ‘no-op’ to continue OSB’s schedule. 

### Issues Resolved
#856 
### Testing
- [x] New functionality includes testing
Redline test against a 3.0 cluster with a 15 second request timeout:
```
|                                                 Min Throughput | keyword-terms |        7.89 |  ops/s |
|                                                Mean Throughput | keyword-terms |       82.29 |  ops/s |
|                                              Median Throughput | keyword-terms |       84.36 |  ops/s |
|                                                 Max Throughput | keyword-terms |       85.91 |  ops/s |
|                                        50th percentile latency | keyword-terms |      246387 |     ms |
|                                        90th percentile latency | keyword-terms |      486953 |     ms |
|                                        99th percentile latency | keyword-terms |      564489 |     ms |
|                                      99.9th percentile latency | keyword-terms |      594356 |     ms |
|                                     99.99th percentile latency | keyword-terms |      599719 |     ms |
|                                       100th percentile latency | keyword-terms |      603099 |     ms |
|                                   50th percentile service time | keyword-terms |     7050.62 |     ms |
|                                   90th percentile service time | keyword-terms |     12557.2 |     ms |
|                                   99th percentile service time | keyword-terms |     15220.2 |     ms |
|                                 99.9th percentile service time | keyword-terms |     15752.9 |     ms |
|                                99.99th percentile service time | keyword-terms |     15861.1 |     ms |
|                                  100th percentile service time | keyword-terms |     15991.9 |     ms |
|                                                     error rate | keyword-terms |        0.61 |      % |

[WARNING] Error rate is 0.61 for operation 'keyword-terms'. Please check the logs.
Redline test finished. Maximum stable client number reached: 663
```
Normal benchmark against the same cluster with 663 clients/throughput:
```
|                                                 Min Throughput | keyword-terms |        0.09 |  ops/s |
|                                                Mean Throughput | keyword-terms |       80.71 |  ops/s |
|                                              Median Throughput | keyword-terms |       82.52 |  ops/s |
|                                                 Max Throughput | keyword-terms |       83.45 |  ops/s |
|                                        50th percentile latency | keyword-terms |      260770 |     ms |
|                                        90th percentile latency | keyword-terms |      469572 |     ms |
|                                        99th percentile latency | keyword-terms |      542089 |     ms |
|                                      99.9th percentile latency | keyword-terms |      557170 |     ms |
|                                     99.99th percentile latency | keyword-terms |      557262 |     ms |
|                                       100th percentile latency | keyword-terms |      557272 |     ms |
|                                   50th percentile service time | keyword-terms |     7925.52 |     ms |
|                                   90th percentile service time | keyword-terms |     11773.1 |     ms |
|                                   99th percentile service time | keyword-terms |     12187.8 |     ms |
|                                 99.9th percentile service time | keyword-terms |       13085 |     ms |
|                                99.99th percentile service time | keyword-terms |     13722.7 |     ms |
|                                  100th percentile service time | keyword-terms |     13765.2 |     ms |
|                                                     error rate | keyword-terms |           0 |      % |
```
Normal benchmark with 50 clients/throughput:
```
|                                                 Min Throughput | keyword-terms |       31.33 |  ops/s |
|                                                Mean Throughput | keyword-terms |       49.68 |  ops/s |
|                                              Median Throughput | keyword-terms |        49.9 |  ops/s |
|                                                 Max Throughput | keyword-terms |       49.95 |  ops/s |
|                                        50th percentile latency | keyword-terms |     561.834 |     ms |
|                                        90th percentile latency | keyword-terms |     674.205 |     ms |
|                                        99th percentile latency | keyword-terms |     748.767 |     ms |
|                                      99.9th percentile latency | keyword-terms |     803.109 |     ms |
|                                     99.99th percentile latency | keyword-terms |      901.93 |     ms |
|                                       100th percentile latency | keyword-terms |     918.753 |     ms |
|                                   50th percentile service time | keyword-terms |     559.671 |     ms |
|                                   90th percentile service time | keyword-terms |     671.373 |     ms |
|                                   99th percentile service time | keyword-terms |     746.237 |     ms |
|                                 99.9th percentile service time | keyword-terms |     800.623 |     ms |
|                                99.99th percentile service time | keyword-terms |      901.93 |     ms |
|                                  100th percentile service time | keyword-terms |     918.753 |     ms |
|                                                     error rate | keyword-terms |           0 |      % |
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
