### PR TITLE
only run lint checker if 2.x-terms-only label is present

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,3 +27,4 @@ jobs:
 
       - name: Run deprecated term lint checker
         run: .ci/scripts/check_deprecated_terms.py
+        if: contains(github.event.pull_request.labels.*.name, '2.x-terms-only')


### PR DESCRIPTION
### Description
adds if condition so lint checker only runs if the `2.x-terms-only` label is present

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
