### PR TITLE
Adding query profiling metrics to metrics store

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -2205,7 +2205,7 @@ class GlobalStats:
             "error_rate": error_rate,
             "duration": duration,
             })
-        
+
     def add_profile_metrics(self, task, operation, profile_metrics):
         self.profile_metrics.append({
             "task": task,

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1809,21 +1809,21 @@ class GlobalStatsCalculator:
 
         for tasks in self.test_procedure.schedule:
             for task in tasks:
-                t = task.name
+                task_name = task.name
                 op_type = task.operation.type
-                error_rate = self.error_rate(t, op_type)
-                duration = self.duration(t)
+                error_rate = self.error_rate(task_name, op_type)
+                duration = self.duration(task_name)
 
                 if task.operation.include_in_results_publishing or error_rate > 0:
-                    self.logger.debug("Gathering request metrics for [%s].", t)
+                    self.logger.debug("Gathering request metrics for [%s].", task_name)
                     result.add_op_metrics(
-                        t,
+                        task_name,
                         task.operation.name,
-                        self.summary_stats("throughput", t, op_type, percentiles_list=self.throughput_percentiles),
-                        self.single_latency(t, op_type),
-                        self.single_latency(t, op_type, metric_name="service_time"),
-                        self.single_latency(t, op_type, metric_name="client_processing_time"),
-                        self.single_latency(t, op_type, metric_name="processing_time"),
+                        self.summary_stats("throughput", task_name, op_type, percentiles_list=self.throughput_percentiles),
+                        self.single_latency(task_name, op_type),
+                        self.single_latency(task_name, op_type, metric_name="service_time"),
+                        self.single_latency(task_name, op_type, metric_name="client_processing_time"),
+                        self.single_latency(task_name, op_type, metric_name="processing_time"),
                         error_rate,
                         duration,
                         self.merge(
@@ -1835,10 +1835,10 @@ class GlobalStatsCalculator:
                     )
 
                     result.add_correctness_metrics(
-                        t,
+                        task_name,
                         task.operation.name,
-                        self.single_latency(t, op_type, metric_name="recall@k"),
-                        self.single_latency(t, op_type, metric_name="recall@1"),
+                        self.single_latency(task_name, op_type, metric_name="recall@k"),
+                        self.single_latency(task_name, op_type, metric_name="recall@1"),
                         error_rate,
                         duration
                     )
@@ -1847,9 +1847,9 @@ class GlobalStatsCalculator:
                     if profile_metrics:
                         profile_metrics.append("query_time")
                         result.add_profile_metrics(
-                            t,
+                            task_name,
                             task.operation.name,
-                            {name: self.single_latency(t, op_type, metric_name=name) for name in profile_metrics}
+                            {name: self.single_latency(task_name, op_type, metric_name=name) for name in profile_metrics}
                         )
 
         self.logger.debug("Gathering indexing metrics.")
@@ -2146,7 +2146,7 @@ class GlobalStats:
             elif metric == "profile_metrics":
                 for item in value:
                     for metric_name in item.keys():
-                        if metric_name not in ["task, operation, error_rate, duration"]:
+                        if metric_name not in ["task", "operation", "error_rate", "duration"]:
                             all_results.append({
                                 "task": item["task"],
                                 "operation": item["operation"],

--- a/osbenchmark/results_publisher.py
+++ b/osbenchmark/results_publisher.py
@@ -199,6 +199,10 @@ class SummaryResultsPublisher:
             if recall_keys_in_task_dict and "mean" in record["recall@1"] and "mean" in record["recall@k"]:
                 metrics_table.extend(self._publish_recall(record, task))
 
+        for record in stats.profile_metrics:
+            task = record["task"]
+            metrics_table.extend(self._publish_profile_metrics(record["metrics"], task))
+
         self.write_results(metrics_table)
 
         if warnings:
@@ -250,6 +254,13 @@ class SummaryResultsPublisher:
         return self._join(
             self._line("Mean recall@k", task, recall_k_mean, "", lambda v: "%.2f" % v),
             self._line("Mean recall@1", task, recall_1_mean, "", lambda v: "%.2f" % v)
+        )
+
+    def _publish_profile_metrics(self, metrics, task):
+        percentiles = [self._publish_percentiles(key, task, value) for key, value in metrics.items()]
+
+        return self._join(
+            *[item for percentile in percentiles for item in percentile]
         )
 
     def _publish_best_client_settings(self, record, task):

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -38,7 +38,7 @@ from functools import total_ordering
 from io import BytesIO
 from os.path import commonprefix
 import multiprocessing
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import ijson
 from opensearchpy import ConnectionTimeout
@@ -1167,6 +1167,36 @@ class Query(Runner):
         # disable eager response parsing - responses might be huge thus skewing results
         opensearch.return_raw_response()
 
+        def get_profile_metrics(response_json: Dict[str, Any], metrics: List) -> Dict[str, int]:
+            """
+            Traverses profile tree and sums each specific profile metric. Then converts ns to ms.
+            """
+            def _get_query_timings(query):
+                breakdown = query['breakdown']
+                # metric_timings["query_time"] += query["time_in_nanos"]
+                for metric in metric_timings.keys():
+                    if metric == "exact_search" and query['type'] == "KNNQuery":
+                        metric_timings[metric] += breakdown["exact_search_after_ann"] + breakdown["exact_search_after_filter"]
+                    elif metric in breakdown:
+                        metric_timings[metric] += breakdown[metric]
+                if "children" in query:
+                    children = query['children']
+                    for child in children:
+                        _get_query_timings(child)
+            
+            metrics.append("query_time")
+            metric_timings = dict.fromkeys(metrics, 0)
+            shards = response_json['profile']['shards']
+            for shard in shards:
+                searches = shard['searches']
+                for search in searches:
+                    queries = search['query']
+                    for query in queries:
+                        metric_timings["query_time"] += query["time_in_nanos"]
+                        _get_query_timings(query)
+            metric_timings = {key : value / 1e6 for key, value in metric_timings.items()}
+            return metric_timings
+
         async def _search_after_query(opensearch, params):
             index = params.get("index", "_all")
             pit_op = params.get("with-point-in-time-from")
@@ -1219,7 +1249,17 @@ class Query(Runner):
         async def _request_body_query(opensearch, params):
             doc_type = params.get("type")
 
+            profile = params.get("profile-query", False)
+            if profile:
+                body["profile"] = True
+
             r = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
+
+            result = {
+                "weight": 1,
+                "unit": "ops",
+                "success": True
+            }
 
             if detailed_results:
                 props = parse(r, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
@@ -1228,21 +1268,18 @@ class Query(Runner):
                 timed_out = props.get("timed_out", False)
                 took = props.get("took", 0)
 
-                return {
-                    "weight": 1,
-                    "unit": "ops",
-                    "success": True,
+                result.update({
                     "hits": hits_total,
                     "hits_relation": hits_relation,
                     "timed_out": timed_out,
                     "took": took
-                }
-            else:
-                return {
-                    "weight": 1,
-                    "unit": "ops",
-                    "success": True
-                }
+                })
+
+            if profile:
+                metric_timings = get_profile_metrics(json.loads(r.getvalue()), params.get("profile-metrics"))
+                result.update(metric_timings)
+
+            return result
 
         async def _scroll_query(opensearch, params):
             hits = 0
@@ -1469,6 +1506,9 @@ class Query(Runner):
                 _set_initial_recall_values(params, result)
 
             doc_type = params.get("type")
+            profile = params.get("profile-query", False)
+            if profile:
+                body["profile"] = True
             response = await self._raw_search(opensearch, doc_type, index, body, request_params, headers=headers)
 
             if detailed_results:
@@ -1503,6 +1543,10 @@ class Query(Runner):
                     continue
                 candidates.append(field_value)
             neighbors_dataset = params["neighbors"]
+
+            if profile:
+                metric_timings = get_profile_metrics(response_json, params.get("profile-metrics"))
+                result.update({"profile-metrics": metric_timings})
 
             if "k" in params:
                 num_neighbors = params.get("k", 1)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1192,7 +1192,7 @@ class Query(Runner):
                         children = query['children']
                         for child in children:
                             _get_query_timings(child)
-                
+
                 metrics.append("query_time")
                 metric_timings = dict.fromkeys(metrics, 0)
                 shards = response_json['profile']['shards']
@@ -1283,7 +1283,8 @@ class Query(Runner):
                     "took": took
                 })
 
-            add_profile_to_results(json.loads(r.getvalue()), params, result)
+            if r:
+                add_profile_to_results(json.loads(r.getvalue()), params, result)
 
             return result
 
@@ -1530,7 +1531,7 @@ class Query(Runner):
 
             recall_processing_start = time.perf_counter()
             response_json = json.loads(response.getvalue())
-            
+
             add_profile_to_results(response_json, params, result)
 
             if _is_empty_search_results(response_json):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -574,6 +574,8 @@ class SearchParamSource(ParamSource):
         request_params = params.get("request-params", {})
         response_compression_enabled = params.get("response-compression-enabled", True)
         with_point_in_time_from = params.get("with-point-in-time-from", None)
+        profile_metrics = params.get("profile-metrics", None)
+        profile_metrics_sample_size = params.get("profile-metrics-sample-size", 0)
 
         self.query_params = {
             "index": target_name,
@@ -596,6 +598,9 @@ class SearchParamSource(ParamSource):
             self.query_params["results-per-page"] = results_per_page
         if with_point_in_time_from:
             self.query_params["with-point-in-time-from"] = with_point_in_time_from
+        if profile_metrics:
+            self.query_params["profile-metrics"] = profile_metrics
+            self.query_params["profile-metrics-sample-size"] = profile_metrics_sample_size
         if "assertions" in params:
             if not detailed_results:
                 # for paginated queries the value does not matter because detailed results are always retrieved.

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -322,10 +322,10 @@ class SamplePostprocessorTests(TestCase):
 
         task = workload.Task("index", workload.Operation("index-op", "bulk", param_source="worker-coordinator-test-param-source"))
         samples = [
-            worker_coordinator.Sample(
+            worker_coordinator.DefaultSample(
                 0, 38598, 24, 0, task, metrics.SampleType.Normal,
                 None, 0.01, 0.007, 0.0007, 0.009, None, 5000, "docs", 1, 1 / 2),
-            worker_coordinator.Sample(
+            worker_coordinator.DefaultSample(
                 0, 38599, 25, 0, task, metrics.SampleType.Normal,
                 None, 0.01, 0.007, 0.0007, 0.009, None, 5000, "docs", 2, 2 / 2),
         ]
@@ -352,10 +352,10 @@ class SamplePostprocessorTests(TestCase):
         task = workload.Task("index", workload.Operation("index-op", "bulk", param_source="worker-coordinator-test-param-source"))
 
         samples = [
-            worker_coordinator.Sample(
+            worker_coordinator.DefaultSample(
                 0, 38598, 24, 0, task, metrics.SampleType.Normal,
                 None, 0.01, 0.007, 0.0007, 0.009, None, 5000, "docs", 1, 1 / 2),
-            worker_coordinator.Sample(
+            worker_coordinator.DefaultSample(
                 0, 38599, 25, 0, task, metrics.SampleType.Normal,
                 None, 0.01, 0.007, 0.0007, 0.009, None, 5000, "docs", 2, 2 / 2),
         ]
@@ -380,7 +380,7 @@ class SamplePostprocessorTests(TestCase):
 
         task = workload.Task("index", workload.Operation("index-op", "bulk", param_source="worker-coordinator-test-param-source"))
         samples = [
-            worker_coordinator.Sample(
+            worker_coordinator.DefaultSample(
                 0, 38598, 24, 0, task, metrics.SampleType.Normal,
                 None, 0.01, 0.007, 0.0007, 0.009, None, 5000, "docs", 1, 1 / 2,
                           dependent_timing=[
@@ -784,9 +784,9 @@ class MetricsAggregationTests(TestCase):
         op = workload.Operation("index", workload.OperationType.Bulk, param_source="worker-coordinator-test-param-source")
 
         samples = [
-            worker_coordinator.Sample(0, 1470838595, 21, 0, op, metrics.SampleType.Warmup,
+            worker_coordinator.DefaultSample(0, 1470838595, 21, 0, op, metrics.SampleType.Warmup,
                                       None, -1, -1, -1, -1, None, 3000, "docs", 1, 1),
-            worker_coordinator.Sample(0, 1470838595.5, 21.5, 0, op, metrics.SampleType.Normal,
+            worker_coordinator.DefaultSample(0, 1470838595.5, 21.5, 0, op, metrics.SampleType.Normal,
                                       None, -1, -1, -1, -1, None, 2500, "docs", 1, 1),
         ]
 
@@ -804,17 +804,17 @@ class MetricsAggregationTests(TestCase):
         op = workload.Operation("index", workload.OperationType.Bulk, param_source="worker-coordinator-test-param-source")
 
         samples = [
-            worker_coordinator.Sample(0, 38595, 21, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 1, 1 / 9),
-            worker_coordinator.Sample(0, 38596, 22, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 2, 2 / 9),
-            worker_coordinator.Sample(0, 38597, 23, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 3, 3 / 9),
-            worker_coordinator.Sample(0, 38598, 24, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 4, 4 / 9),
-            worker_coordinator.Sample(0, 38599, 25, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 5, 5 / 9),
-            worker_coordinator.Sample(0, 38600, 26, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 6, 6 / 9),
-            worker_coordinator.Sample(1, 38598.5, 24.5, 0, op, metrics.SampleType.Normal,
+            worker_coordinator.DefaultSample(0, 38595, 21, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 1, 1 / 9),
+            worker_coordinator.DefaultSample(0, 38596, 22, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 2, 2 / 9),
+            worker_coordinator.DefaultSample(0, 38597, 23, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 3, 3 / 9),
+            worker_coordinator.DefaultSample(0, 38598, 24, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 4, 4 / 9),
+            worker_coordinator.DefaultSample(0, 38599, 25, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 5, 5 / 9),
+            worker_coordinator.DefaultSample(0, 38600, 26, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, None, 5000, "docs", 6, 6 / 9),
+            worker_coordinator.DefaultSample(1, 38598.5, 24.5, 0, op, metrics.SampleType.Normal,
                                       None, -1, -1, -1, -1, None, 5000, "docs", 4.5, 7 / 9),
-            worker_coordinator.Sample(1, 38599.5, 25.5, 0, op, metrics.SampleType.Normal,
+            worker_coordinator.DefaultSample(1, 38599.5, 25.5, 0, op, metrics.SampleType.Normal,
                                       None, -1, -1, -1, -1, None, 5000, "docs", 5.5, 8 / 9),
-            worker_coordinator.Sample(1, 38600.5, 26.5, 0, op, metrics.SampleType.Normal,
+            worker_coordinator.DefaultSample(1, 38600.5, 26.5, 0, op, metrics.SampleType.Normal,
                                       None, -1, -1, -1, -1, None, 5000, "docs", 6.5, 9 / 9)
         ]
 
@@ -838,9 +838,9 @@ class MetricsAggregationTests(TestCase):
                              param_source="worker-coordinator-test-param-source")
 
         samples = [
-            worker_coordinator.Sample(0, 38595, 21, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 1, 1 / 3),
-            worker_coordinator.Sample(0, 38596, 22, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 2, 2 / 3),
-            worker_coordinator.Sample(0, 38597, 23, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 3, 3 / 3),
+            worker_coordinator.DefaultSample(0, 38595, 21, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 1, 1 / 3),
+            worker_coordinator.DefaultSample(0, 38596, 22, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 2, 2 / 3),
+            worker_coordinator.DefaultSample(0, 38597, 23, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, -1, 8000, 5000, "byte", 3, 3 / 3),
         ]
 
         aggregated = self.calculate_global_throughput(samples)
@@ -1342,7 +1342,8 @@ class AsyncExecutorTests(TestCase):
                                                             total_clients=task.clients)
         schedule = worker_coordinator.schedule_for(
             task_allocation, param_source)
-        sampler = worker_coordinator.Sampler(start_timestamp=task_start)
+        sampler = worker_coordinator.DefaultSampler(start_timestamp=task_start)
+        profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
@@ -1353,6 +1354,7 @@ class AsyncExecutorTests(TestCase):
                                                     "default": opensearch
                                                 },
                                                 sampler=sampler,
+                                                profile_sampler=profile_sampler,
                                                 cancel=cancel,
                                                 complete=complete,
                                                 on_error="continue")
@@ -1402,7 +1404,8 @@ class AsyncExecutorTests(TestCase):
         schedule = worker_coordinator.schedule_for(
             task_allocation, param_source)
 
-        sampler = worker_coordinator.Sampler(start_timestamp=task_start)
+        sampler = worker_coordinator.DefaultSampler(start_timestamp=task_start)
+        profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
@@ -1413,6 +1416,7 @@ class AsyncExecutorTests(TestCase):
                                                     "default": opensearch
                                                 },
                                                 sampler=sampler,
+                                                profile_sampler=profile_sampler,
                                                 cancel=cancel,
                                                 complete=complete,
                                                 on_error="continue")
@@ -1469,7 +1473,8 @@ class AsyncExecutorTests(TestCase):
         schedule = worker_coordinator.schedule_for(
             task_allocation, param_source)
 
-        sampler = worker_coordinator.Sampler(start_timestamp=task_start)
+        sampler = worker_coordinator.DefaultSampler(start_timestamp=task_start)
+        profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
@@ -1480,6 +1485,7 @@ class AsyncExecutorTests(TestCase):
                                                     "default": opensearch
                                                 },
                                                 sampler=sampler,
+                                                profile_sampler=profile_sampler,
                                                 cancel=cancel,
                                                 complete=complete,
                                                 on_error="continue")
@@ -1540,8 +1546,8 @@ class AsyncExecutorTests(TestCase):
                               warmup_time_period=0.5, time_period=0.5, clients=4,
                               params={"target-throughput": target_throughput, "clients": 4},
                               completes_parent=True)
-            sampler = worker_coordinator.Sampler(start_timestamp=0)
-
+            sampler = worker_coordinator.DefaultSampler(start_timestamp=0)
+            profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=0)
             cancel = threading.Event()
             complete = threading.Event()
 
@@ -1559,6 +1565,7 @@ class AsyncExecutorTests(TestCase):
                                                         "default": opensearch
                                                     },
                                                     sampler=sampler,
+                                                    profile_sampler=profile_sampler,
                                                     cancel=cancel,
                                                     complete=complete,
                                                     on_error="continue")
@@ -1609,8 +1616,8 @@ class AsyncExecutorTests(TestCase):
                                                                 total_clients=task.clients)
             schedule = worker_coordinator.schedule_for(
                 task_allocation, param_source)
-            sampler = worker_coordinator.Sampler(start_timestamp=0)
-
+            sampler = worker_coordinator.DefaultSampler(start_timestamp=0)
+            profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=0)
             cancel = threading.Event()
             complete = threading.Event()
             execute_schedule = worker_coordinator.AsyncExecutor(client_id=0,
@@ -1620,6 +1627,7 @@ class AsyncExecutorTests(TestCase):
                                                         "default": opensearch
                                                     },
                                                     sampler=sampler,
+                                                    profile_sampler=profile_sampler,
                                                     cancel=cancel,
                                                     complete=complete,
                                                     on_error="continue")
@@ -1668,7 +1676,8 @@ class AsyncExecutorTests(TestCase):
                           warmup_time_period=0.5, time_period=0.5, clients=4,
                           params={"clients": 4})
 
-        sampler = worker_coordinator.Sampler(start_timestamp=0)
+        sampler = worker_coordinator.DefaultSampler(start_timestamp=0)
+        profile_sampler = worker_coordinator.ProfileMetricsSampler(start_timestamp=0)
         cancel = threading.Event()
         complete = threading.Event()
         execute_schedule = worker_coordinator.AsyncExecutor(client_id=2,
@@ -1678,6 +1687,7 @@ class AsyncExecutorTests(TestCase):
                                                     "default": opensearch
                                                 },
                                                 sampler=sampler,
+                                                profile_sampler=profile_sampler,
                                                 cancel=cancel,
                                                 complete=complete,
                                                 on_error="continue")
@@ -1865,6 +1875,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
                                   workload.Operation("test-op", workload.OperationType.Bulk),
                                   clients=2)
         self.sampler = mock.Mock()
+        self.profile_sampler = mock.Mock()
         self.cancel = threading.Event()
         self.complete = threading.Event()
         self.schedule_handle = mock.Mock()
@@ -1883,6 +1894,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
             schedule=self.schedule_handle,
             opensearch=self.opensearch,
             sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
             cancel=self.cancel,
             complete=self.complete,
             on_error="abort",
@@ -2002,6 +2014,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         self.assertFalse(completed)
         self.schedule_handle.after_request.assert_called_once()
         self.sampler.add.assert_called_once()
+        self.profile_sampler.add.assert_not_called()
 
     def test_process_results_with_inactive_client(self):
         """Test _process_results does not add a sample for an inactive client."""
@@ -2024,6 +2037,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         self.assertFalse(completed)
         self.schedule_handle.after_request.assert_called_once()
         self.sampler.add.assert_not_called()
+        self.profile_sampler.add.assert_not_called()
 
     @run_async
     async def test_cleanup_with_message_producer(self):

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -315,7 +315,7 @@ class SamplePostprocessorTests(TestCase):
 
     @mock.patch("osbenchmark.metrics.MetricsStore")
     def test_all_samples(self, metrics_store):
-        post_process = worker_coordinator.SamplePostprocessor(metrics_store,
+        post_process = worker_coordinator.DefaultSamplePostprocessor(metrics_store,
                                                   downsample_factor=1,
                                                   workload_meta_data={},
                                                   test_procedure_meta_data={})
@@ -344,7 +344,7 @@ class SamplePostprocessorTests(TestCase):
 
     @mock.patch("osbenchmark.metrics.MetricsStore")
     def test_downsamples(self, metrics_store):
-        post_process = worker_coordinator.SamplePostprocessor(metrics_store,
+        post_process = worker_coordinator.DefaultSamplePostprocessor(metrics_store,
                                                   downsample_factor=2,
                                                   workload_meta_data={},
                                                   test_procedure_meta_data={})
@@ -373,7 +373,7 @@ class SamplePostprocessorTests(TestCase):
 
     @mock.patch("osbenchmark.metrics.MetricsStore")
     def test_dependent_samples(self, metrics_store):
-        post_process = worker_coordinator.SamplePostprocessor(metrics_store,
+        post_process = worker_coordinator.DefaultSamplePostprocessor(metrics_store,
                                                   downsample_factor=1,
                                                   workload_meta_data={},
                                                   test_procedure_meta_data={})


### PR DESCRIPTION

### Description
This is a high-level implementation of the issue linked below. Basically, a workload can specify query profile metrics and then the benchmarking tool samples the first N queries with a profiler. OSB then traverses through the entire profile tree and sums the profile metrics that were passed in (if present). The queries sampled for profiling are excluded from the operational metrics to avoid skewing the results. This means that a new sampler had to be created for the profile metric samples. Also, there are no checks currently on the sample size given because of how `schedule` is a generator type.

Ideally, it would be nice if samples could be added more easily to a `Sampler` (so we wouldn't have to define a new `Sample` subclass for every single metric we want to get percentiles from). It would also be nice if things could be added more easily to the metrics store instead of the current hard-coded version -- we could create a function to add some sort of metrics group (operational, correctness, profile-metric) to the store.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-benchmark/issues/886

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
