### PR TITLE
Update RELEASE_GUIDE.md to reflect latest release process and update `main-latest` to `dev`

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Docker Build Multi-Platform
         run: |
             docker buildx version
-            tag=main-latest
+            tag=dev
             set -x
             docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=`cat version.txt` --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f docker/Dockerfile -t opensearchstaging/opensearch-benchmark:"$tag" --push .
             set +x

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -93,9 +93,9 @@ git checkout <VERSION BRANCH>
 - Verify that the created image with the tag `<VERSION>` shares the same compressed sizes as the `dev` image.
 
 
-9. **Trigger Docker Hub Promote workflow:** Run `Docker Promote` workflow on the image created from the previous step.
+9. **Trigger docker-promotion workflow:** Run `docker-promotion` workflow on the image created from the previous step.
 - This workflow will take the image created in the previous step and promotes it to to both Docker Hub prod account and ECR.
-- Running `Docker Promote` workflow will automatically trigger four `copy-over` workflows:
+- Running `docker-promotion` workflow will automatically trigger four `copy-over` workflows:
         1. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:<VERSION>
         2. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:latest
         3. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:<VERSION>

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -81,26 +81,25 @@ git checkout <VERSION BRANCH>
     6. Run a basic workload on Linux and MacOS:  `opensearch-benchmark execute-test --workload pmc --test-mode`
     7. If you are fastidious, you can check the installed source files at `` `python3 -m site --user-site`/osbenchmark `` to verify that a recent change is indeed present.
 
-7. **Verify Docker Hub Staging OSB Image Works:** Revisit and test out the latest `dev` image.
+7. **Verify Docker Hub staging OSB dev image works:** Revisit and test out the latest `dev` image.
     1. The staging images are at https://hub.docker.com/r/opensearchstaging/opensearch-benchmark/tags.
     2. Pull the latest image: `docker pull opensearchstaging/opensearch-benchmark:dev`
     3. Check the version of OSB: `docker run opensearchstaging/opensearch-benchmark:dev —version`
     4. Run any other commands listed on the Docker Hub overview tab.
 
-8. **Trigger Docker Hub Copy-Over:** Contact the oncall managing OpenSearch repositories and request a copy-over.
-- After confirming that the `dev` image contains the latest changes and latest version, we can copy over this image to an image with the `<VERSION>` tag.
-- For example, if we are releasing `1.4.0`, ask the oncall to run the following workfow: repository: opensearchstaging, image: opensearch-benchmark:dev → repository: opensearchstaging, image: opensearch-benchmark:<VERSION>
+8. **Trigger Docker Hub copy-over workflow:** Contact the oncall managing OpenSearch repositories and request a `copy-over` workflow.After confirming that the `dev` image in Doker Hub staging repository contains the latest changes and latest version, we can copy over this image to an image with the `<VERSION>` tag in the same repository.
+    - For example, if we are releasing `1.4.0`, ask the oncall to run the following workfow: repository: opensearchstaging, image: opensearch-benchmark:dev → repository: opensearchstaging, image: opensearch-benchmark:<VERSION>
 - The reason this is done because `dev` is the image with the latest changes from `main`, which should also be the latest changes from the version branch we created earlier.
 - Verify that the created image with the tag `<VERSION>` shares the same compressed sizes as the `dev` image.
 
 
-9. **Trigger Docker Hub Promotion:** Run `Docker Promotion` workflow on the image created from the previous step.
-- This should  Docker Hub Staging to Docker Hub Production and ECR: Once you have verified that PyPI and Docker Hub staging image (latest image with `dev` tag) works, contact Admin team member. Admin team member will help initiate `Docker Promotion` workflow, where Jenkins copies the Docker image from Docker Hub staging account to both Docker Hub prod account and ECR.
-- Running `Docker Promotion` workflow will automatically trigger four `copy-over` workflows:
+9. **Trigger Docker Hub Promote workflow:** Run `Docker Promote` workflow on the image created from the previous step.
+- This workflow will take the image created in the previous step and promotes it to to both Docker Hub prod account and ECR.
+- Running `Docker Promote` workflow will automatically trigger four `copy-over` workflows:
         1. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:<VERSION>
         2. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:latest
-        3. repository: public.ecr.aws/opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:<VERSION>
-        4. repository: public.ecr.aws/opensearchstaging, image: opensearch-benchmark:latest → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:latest
+        3. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:<VERSION>
+        4. repository: opensearchstaging, image: opensearch-benchmark:latest → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:latest
 
 10. **Verify release draft and that Dockerhub Production and ECR Production have newest tags:**
     1. Check that the version appears in GitHub (https://github.com/opensearch-project/opensearch-benchmark/releases) and is marked as the “latest” release.  There should be an associated changelog as well.  Clicking on the “Tags” tab should indicate the version number is one of the project’s tags and its timestamp should match that of the last commit.  If there was an error that prevented the release from being published, but this was fixed manually, click on the edit button (pencil icon) next to the release.  This will provide options to generate the release notes, publish the release and label it as the "latest" one.

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -43,31 +43,36 @@ Add backport labels to PRs and commits so that changes can be added to `main` br
 * Since releases are generally published on Thursdays, maintainers should try to ensure all changes are merged in by Tuesday.
 * A week prior to the scheduled release, maintainers should announce the fact in the [#performance channel](https://opensearch.slack.com/archives/C0516H8EJ7R) within the OpenSearch Slack community.
 * Ensure that documentation is appropriately updated with respect to incoming changes prior to the release.
-  
+
 ## Release the new version of OpenSearch Benchmark to PyPI, Docker, and ECR
 
-1. Clone the official OpenSearch Benchmark git repository and change directory to it.  This is where the following commands will be issued.
+1. **Update version.txt in main:** In mainline, open up a new PR to update `version.txt` to match the newest version and merge it into mainline.
+- For example, if OSB is currently at version `1.3.0` and we want to release the next version as `1.4.0`, update `version.txt` from `1.3.0` to `1.4.0`. Once it's been merged into mainline, double-check that the image tagged with `dev` in opensearchstaging/opensearch-benchmark has been updated recently. Once
+- If we are doing a patch release, visit the feature branch and update the `version.txt` to reflect the new patch release.
 
-2. Ensure that version.txt matches the new release version before proceeding. If not, open a PR that updates the version in version.txt and merge it in before proceeding with the following steps. For example, if OSB is currently at version `1.3.0` and we want to release the next version as `1.4.0`, update `version.txt` from `1.3.0` to `1.4.0`.
+2. **Create version branch:** Releases are published from a version branch, not directly from `main`. Maintainers should create a new branch that is based off of `main`. This can be done easily through the official repository's Github UI.
+- In the above example, we would create the `1.4` branch and switch to it.  For patch releases, such as `1.3.1`, the `1.3` branch will already exist and does not need to be created.
 
-3. Releases are published from a version branch, not directly from `main`.  In the above example, we would create the `1.4` branch and switch to it.  For patch releases, such as `1.3.1`, the `1.3` branch will already exist and does not need to be created.
-
-4. Create a tag for the `1.4.0` release.
+3. **Check out version branch locally:** If you haven't already, clone the official OpenSearch Benchmark git repository and change directory to it. Fetch the latest changes and the version branch you just created.
 ```
+git fetch origin
+git checkout <VERSION BRANCH>
+```
+
+4. **Create and push tag:** From the command-line, create and push a tag to the version branch.
+- This starts a Github Actions workflow and creates an automated issue in the OSB repository. The issue needs to be commented on by a maintainer of the repository for the release process to proceed.
+- The Github ACtions workflow uploads OSB to PyPI.
+```
+    # Create tag
     git tag 1.4.0 1.4
-```
 
-5. Push the tag.  This starts a workflow in Jenkins and creates an automated issue in the OSB repository. The issue needs to be commented on by a maintainer of the repository for the release process to proceed.  The workflow uploads OSB to PyPI and OSB Docker Hub Staging account. Once the workflows are finished publishing OSB to PyPI and OSB Docker Hub staging account, the maintainer who pushed the tag should visit both PyPI and Docker Hub staging to perform the following steps to verify that the artifacts have been properly uploaded.
-
-```
+    # Push tag
     git push origin 1.4.0
 ```
 
-6. Check the progress of release here in the Jenkins console:: https://build.ci.opensearch.org/job/opensearch-benchmark-release/
-    1. For a more detailed look at what's happening, you can take the Build ID (which is the number highlighted in blue beneath "Stage View") and substitute it into this URL: https://build.ci.opensearch.org/blue/organizations/jenkins/opensearch-benchmark-release/detail/opensearch-benchmark-release/<Build ID>/pipeline/
-     2. If failed, inspect the logs.
+5. **Track PyPi Release:** Visit `Actions` tab in official OSB repositroy, click `Publish Release to GitHub` on the left side menu, and click the latest action that is running to track the progress of the release.
 
-7. Verify PyPI:
+6. **Verify PyPi Release** Once the release has completed.
     1. Download the OSB distribution build from PyPI: https://pypi.org/project/opensearch-benchmark/#files.  This is a `wheel` file with the extension `.whl`.
     2. Install it with `pip install`.
     3. Run `opensearch-benchmark --version` to ensure that it is the correct version
@@ -76,25 +81,33 @@ Add backport labels to PRs and commits so that changes can be added to `main` br
     6. Run a basic workload on Linux and MacOS:  `opensearch-benchmark execute-test --workload pmc --test-mode`
     7. If you are fastidious, you can check the installed source files at `` `python3 -m site --user-site`/osbenchmark `` to verify that a recent change is indeed present.
 
-8. Verify Docker Hub Staging OSB Image Works:
+7. **Verify Docker Hub Staging OSB Image Works:** Revisit and test out the latest `dev` image.
     1. The staging images are at https://hub.docker.com/r/opensearchstaging/opensearch-benchmark/tags.
-    2. Pull the latest image: `docker pull opensearchstaging/opensearch-benchmark:<VERSION>`
-    3. Check the version of OSB: `docker run opensearchstaging/opensearch-benchmark:<VERSION> —version`
+    2. Pull the latest image: `docker pull opensearchstaging/opensearch-benchmark:dev`
+    3. Check the version of OSB: `docker run opensearchstaging/opensearch-benchmark:dev —version`
     4. Run any other commands listed on the Docker Hub overview tab.
 
-9. Copy over the image from Docker Hub Staging to Docker Hub Production and ECR: Once you have verified that PyPI and Docker Hub staging image works, contact Admin team member. Admin team member will help promote the “copy-over” workflow, where Jenkins copies the Docker image from Docker Hub staging account to both Docker Hub prod account and ECR.
-    1. Admin will need to invoke the copy-over four times:
+8. **Trigger Docker Hub Copy-Over:** Contact the oncall managing OpenSearch repositories and request a copy-over.
+- After confirming that the `dev` image contains the latest changes and latest version, we can copy over this image to an image with the `<VERSION>` tag.
+- For example, if we are releasing `1.4.0`, ask the oncall to run the following workfow: repository: opensearchstaging, image: opensearch-benchmark:dev → repository: opensearchstaging, image: opensearch-benchmark:<VERSION>
+- The reason this is done because `dev` is the image with the latest changes from `main`, which should also be the latest changes from the version branch we created earlier.
+- Verify that the created image with the tag `<VERSION>` shares the same compressed sizes as the `dev` image.
+
+
+9. **Trigger Docker Hub Promotion:** Run `Docker Promotion` workflow on the image created from the previous step.
+- This should  Docker Hub Staging to Docker Hub Production and ECR: Once you have verified that PyPI and Docker Hub staging image (latest image with `dev` tag) works, contact Admin team member. Admin team member will help initiate `Docker Promotion` workflow, where Jenkins copies the Docker image from Docker Hub staging account to both Docker Hub prod account and ECR.
+- Running `Docker Promotion` workflow will automatically trigger four `copy-over` workflows:
         1. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:<VERSION>
         2. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: opensearchproject, image: opensearch-benchmark:latest
-        3. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:<VERSION>
-        4. repository: opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:latest
+        3. repository: public.ecr.aws/opensearchstaging, image: opensearch-benchmark:<VERSION> → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:<VERSION>
+        4. repository: public.ecr.aws/opensearchstaging, image: opensearch-benchmark:latest → repository: public.ecr.aws/opensearchproject, image: opensearch-benchmark:latest
 
-10. See if OpenSearch-Benchmark Tags is Published:
+10. **Verify release draft and that Dockerhub Production and ECR Production have newest tags:**
     1. Check that the version appears in GitHub (https://github.com/opensearch-project/opensearch-benchmark/releases) and is marked as the “latest” release.  There should be an associated changelog as well.  Clicking on the “Tags” tab should indicate the version number is one of the project’s tags and its timestamp should match that of the last commit.  If there was an error that prevented the release from being published, but this was fixed manually, click on the edit button (pencil icon) next to the release.  This will provide options to generate the release notes, publish the release and label it as the "latest" one.
     2. Check Docker Hub Production: https://hub.docker.com/r/opensearchproject/opensearch-benchmark.  Both “latest” and the published release should appear on the page along with the appropriate publication timestamp.
     3. Check ECR: https://gallery.ecr.aws/opensearchproject/opensearch-benchmark.  The dropdown box at the top should list both “latest” and the published release as entries.  The publication time is also indicated.
 
-11. Notify the Community: Create a message that introduces the newly released OpenSearch Benchmark version and includes a brief summary of changes, enhanacements, and bug fixes in the new version. The message may look something like the following:
+11. **Notify the Community:** Create a message that introduces the newly released OpenSearch Benchmark version and includes a brief summary of changes, enhanacements, and bug fixes in the new version. The message may look something like the following:
 ```
 @here OpenSearch Benchmark (OSB) 1.2.0 has just been released!
 
@@ -110,20 +123,13 @@ Wow! Where can I get this?
 Send this message in the following channels in OpenSearch Community Slack:
 * [#performance](https://opensearch.slack.com/archives/C0516H8EJ7R)
 
-
-12. Ensure that we backport changes to other version branches as needed. See the guide for more information.
-    1. Unless you released a major version, update main branch’s `version.txt` to the next minor version. For instance, if `1.1.0` was just released, the file in the `main` branch should be updated to `1.2.0`.
-    2. Update the `version.txt` in the branch for the version that was just released with the current version but patch version incremented. For instance, if 1.1.0 was just released, the file in the `1.1` branch should be updated to `1.1.1`.
-    3. Previous minor version is now stale
-    4. For patch releases only: Ensure that the `main` branch will not need to have its version.txt updated since it's already pointing to the nexts major version. However, the branch with the major and minor version should have its `version.txt` file updated. For example, if `1.3.1` patch was just released, we'll need to visit the `1.3` branch and update the `version.txt` file to now point to `1.3.2`. However, we won't need to update `version.txt` in `main` branch since it's already pointing to the next minor release, i.e. `1.4.0`.
-
 ## Error Handling
 
 ### Restarting the Release Process after an Error
 
 If an error occurs during build process and you need to retrigger the workflow, do the following:
 
-* Delete the tag locally: `git tag -d <VERSION>` 
+* Delete the tag locally: `git tag -d <VERSION>`
 * Delete the tag on GitHub: `git push --delete origin <VERSION>`
 * Delete the draft release on GitHub
 * Create the tag again and push it to re-initiate the release process.

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -61,7 +61,7 @@ git checkout <VERSION BRANCH>
 
 4. **Create and push tag:** From the command-line, create and push a tag to the version branch.
 - This starts a Github Actions workflow and creates an automated issue in the OSB repository. The issue needs to be commented on by a maintainer of the repository for the release process to proceed.
-- The Github ACtions workflow uploads OSB to PyPI.
+- The Github Actions workflow uploads OSB to PyPI.
 ```
     # Create tag
     git tag 1.4.0 1.4


### PR DESCRIPTION
### Description
OSB's release process has been updated to use Github Actions to release to PyPi and Dockerhub staging repository. This PR updates RELEASE_GUIDE.md to reflect our latest release process. 

Have also updated Dockerhub Push Release workflow to release to `dev` tag instead of `main-latest`

After this gets merged in, we should request admin to remove `latest` tag and `main-latest` in Dockerhub staging repository for OSB to avoid confusion.  

Note: We do not need to release to ECR staging. `docker-promotion` triggers 4 `copy-over` workflows that copy the image created in staging over to two image tags in Dockerhub prod and two image tags in ECR prod.

### Testing
- Tested with new release of 1.14.0 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
