### PR TITLE
add checker for 1.x terms

### DIFF
--- a/.ci/scripts/check_deprecated_terms.py
+++ b/.ci/scripts/check_deprecated_terms.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+
+DEPRECATED_TERMS = [
+    "provision-configs",
+    "results-publisher",
+    "load-worker-coordinator-hosts",
+    "execute-test",
+]
+
+VARIANT_PATTERNS = []
+
+# Generate regex variants (hyphen, underscore, camelCase, word-order naive permutations)
+def generate_variants(term):
+    base = term.replace("-", " ").replace("_", " ")
+    words = base.split()
+    variants = set()
+
+    # kebab-case, snake_case, camelCase, PascalCase, permutations
+    variants.add("-".join(words))
+    variants.add("_".join(words))
+    variants.add("".join([w.capitalize() for w in words]))        # PascalCase
+    variants.add(words[0] + "".join([w.capitalize() for w in words[1:]]))  # camelCase
+
+    # Word order permutations (naive)
+    if len(words) == 2:
+        variants.add("-".join(words[::-1]))
+        variants.add("_".join(words[::-1]))
+        variants.add(words[1] + words[0].capitalize())  # camelCase flip
+
+    return variants
+
+for term in DEPRECATED_TERMS:
+    for variant in generate_variants(term):
+        VARIANT_PATTERNS.append(re.compile(re.escape(variant), re.IGNORECASE))
+
+def should_check_file(filename):
+    return filename.endswith((".py", ".yml", ".yaml", ".md", ".sh", ".json", ".txt"))
+
+def main():
+    error_found = False
+
+    for root, _, files in os.walk("."):
+        if any(skip in root for skip in [".git", "venv", "__pycache__", ".pytest_cache"]):
+            continue
+
+        for f in files:
+            full_path = os.path.join(root, f)
+            if not should_check_file(full_path):
+                continue
+
+            try:
+                with open(full_path, "r", encoding="utf-8") as file:
+                    for i, line in enumerate(file, 1):
+                        for pattern in VARIANT_PATTERNS:
+                            if pattern.search(line):
+                                print(f"[Deprecated Term] {full_path}:{i}: {line.strip()}")
+                                error_found = True
+            except Exception as e:
+                print(f"[Warning] Skipped file {full_path}: {e}")
+
+    if error_found:
+        print("\n❌ Deprecated terms found. Please remove or rename them.")
+        sys.exit(1)
+
+    print("✅ No deprecated terms found.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run the CI build script
         run: bash .ci/build.sh build_and_unit_test
+
+      - name: Run deprecated term lint checker
+        run: .ci/scripts/check_deprecated_terms.py


### PR DESCRIPTION
### Description
Adds a lint checker for 1.x terms. Takes the set of terms described in the [issue](https://github.com/opensearch-project/opensearch-benchmark/issues/841#issue-3074992912) and checks for any variants of the terms (hyphen, underscore, camelCase, etc). Prints out deprecated terms if they are found

### Issues Resolved
#841 

### Testing
- [x] New functionality includes testing

Ran script against 2.0-develop branch
![Screenshot 2025-07-07 at 3 52 22 PM](https://github.com/user-attachments/assets/0e67616d-5152-4612-9993-fb31901bc6fe)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
