### PR TITLE
add ability to use benchmark.ini file to customize redline tests

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -41,7 +41,6 @@ from osbenchmark.builder import provision_config, builder
 from osbenchmark.workload_generator import workload_generator
 from osbenchmark.utils import io, convert, process, console, net, opts, versions
 from osbenchmark import aggregator
-from osbenchmark.worker_coordinator.worker_coordinator import ConfigureFeedbackScaling
 
 def create_arg_parser():
     def positive_number(v):

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -672,19 +672,19 @@ def create_arg_parser():
         "--redline-scale-step",
         type=int,
         help="How many clients to add while scaling up during redline testing (default: 5).",
-        default=ConfigureFeedbackScaling.DEFAULT_SCALE_STEP
+        default=None
     )
     test_execution_parser.add_argument(
         "--redline-scaledown-percentage",
         type=float,
         help="What percentage of clients to remove when errors occur (default: 10%%).",
-        default=ConfigureFeedbackScaling.DEFAULT_SCALEDOWN_PCT
+        default=None
     )
     test_execution_parser.add_argument(
         "--redline-post-scaledown-sleep",
         type=int,
         help="How many seconds to wait before scaling up again after a scale down (default: 30).",
-        default=ConfigureFeedbackScaling.DEFAULT_SLEEP_SECONDS
+        default=None
     )
     test_execution_parser.add_argument(
         "--redline-max-clients",
@@ -702,13 +702,13 @@ def create_arg_parser():
         "--redline-cpu-window-seconds",
         type=int,
         help="How many seconds the window for average CPU load should be in seconds during CPU-based redline testing. (Default: 30)",
-        default=ConfigureFeedbackScaling.DEFAULT_CPU_WINDOW_SECONDS
+        default=None
     )
     test_execution_parser.add_argument(
         "--redline-cpu-check-interval",
         type=int,
         help="How many seconds between CPU checks there should be during CPU-based redline testing. (Default: 30)",
-        default=ConfigureFeedbackScaling.DEFAULT_CPU_CHECK_INTERVAL
+        default=None
     )
 
     ###############################################################################

--- a/osbenchmark/resources/benchmark.ini
+++ b/osbenchmark/resources/benchmark.ini
@@ -36,3 +36,4 @@ preserve_benchmark_candidate = false
 [distributions]
 release.cache = true
 
+[redline]

--- a/osbenchmark/resources/benchmark.ini
+++ b/osbenchmark/resources/benchmark.ini
@@ -37,3 +37,8 @@ preserve_benchmark_candidate = false
 release.cache = true
 
 [redline]
+scale_step = 5
+scaledown_percentage = 0.10
+post_scaledown_sleep = 30
+cpu_window_seconds = 30
+cpu_check_interval = 30

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -211,7 +211,7 @@ def load_redline_config():
     benchmark_home = os.environ.get('BENCHMARK_HOME') or os.environ['HOME']
     benchmark_ini = benchmark_home + '/.benchmark/benchmark.ini'
     if not os.path.isfile(benchmark_ini):
-        print(f"WARNING: redline config file {benchmark_ini} not found. Proceeding with default values.")
+        console.println(f"WARNING: redline config file {benchmark_ini} not found. Proceeding with default values.")
         return {}
 
     config.read(benchmark_ini)

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -230,7 +230,7 @@ def load_redline_config():
         ]:
             if key in redline:
                 config_object[key] = redline[key]
-    
+
     return config_object
 
 class ConfigureFeedbackScaling:


### PR DESCRIPTION
### Description
Adds a new `[redline]` section to `benchmark.ini` along with some default values for redline testing. These are equivalent to the default values originally used in the FeedbackActor, and allow the user to customize various parts of redline testing from the config object rather than using command flags.

The priority for which value to use is: 
command flag -> config object values -> default values in the `ConfigureFeedbackScaling` class.

And the values that can be customized in the config object include:
- The scale_step (how many clients are unpaused per tick)
- The scale_down_percentage (what percentage of clients are scaled down upon an error)
- The sleep_seconds (how long the FeedbackActor chooses to rest before pushing more load on the host)
- The cpu_window_seconds (How long of a window the FeedbackActor takes into account when calculating average CPU load)
- The cpu_check_interval (How often the FeedbackActor queries the datastore to check avg CPU load)

### Issues Resolved
#885 

### Testing
- [x] New functionality includes testing

Running redline tests with/without various values in the config object

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
