### PR TITLE
Introduce CPU-based Feedback for Redline Testing

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -692,6 +692,12 @@ def create_arg_parser():
         help="Maximum number of clients to allow during redline testing. If not set, will default to clients defined in the test procedure.",
         default=None
     )
+    test_execution_parser.add_argument(
+        "--redline-max-cpu-usage",
+        type=int,
+        help="Maximum CPU utilization before scaling back client numbers",
+        default=None
+    )
 
     ###############################################################################
     #
@@ -985,6 +991,7 @@ def configure_test(arg_parser, args, cfg):
         cfg.add(config.Scope.applicationOverride, "workload", "redline.scale_down_pct", args.redline_scaledown_percentage)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.sleep_seconds", args.redline_post_scaledown_sleep)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.max_clients", args.redline_max_clients)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.max_cpu_usage", args.redline_max_cpu_usage)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -809,7 +809,7 @@ def execute_test(cfg, kill_running_processes=False):
     # redline testing: check metrics store type before running cpu based feedback test
     cpu_max = cfg.opts("workload", "redline.max_cpu_usage", default_value=None)
     if cpu_max is not None:
-        store = metrics.metrics_store(cfg, workload="dummy", test_procedure="dummy", read_only=False)
+        store = metrics.metrics_store(cfg, read_only=False)
         try:
             if isinstance(store, metrics.InMemoryMetricsStore):
                 raise exceptions.SystemSetupError(

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -806,6 +806,19 @@ def execute_test(cfg, kill_running_processes=False):
                   f"Otherwise, you need to manually kill them."
             raise exceptions.BenchmarkError(msg)
 
+    # redline testing: check metrics store type before running cpu based feedback test
+    cpu_max = cfg.opts("workload", "redline.max_cpu_usage", default_value=None)
+    if cpu_max is not None:
+        store = metrics.metrics_store(cfg, workload="dummy", test_procedure="dummy", read_only=False)
+        try:
+            if isinstance(store, metrics.InMemoryMetricsStore):
+                raise exceptions.SystemSetupError(
+                    "CPU-based feedback requires a metrics store, but you're using the in-memory store. "
+                    "Specify a metrics store in your benchmark.ini or via CLI to continue."
+                )
+        finally:
+            store.close()
+
     with_actor_system(test_execution_orchestrator.run, cfg)
 
 

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -695,8 +695,20 @@ def create_arg_parser():
     test_execution_parser.add_argument(
         "--redline-max-cpu-usage",
         type=int,
-        help="Maximum CPU utilization before scaling back client numbers",
+        help="Maximum CPU utilization before scaling back client numbers. Used to activate CPU-based feedback in OSB.",
         default=None
+    )
+    test_execution_parser.add_argument(
+        "--redline-cpu-window-seconds",
+        type=int,
+        help="How many seconds the window for average CPU load should be in seconds during CPU-based redline testing. (Default: 30)",
+        default=ConfigureFeedbackScaling.DEFAULT_CPU_WINDOW_SECONDS
+    )
+    test_execution_parser.add_argument(
+        "--redline-cpu-check-interval",
+        type=int,
+        help="How many seconds between CPU checks there should be during CPU-based redline testing. (Default: 30)",
+        default=ConfigureFeedbackScaling.DEFAULT_CPU_CHECK_INTERVAL
     )
 
     ###############################################################################
@@ -992,6 +1004,8 @@ def configure_test(arg_parser, args, cfg):
         cfg.add(config.Scope.applicationOverride, "workload", "redline.sleep_seconds", args.redline_post_scaledown_sleep)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.max_clients", args.redline_max_clients)
         cfg.add(config.Scope.applicationOverride, "workload", "redline.max_cpu_usage", args.redline_max_cpu_usage)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.cpu_window_seconds", args.redline_cpu_window_seconds)
+        cfg.add(config.Scope.applicationOverride, "workload", "redline.cpu_check_interval", args.redline_cpu_check_interval)
     cfg.add(config.Scope.applicationOverride, "workload", "latency.percentiles", args.latency_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", args.throughput_percentiles)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.enabled", args.randomization_enabled)

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1088,6 +1088,14 @@ class OsMetricsStore(MetricsStore):
         # no need for an externalizable representation - stores everything directly
         return None
 
+    @property
+    def index(self) -> str:
+        return self._index
+
+    @property
+    def test_execution_id(self) -> str:
+        return self._test_execution_id
+
     def __str__(self):
         return "OpenSearch metrics store"
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -529,7 +529,7 @@ class FeedbackActor(actor.BenchmarkActor):
         }
         resp = self.os_client.search(index=self.metrics_index, body=body)
         buckets = resp['aggregations']['nodes']['buckets']
-        if len(buckets):
+        if buckets:
             for bucket in buckets:
                 self.logger.info("Node %s avg CPU=%.1f%% > threshold %.1f%%", bucket['key'], bucket['avg_cpu']['value'], self.max_cpu_threshold)
                 try:
@@ -1088,14 +1088,14 @@ class WorkerCoordinator:
             test_execution_id = None
             # we must have a metrics store connected for CPU based feedback
             cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None)
-            if cpu_max and type(self.metrics_store) == metrics.InMemoryMetricsStore:
+            if cpu_max and isinstance(self.metrics_store, metrics.InMemoryMetricsStore):
                 raise exceptions.SystemSetupError("CPU-based feedback requires a metrics store. You are using an in-memory metrics store")
             elif cpu_max and 'node-stats' not in self.config.opts("telemetry", "devices"):
                 raise exceptions.SystemSetupError("Node stats not enabled. You must use `--telemetry node-stats` flag for CPU-based feedback")
-            elif cpu_max and type(self.metrics_store) == metrics.OsMetricsStore:
+            elif cpu_max and isinstance(self.metrics_store, metrics.OsMetricsStore):
                 # pass over the index and test execution ID so the feedbackActor can query the datastore
-                metrics_index = self.metrics_store._index
-                test_execution_id = self.metrics_store._test_execution_id
+                metrics_index = self.metrics_store.index
+                test_execution_id = self.metrics_store.test_execution_id
 
             scale_step = self.config.opts("workload", "redline.scale_step", default_value=5)
             scale_down_pct = self.config.opts("workload", "redline.scale_down_pct", default_value=0.10)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -998,7 +998,7 @@ class WorkerCoordinator:
         else:
             self.wait_for_rest_api(os_clients)
             self.target.on_cluster_details_retrieved(self.retrieve_cluster_info(os_clients))
-        
+
         # Redline testing: Check if cpu feedback is enabled. Enable the node-stats telemetry device if we need to
         cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=[])
         if cpu_max:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -209,11 +209,16 @@ class ConfigureFeedbackScaling:
     DEFAULT_SCALE_STEP = 5
     DEFAULT_SCALEDOWN_PCT = 0.10
 
-    def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None):
+    def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None, cpu_max=None,
+                metrics_index=None, test_execution_id=None, cfg=None):
         self.scale_step = scale_step if scale_step is not None else self.DEFAULT_SCALE_STEP
         self.scale_down_pct = scale_down_pct if scale_down_pct is not None else self.DEFAULT_SCALEDOWN_PCT
         self.sleep_seconds = sleep_seconds if sleep_seconds is not None else self.DEFAULT_SLEEP_SECONDS
         self.max_clients = max_clients
+        self.cpu_max=cpu_max
+        self.cfg=cfg
+        self.metrics_index=metrics_index
+        self.test_execution_id=test_execution_id
 
 class EnableFeedbackScaling:
     pass
@@ -262,6 +267,13 @@ class FeedbackActor(actor.BenchmarkActor):
         self.probe_probability = 0.05
         self.probe_interval = 10
         self._cycles_since_probe = 0
+        # for cpu based feedback
+        self.last_cpu_check = time.perf_counter()
+        self.max_cpu_threshold = None
+        # client, index, and test execution ID for querying
+        self.os_client = None
+        self.metrics_index = None
+        self.test_execution_id=None
 
     def receiveMsg_StartFeedbackActor(self, msg, sender) -> None:
         """
@@ -295,6 +307,15 @@ class FeedbackActor(actor.BenchmarkActor):
         self.num_clients_to_scale_up = msg.scale_step
         self.percentage_clients_to_scale_down = msg.scale_down_pct
         self.POST_SCALEDOWN_SECONDS = msg.sleep_seconds
+        # CPU feedback related items
+        self.max_cpu_threshold = msg.cpu_max
+        self.test_execution_id=msg.test_execution_id
+        self.cfg=msg.cfg
+        self.metrics_index = msg.metrics_index
+        if self.max_cpu_threshold:
+            # create a new client to query the datastore for CPU based feedback
+            # we can't pass the original metrics_store object from the WorkerCoordinator since it can't be pickled in a thespianpy message
+            self.os_client = metrics.OsClientFactory(self.cfg).create()
         self.logger.info(
         "Feedback actor has received the following configuration: Max clients = %s, scale step = %d, scale down percentage = %f, sleep time = %d",
         self.total_client_count, self.num_clients_to_scale_up, self.percentage_clients_to_scale_down, self.POST_SCALEDOWN_SECONDS
@@ -332,6 +353,10 @@ class FeedbackActor(actor.BenchmarkActor):
 
     def handle_state(self) -> None:
         current_time = time.perf_counter()
+        # check CPU usage every N seconds
+        if (self.max_cpu_threshold and current_time - self.last_cpu_check >= self.POST_SCALEDOWN_SECONDS):
+            self._check_cpu_usage()
+            self.last_cpu_check = current_time
         errors = self.check_for_errors()
 
         sys.stdout.write("\x1b[s")               # Save cursor position
@@ -454,6 +479,57 @@ class FeedbackActor(actor.BenchmarkActor):
         finally:
             self.last_scaleup_time = time.perf_counter()
             self.state = FeedbackState.NEUTRAL
+
+    def _check_cpu_usage(self):
+        """
+        Grab the average CPU load per-node in the past N seconds
+        If any exceed the threshold given, report to the error queue
+        """
+        body = {
+            "size": 0,
+            "query": {
+                "bool": {
+                "filter": [
+                    { "term":  { "name": "node-stats" }},
+                    { "term":  { "test-execution-id": self.test_execution_id }},
+                    { "range": { "@timestamp": { "gte": "now-30s", "lte": "now" }}}
+                ]
+                }
+            },
+            "aggs": {
+                "nodes": {
+                "terms": {
+                    "field": "meta.node_name",
+                    "size": 1000
+                },
+                "aggs": {
+                    "avg_cpu": {
+                    "avg": { "field": "process_cpu_percent" }
+                    },
+                    "hot_node_filter": {
+                    "bucket_selector": {
+                        "buckets_path": { "avgCpu": "avg_cpu" },
+                        "script": f"params.avgCpu > {self.max_cpu_threshold}"
+                    }
+                    }
+                }
+                }
+            }
+        }
+        resp = self.os_client.search(index=self.metrics_index, body=body)
+        buckets = resp['aggregations']['nodes']['buckets']
+        if len(buckets):
+            for bucket in buckets:
+                self.logger.info("Node %s avg CPU=%.1f%% > threshold %.1f%%", bucket['key'], bucket['avg_cpu']['value'], self.max_cpu_threshold)
+                try:
+                    self.error_queue.put_nowait({
+                        "type":       "cpu_threshold_exceeded",
+                        "node_name":  bucket['key'],
+                        "value":      bucket['avg_cpu']['value']
+                    })
+                except queue.Full:
+                    self.logger.warning("Error queue full; dropping cpu_threshold_exceeded for node %s", bucket['key'])
+                break # we only need one error message to trigger a scaledown
 
 class WorkerCoordinatorActor(actor.BenchmarkActor):
     RESET_RELATIVE_TIME_MARKER = "reset_relative_time"
@@ -997,6 +1073,16 @@ class WorkerCoordinator:
                     self.workers.append(worker)
                     worker_id += 1
         if redline_enabled:
+            metrics_index = None
+            test_execution_id = None
+            # we must have a metrics store connected for CPU based feedback
+            cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None)
+            if cpu_max and type(self.metrics_store) == metrics.InMemoryMetricsStore:
+                raise exceptions.SystemSetupError("CPU-based feedback requires a metrics store. You are using an in-memory metrics store")
+            elif cpu_max and type(self.metrics_store) == metrics.OsMetricsStore:
+                # pass over the index and test execution ID so the feedbackActor can query the datastore
+                metrics_index = self.metrics_store._index
+                test_execution_id = self.metrics_store._test_execution_id
             scale_step = self.config.opts("workload", "redline.scale_step", default_value=5)
             scale_down_pct = self.config.opts("workload", "redline.scale_down_pct", default_value=0.10)
             sleep_seconds = self.config.opts("workload", "redline.sleep_seconds", default_value=30)
@@ -1004,7 +1090,11 @@ class WorkerCoordinator:
             scale_step=scale_step,
             scale_down_pct=scale_down_pct,
             sleep_seconds=sleep_seconds,
-            max_clients=max_clients
+            max_clients=max_clients,
+            cpu_max=cpu_max,
+            cfg=self.config,
+            metrics_index=metrics_index,
+            test_execution_id=test_execution_id
             ))
             self.target.start_feedbackActor(self.shared_client_dict)
 

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -104,6 +104,7 @@ class WorkerCoordinatorTests(TestCase):
         self.cfg.add(config.Scope.application, "workload", "test_procedure.name", "default")
         self.cfg.add(config.Scope.application, "workload", "params", {})
         self.cfg.add(config.Scope.application, "workload", "test.mode.enabled", True)
+        self.cfg.add(config.Scope.applicationOverride, "workload", "test_procedure.name", "default")
         self.cfg.add(config.Scope.application, "telemetry", "devices", [])
         self.cfg.add(config.Scope.application, "telemetry", "params", {"ccr-stats-indices": {"default": ["leader_index"]}})
         self.cfg.add(config.Scope.application, "builder", "provision_config_instance.names", ["default"])
@@ -113,6 +114,7 @@ class WorkerCoordinatorTests(TestCase):
         self.cfg.add(config.Scope.application, "client", "options", WorkerCoordinatorTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "worker_coordinator", "load_worker_coordinator_hosts", ["localhost"])
         self.cfg.add(config.Scope.application, "results_publishing", "datastore.type", "in-memory")
+        self.cfg.add(config.Scope.applicationOverride, "workload", "redline.max_cpu_usage", None)
 
         default_test_procedure = workload.TestProcedure("default", default=True, schedule=[
             workload.Task(name="index", operation=workload.Operation("index", operation_type=workload.OperationType.Bulk), clients=4)
@@ -1980,7 +1982,7 @@ class FeedbackActorTests(TestCase):
         }
         self.actor.os_client = mock_os_client
 
-        self.actor._check_cpu_usage()
+        self.actor._check_cpu_usage() # pylint: disable=protected-access
 
         assert not self.actor.error_queue.empty()
         error = self.actor.error_queue.get_nowait()
@@ -2005,7 +2007,7 @@ class FeedbackActorTests(TestCase):
         }
         self.actor.os_client = mock_os_client
 
-        self.actor._check_cpu_usage()
+        self.actor._check_cpu_usage() # pylint: disable=protected-access
 
         assert self.actor.error_queue.empty()
 
@@ -2035,5 +2037,5 @@ class FeedbackActorTests(TestCase):
         self.actor.os_client = mock_os_client
 
         # Should not raise
-        self.actor._check_cpu_usage()
+        self.actor._check_cpu_usage() # pylint: disable=protected-access
         assert full_queue.qsize() == 1  # Still full; error dropped


### PR DESCRIPTION
### Description
Introduces CPU-based feedback for redline testing.

Requires the user to have a metrics store, as well as enabling the node-stats telemetry devices.
The lack of either results in test failure:
```
[ERROR] Cannot execute-test. Error in worker_coordinator (CPU-based feedback requires a metrics store. You are using an in-memory metrics store)
```
And
```
[ERROR] Cannot execute-test. Error in worker_coordinator (Node stats not enabled. You must use `--telemetry node-stats` flag for CPU-based feedback)
```

Also requires the use of the `--redline-cpu-max-usage` flag. This flag takes an int and determines the max threshold for the CPU load of any given node during the test.

Additional flags that are not required, include:
`--redline-cpu-window-seconds` - Controls the size of the window from which OSB checks the average load on each individual node in the cluster. Default is 30, so OSB checks the average CPU load per node over the last 30 seconds.
`--redline-cpu-check-interval` - Controls how often the FeedbackActor queries the users’ datastore to check CPU load. Default is 30 as in every 30 seconds.

This feature takes advantage of OSB's node-stats telemetry device and queries the datastore connected to the load generation host every N seconds. It gathers the CPU usage for each node into 'buckets', and reports any that exceed the threshold to the FeedbackActor's error queue.

Only _one_ node needs to exceed the threshold for the FeedbackActor to trigger a scale-down.

### Issues Resolved
#839 

### Testing
- [x] New functionality includes testing

Testing with different config flag configurations + a working configuration. Results shown here against a 3.0 cluster with a max CPU usage of 30%:
![Screenshot 2025-06-11 at 3 30 59 PM](https://github.com/user-attachments/assets/e28c8f92-f0b4-462f-be42-812c86abf3da)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
