### PR TITLE
add mandatory=False flag for CPU feedback fetch

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -807,7 +807,7 @@ def execute_test(cfg, kill_running_processes=False):
             raise exceptions.BenchmarkError(msg)
 
     # redline testing: check metrics store type before running cpu based feedback test
-    cpu_max = cfg.opts("workload", "redline.max_cpu_usage", default_value=None)
+    cpu_max = cfg.opts("workload", "redline.max_cpu_usage", default_value=None, mandatory=False)
     if cpu_max is not None:
         store = metrics.metrics_store(cfg, read_only=False)
         try:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1000,7 +1000,7 @@ class WorkerCoordinator:
             self.target.on_cluster_details_retrieved(self.retrieve_cluster_info(os_clients))
 
         # Redline testing: Check if cpu feedback is enabled. Enable the node-stats telemetry device if we need to
-        cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=[])
+        cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None, mandatory=False)
         if cpu_max:
             devices = self.config.opts("telemetry", "devices", default_value=[])
             if "node-stats" not in devices:
@@ -1100,7 +1100,7 @@ class WorkerCoordinator:
             metrics_index = None
             test_execution_id = None
             # we must have a metrics store connected for CPU based feedback
-            cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None)
+            cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None, mandatory=False)
             if cpu_max and isinstance(self.metrics_store, metrics.InMemoryMetricsStore):
                 raise exceptions.SystemSetupError("CPU-based feedback requires a metrics store. You are using an in-memory metrics store")
             elif cpu_max and "node-stats" not in self.config.opts("telemetry", "devices"):


### PR DESCRIPTION
### Description
lack of `mandatory=False` flag when fetching cpu_max value from config object would cause normal benchmarks to crash with the following:
```
(.venv) [ec2-user@ip-123-45-67-890 opensearch-benchmark]$ osb execute-test --workload=big5 --target-host="localhost:9200" --workload-params="number_of_replicas:0" --exclude-tasks="type:search" --user-tag="version:osb-2"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: 3a5e8a2e-ba6a-473b-9cfd-673befbd7e13
[ERROR] Cannot execute-test. No value for mandatory configuration: section='workload', key='redline.max_cpu_usage'
```

This PR adds the `mandatory=False` flag to each check we do in benchmark.py/worker_coordinator.py to prevent these crashes.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [x] New functionality includes testing

Tests ran to ensure no more crashes

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
