### PR TITLE
Data Producer with multi-part downloads and partitioning

### DIFF
--- a/osbenchmark/cloud_provider/vendors/s3_data_producer.py
+++ b/osbenchmark/cloud_provider/vendors/s3_data_producer.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import os
+import sys
+import logging
+
+from concurrent.futures import ThreadPoolExecutor, wait
+from boto3 import client
+
+from osbenchmark import exceptions
+from osbenchmark.data_streaming.data_producer import DataProducer
+from osbenchmark.cloud_provider import CloudProviderFactory
+from osbenchmark.cloud_provider.vendors.aws import AWSProvider
+
+
+class S3DataProducer(DataProducer):
+    """
+    Generate data by downloading an object from S3.
+    Will support downloading from multiple objects in the future.
+    """
+    def __init__(self, bucket:str, keys, client_options: dict) -> None:
+        """
+        Constructor.
+        :param bucket: The S3 bucket to download from.
+        :param key: The object(s) to download, a string or a list of strings.
+        :param client_options: A dict containing the client options.
+        """
+        try:
+            self.logger = logging.getLogger(__name__)
+            self.bucket = bucket
+            self.keys = keys
+
+            # Defaults.  These may be overridden by the Ingestion Manager later.
+            self.data_dir = "."
+            self.chunk_prefix = "chunk-"
+            self.chunk_size = 50 * 1024**2              # download 50 MB chunks
+            self.num_workers = 16                       # should be based on number of cores
+
+            # Credentials are set via the client options in a similar manner as used for
+            # the existing SigV4 support.
+            if client_options:
+                # We assume "amazon_aws_log_in" is set as one of the client options.
+                provider = CloudProviderFactory.get_provider_from_client_options(client_options)
+                if not isinstance(provider, AWSProvider):
+                    raise exceptions.ConfigError("S3DataProducer operates only on AWS")
+
+                # Extract credentials from the environment, as set in the OSB_* variables.
+                provider.parse_log_in_params(client_options=client_options)
+                masked_client_options = dict(client_options)
+                provider.mask_client_options(masked_client_options, client_options)
+                self.logger.info("Masking client options with cloud provider: [%s]", provider)
+
+                self.s3_client = client('s3',
+                                   aws_access_key_id = provider.aws_log_in_config['aws_access_key_id'],
+                                   aws_secret_access_key = provider.aws_log_in_config['aws_secret_access_key'],
+                                   aws_session_token = provider.aws_log_in_config['aws_session_token'],
+                                   )
+            else:
+                # For testing.  Set credentials with environment variables.
+                self.s3_client = client('s3')
+        except Exception as e:
+            print(f"Error: {e}")
+
+    def _get_next_downloader(self):
+        "Generator that returns the downloader for the next object to be downloaded."
+        # Name globbing to be added later.
+        keys = [self.keys] if not isinstance(self.keys, list) else self.keys
+        for k in keys:
+            # Obtain the object size.
+            response = self.s3_client.head_object(Bucket=self.bucket, Key=k)
+            size = response['ContentLength']
+            yield self._s3_multipart_downloader(self.bucket, k, 0, size)
+
+    def _gen_range_args(self, beg, end, chunk_size):
+        "Partition a range and return the bounds in range header format."
+        # Note that the S3 range header arg bounds are inclusive.
+        # See: https://www.rfc-editor.org/rfc/rfc9110.html#name-range
+        length = end - beg
+        n = (length + chunk_size - 1) // chunk_size
+        ranges = list()
+        for i in range(n):
+            r_beg = beg + i * chunk_size
+            if i == n - 1:
+                r_end = end - 1
+            else:
+                r_end = r_beg + chunk_size - 1
+            ranges.append(f'bytes={r_beg}-{r_end}')
+        return ranges
+
+    def _s3_get_object_subrange(self, args):
+        "Download a subrange of an S3 object."
+        bucket, key, range = args
+        resp = self.s3_client.get_object(Bucket=bucket, Key=key, Range=range)
+        return resp['Body'].read()
+
+    def _s3_multipart_downloader(self, bucket, key, beg, end):
+        """
+        Generator that splits a streaming download into parts, runs a subset of these
+        downloads concurrently, and returns the next downloaded chunk.
+        """
+        ranges = self._gen_range_args(beg, end, self.chunk_size)
+
+        # Carry out a multi-part download, with the specified number of workers.
+        # Ensure futures are garbage collected before more are issued, to not run out of memory.
+        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+            for i in range(0, len(ranges), self.num_workers):
+                subranges = ranges[i:i+self.num_workers]
+                futures = [executor.submit(self._s3_get_object_subrange, (bucket, key, range))
+                           for range in subranges]
+                wait(futures)
+                for future in futures:
+                    yield future.result()
+
+    def _output_chunk(self, rsl, chunk_id):
+        "Write a chunk into its file.  It will be processed later by one ingestion client."
+        with open(os.path.join(self.data_dir, self.chunk_prefix + "{:04d}".format(chunk_id)),
+                  "w", encoding='utf-8') as fh:
+            fh.write(rsl)
+
+    def generate_chunked_data(self):
+        "Generate chunked output ready for ingestion by OSB clients."
+        chunk_id = 0
+        partial_line = ""
+        downloaders = self._get_next_downloader()
+        for downloader in downloaders:
+            for chunk in downloader:
+                rsl = chunk.decode('utf-8')
+                i = len(rsl)
+                while i and rsl[i-1] != '\n':
+                    i -= 1
+                if i == 0:
+                    raise exceptions.DataStreamingError(f"could not locate document end in chunk {chunk_id}")
+                self._output_chunk(partial_line + rsl[:i], chunk_id)
+                partial_line = rsl[i:]
+                chunk_id += 1
+
+
+# For testing.  Set AWS credentials using environment variables.
+def main(bucket: str, keys: str) -> None:
+    producer = S3DataProducer(bucket, keys, None)
+    producer.generate_chunked_data()
+
+if __name__ == '__main__':
+    # pylint: disable = no-value-for-parameter
+    main(*sys.argv[1:])

--- a/osbenchmark/data_streaming/data_producer.py
+++ b/osbenchmark/data_streaming/data_producer.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+from abc import ABC, abstractmethod
+
+class DataProducer(ABC):
+
+    @abstractmethod
+    def generate_chunked_data(self) -> None:
+        pass

--- a/osbenchmark/exceptions.py
+++ b/osbenchmark/exceptions.py
@@ -125,6 +125,15 @@ class ConfigurationError(BenchmarkError):
         message -- explanation of the error
     """
 
+
+class DataStreamingError(BenchmarkError):
+    """Exception raised for errors in the data streaming module.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+
 class MappingsError(BenchmarkError):
     """Exception raised for errors in OpenSearch mappings provided.
 

--- a/tests/data_streaming/__init__.py
+++ b/tests/data_streaming/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.

--- a/tests/data_streaming/producer_test.py
+++ b/tests/data_streaming/producer_test.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# pylint: disable=protected-access
+
+from unittest import TestCase
+import unittest.mock as mock
+
+from osbenchmark.cloud_provider.vendors.s3_data_producer import S3DataProducer
+
+class TestS3DataProducer(TestCase):
+
+    # pylint: disable = arguments-differ
+    @mock.patch('osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer.__init__', return_value=None)
+    def setUp(self, mock_init):
+        self.producer = S3DataProducer('bucket', 'key', None)
+
+    def test_gen_range_args_aligned(self):
+        self.assertEqual(self.producer._gen_range_args(0, 8, 4), ['bytes=0-3', 'bytes=4-7'])
+
+    def test_gen_range_args_unaligned(self):
+        self.assertEqual(self.producer._gen_range_args(0, 10, 4), ['bytes=0-3', 'bytes=4-7', 'bytes=8-9'])
+
+    def test_gen_range_args_empty(self):
+        self.assertEqual(self.producer._gen_range_args(0, 0, 4), [])
+
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._output_chunk")
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._get_next_downloader")
+    def test_generate_chunked_data_aligned(self, downloader, outputter):
+        downloader.return_value = [ [ b"this is line 1\n" ] ]
+        self.producer.generate_chunked_data()
+        outputter.assert_called_with("this is line 1\n", 0)
+
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._output_chunk")
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._get_next_downloader")
+    def test_generate_chunked_data_unaligned(self, downloader, outputter):
+        downloader.return_value = [ [ b"this is line 1\nthis is line 2" ] ]
+        self.producer.generate_chunked_data()
+        outputter.assert_called_with("this is line 1\n", 0)
+
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._output_chunk")
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._get_next_downloader")
+    def test_generate_chunked_data_aligned_multiline(self, downloader, outputter):
+        downloader.return_value = [ [ b"this is line 0\nthis is line 1\n" ] ]
+        self.producer.generate_chunked_data()
+        outputter.assert_called_with("this is line 0\nthis is line 1\n", 0)
+
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._output_chunk")
+    @mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._get_next_downloader")
+    def test_generate_chunked_data_unaligned_multiline(self, downloader, outputter):
+        downloader.return_value = [ [ b"this is line 0\nthis is line 1\nthis is line 2" ] ]
+        self.producer.generate_chunked_data()
+        outputter.assert_called_with("this is line 0\nthis is line 1\n", 0)
+
+    def int_generator(self, n):
+        for i in range(n):
+            yield i
+
+    def get_object_subrange(self, args):
+        return next(self.get_obj_subrange_generator)
+
+    def test_multipart_downloader_4_2(self):
+        self.producer.chunk_size = 4
+        self.producer.num_workers = 2
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1, 2])
+
+    def test_multipart_downloader_4_1(self):
+        self.producer.chunk_size = 4
+        self.producer.num_workers = 1
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1, 2])
+
+    def test_multipart_downloader_4_4(self):
+        self.producer.chunk_size = 4
+        self.producer.num_workers = 4
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1, 2])
+
+    def test_multipart_downloader_4_8(self):
+        self.producer.chunk_size = 4
+        self.producer.num_workers = 8
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1, 2])
+
+    def test_multipart_downloader_8_2(self):
+        self.producer.chunk_size = 8
+        self.producer.num_workers = 2
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1])
+
+    def test_multipart_downloader_8_4(self):
+        self.producer.chunk_size = 8
+        self.producer.num_workers = 4
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1])
+
+    def test_multipart_downloader_8_1(self):
+        self.producer.chunk_size = 8
+        self.producer.num_workers = 4
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1])
+
+    def test_multipart_downloader_8_5(self):
+        self.producer.chunk_size = 8
+        self.producer.num_workers = 5
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1])
+
+    def test_multipart_downloader_8_8(self):
+        self.producer.chunk_size = 8
+        self.producer.num_workers = 8
+        self.get_obj_subrange_generator = self.int_generator(40)
+
+        with mock.patch("osbenchmark.cloud_provider.vendors.s3_data_producer.S3DataProducer._s3_get_object_subrange", wraps=self.get_object_subrange):
+            generator = self.producer._s3_multipart_downloader('bucket', 'key', 0, 12)
+            self.assertEqual(list(generator), [0, 1])


### PR DESCRIPTION
### Description
Initial implementation of the Data Producer for data streaming with support for S3.  Scaling improvements will be added separately since multi-part download functionality needs to be explicitly managed.

### Issues Resolved
#872 

### Testing
- [X] Unit tests

### Example Output
```
After setting credentials appropriately and attempting to download a 10 GB corpus:

[926]osb-dst:SCR-0:test@$ time python3 -m osbenchmark.cloud_provider.vendors.s3_data_producer big5-corpus documents-10.json

real    1m10.78s
user    0m26.51s
sys     0m37.87s
[927]osb-dst:SCR-0:test@$ ls
total 10486168
51200 chunk-0000  51204 chunk-0016  51200 chunk-0032  51200 chunk-0048  51200 chunk-0064  51204 chunk-0080  51204 chunk-0096  51200 chunk-0112  51200 chunk-0128  51204 chunk-0144  51200 chunk-0160  51204 chunk-0176  51204 chunk-0192
51204 chunk-0001  51200 chunk-0017  51200 chunk-0033  51204 chunk-0049  51204 chunk-0065  51204 chunk-0081  51204 chunk-0097  51204 chunk-0113  51204 chunk-0129  51200 chunk-0145  51204 chunk-0161  51200 chunk-0177  51204 chunk-0193
51204 chunk-0002  51204 chunk-0018  51200 chunk-0034  51204 chunk-0050  51200 chunk-0066  51200 chunk-0082  51200 chunk-0098  51200 chunk-0114  51200 chunk-0130  51204 chunk-0146  51200 chunk-0162  51204 chunk-0178  51200 chunk-0194
51200 chunk-0003  51204 chunk-0019  51204 chunk-0035  51204 chunk-0051  51204 chunk-0067  51204 chunk-0083  51204 chunk-0099  51204 chunk-0115  51204 chunk-0131  51204 chunk-0147  51200 chunk-0163  51200 chunk-0179  51204 chunk-0195
51200 chunk-0004  51200 chunk-0020  51200 chunk-0036  51200 chunk-0052  51200 chunk-0068  51204 chunk-0084  51204 chunk-0100  51204 chunk-0116  51204 chunk-0132  51200 chunk-0148  51204 chunk-0164  51200 chunk-0180  51200 chunk-0196
51200 chunk-0005  51200 chunk-0021  51200 chunk-0037  51204 chunk-0053  51204 chunk-0069  51200 chunk-0085  51200 chunk-0101  51200 chunk-0117  51200 chunk-0133  51200 chunk-0149  51200 chunk-0165  51204 chunk-0181  51200 chunk-0197
51204 chunk-0006  51204 chunk-0022  51204 chunk-0038  51200 chunk-0054  51200 chunk-0070  51204 chunk-0086  51200 chunk-0102  51200 chunk-0118  51200 chunk-0134  51200 chunk-0150  51204 chunk-0166  51200 chunk-0182  51204 chunk-0198
51200 chunk-0007  51200 chunk-0023  51204 chunk-0039  51204 chunk-0055  51200 chunk-0071  51204 chunk-0087  51204 chunk-0103  51204 chunk-0119  51204 chunk-0135  51204 chunk-0151  51200 chunk-0167  51204 chunk-0183  51200 chunk-0199
51204 chunk-0008  51200 chunk-0024  51200 chunk-0040  51200 chunk-0056  51204 chunk-0072  51200 chunk-0088  51200 chunk-0104  51204 chunk-0120  51204 chunk-0136  51200 chunk-0152  51204 chunk-0168  51204 chunk-0184  51204 chunk-0200
51204 chunk-0009  51204 chunk-0025  51204 chunk-0041  51204 chunk-0057  51200 chunk-0073  51204 chunk-0089  51204 chunk-0105  51200 chunk-0121  51200 chunk-0137  51200 chunk-0153  51200 chunk-0169  51200 chunk-0185  51204 chunk-0201
51200 chunk-0010  51204 chunk-0026  51200 chunk-0042  51204 chunk-0058  51204 chunk-0074  51200 chunk-0090  51200 chunk-0106  51200 chunk-0122  51200 chunk-0138  51200 chunk-0154  51200 chunk-0170  51204 chunk-0186  51200 chunk-0202
51200 chunk-0011  51200 chunk-0027  51204 chunk-0043  51204 chunk-0059  51204 chunk-0075  51204 chunk-0091  51204 chunk-0107  51204 chunk-0123  51200 chunk-0139  51204 chunk-0155  51204 chunk-0171  51200 chunk-0187  51200 chunk-0203
51204 chunk-0012  51200 chunk-0028  51204 chunk-0044  51204 chunk-0060  51200 chunk-0076  51200 chunk-0092  51200 chunk-0108  51200 chunk-0124  51204 chunk-0140  51204 chunk-0156  51200 chunk-0172  51200 chunk-0188  40964 chunk-0204
51200 chunk-0013  51200 chunk-0029  51204 chunk-0045  51200 chunk-0061  51204 chunk-0077  51204 chunk-0093  51200 chunk-0109  51204 chunk-0125  51200 chunk-0141  51204 chunk-0157  51200 chunk-0173  51204 chunk-0189
51200 chunk-0014  51204 chunk-0030  51204 chunk-0046  51204 chunk-0062  51200 chunk-0078  51200 chunk-0094  51204 chunk-0110  51204 chunk-0126  51204 chunk-0142  51204 chunk-0158  51204 chunk-0174  51200 chunk-0190
51204 chunk-0015  51200 chunk-0031  51200 chunk-0047  51200 chunk-0063  51200 chunk-0079  51200 chunk-0095  51204 chunk-0111  51204 chunk-0127  51204 chunk-0143  51200 chunk-0159  51200 chunk-0175  51200 chunk-0191
[928]osb-dst:SCR-0:test@$ head -2 chunk-0030
{"@timestamp": "2023-01-01T04:18:41.000Z","aws.cloudwatch": {"log_stream": "luckgriffin","ingestion_time": "2024-03-13T06:41:14.229Z","log_group": "/var/log/messages"},"cloud": {"region": "ap-northeast-1"},"log.file.path": "/var/log/messages/luckgriffin","input": {"type": "aws-cloudwatch"},"data_stream": {"namespace": "default","type": "logs","dataset": "generic"},"process": {"name": "httpd"},"message": "2024-03-13T06:41:14.229Z Mar 13 06:41:14 ip-121-160-175-67 httpd: weaver tail nape crystal carp iguana horn dagger wanderer princess jaw brow storm lifter pig hisser curtain moose fin jay sentry gull witch bushhare","event": {"id": "rubyheron","ingested": "2024-03-13T06:20:24.229641805Z","dataset": "generic"},"host": {"name": "clearwitch"},"metrics": {"size": 1374, "tmin": 1},"agent": {"id": "c79a289f-6c16-4de2-a6c8-8ee5c84473d5","name": "clearwitch","type": "filebeat","version": "8.8.0","ephemeral_id": "c79a289f-6c16-4de2-a6c8-8ee5c84473d5"},"tags": ["preserve_original_event"]}
{"@timestamp": "2023-01-01T04:13:14.000Z","aws.cloudwatch": {"log_stream": "bronzelightning","ingestion_time": "2024-03-13T06:41:14.229Z","log_group": "/var/log/messages"},"cloud": {"region": "me-south-1"},"log.file.path": "/var/log/messages/bronzelightning","input": {"type": "aws-cloudwatch"},"data_stream": {"namespace": "default","type": "logs","dataset": "generic"},"process": {"name": "journal"},"message": "2024-03-13T06:41:14.229Z Mar 13 06:41:14 ip-148-133-209-204 journal: weaver hugger crusher scowl sword bunny terrier prince devourer razor crown ape lightning arrow carver painter spike tail lizard skull chill lancer stinger quilthawk","event": {"id": "whitepalm","ingested": "2024-03-13T06:19:17.229679276Z","dataset": "generic"},"host": {"name": "azurescorpion"},"metrics": {"size": 1414, "tmin": 1},"agent": {"id": "954bc54b-9454-4971-8c6e-b0968eeeaaed","name": "azurescorpion","type": "filebeat","version": "8.8.0","ephemeral_id": "954bc54b-9454-4971-8c6e-b0968eeeaaed"},"tags": ["preserve_original_event"]}
[929]osb-dst:SCR-0:test@$ tail -2 chunk-0030
{"@timestamp": "2023-01-01T04:33:16.000Z","aws.cloudwatch": {"log_stream": "pollenflame","ingestion_time": "2024-03-13T06:41:15.640Z","log_group": "/var/log/messages"},"cloud": {"region": "ap-northeast-2"},"log.file.path": "/var/log/messages/pollenflame","input": {"type": "aws-cloudwatch"},"data_stream": {"namespace": "default","type": "logs","dataset": "generic"},"process": {"name": "httpd"},"message": "2024-03-13T06:41:15.640Z Mar 13 06:41:15 ip-236-55-130-212 httpd: antelope shift lasher throat leg princess chopper snapdragonhugger","event": {"id": "narrowotter","ingested": "2024-03-13T06:21:15.640819318Z","dataset": "generic"},"host": {"name": "glorychill"},"metrics": {"size": 1831, "tmin": 1},"agent": {"id": "954bc54b-9454-4971-8c6e-b0968eeeaaed","name": "glorychill","type": "filebeat","version": "8.8.0","ephemeral_id": "954bc54b-9454-4971-8c6e-b0968eeeaaed"},"tags": ["preserve_original_event"]}
{"@timestamp": "2023-01-01T04:27:03.000Z","aws.cloudwatch": {"log_stream": "sunrisehunter","ingestion_time": "2024-03-13T06:41:15.640Z","log_group": "/var/log/messages"},"cloud": {"region": "ap-south-2"},"log.file.path": "/var/log/messages/sunrisehunter","input": {"type": "aws-cloudwatch"},"data_stream": {"namespace": "default","type": "logs","dataset": "generic"},"process": {"name": "journal"},"message": "2024-03-13T06:41:15.640Z Mar 13 06:41:15 ip-126-222-63-144 journal: crusher goose lifter shield oriole iridescenttrack","event": {"id": "pyritegrabber","ingested": "2024-03-13T06:24:08.640842786Z","dataset": "generic"},"host": {"name": "lasersalmon"},"metrics": {"size": 1663, "tmin": 1},"agent": {"id": "5f25fa16-6a99-489f-b1c5-f27c0627a459","name": "lasersalmon","type": "filebeat","version": "8.8.0","ephemeral_id": "5f25fa16-6a99-489f-b1c5-f27c0627a459"},"tags": ["preserve_original_event"]}
[930]osb-dst:SCR-0:test@$ du -c chunk-0* | tail
51200   chunk-0196
51200   chunk-0197
51204   chunk-0198
51200   chunk-0199
51204   chunk-0200
51204   chunk-0201
51200   chunk-0202
51200   chunk-0203
40964   chunk-0204
10486168        total
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
