### PR TITLE
Fix help text bug for execute-test subcommand

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -677,7 +677,7 @@ def create_arg_parser():
     test_execution_parser.add_argument(
         "--redline-scaledown-percentage",
         type=float,
-        help="What percentage of clients to remove when errors occur (default: 10%).",
+        help="What percentage of clients to remove when errors occur (default: 10%%).",
         default=ConfigureFeedbackScaling.DEFAULT_SCALEDOWN_PCT
     )
     test_execution_parser.add_argument(


### PR DESCRIPTION
### Description
There's a bug in `--redline-scaledown-percentage` parameter option. Argparse thinks the help text needs to be formatted because there's a single `%` character. To tell Argparse to display the character, we need two of them.

### Issues Resolved
#855 

### Testing
- [x] New functionality includes testing
Tested with and without the change. Output shows up now when the change is present.
```
  --redline-scaledown-percentage REDLINE_SCALEDOWN_PERCENTAGE
                        What percentage of clients to remove when errors occur (default: 10%).
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
