### PR TITLE
[BUG FIX] Profile Metric KNNQuery Fix

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1184,9 +1184,7 @@ class Query(Runner):
                     breakdown = query['breakdown']
                     # metric_timings["query_time"] += query["time_in_nanos"]
                     for metric in metric_timings.keys():
-                        if metric == "exact_search" and query['type'] == "KNNQuery":
-                            metric_timings[metric] += breakdown["exact_search_after_ann"] + breakdown["exact_search_after_filter"]
-                        elif metric in breakdown:
+                        if metric in breakdown:
                             metric_timings[metric] += breakdown[metric]
                     if "children" in query:
                         children = query['children']


### PR DESCRIPTION
### Description
k-NN repo had changes dealing with KNNQuery and the simplification to its output (no more "_after_ann" or "_after_filter"). Therefore, the newly merged code dealing with profile metrics getting benchmarked needs to change. This is a simple if-statement removal. Changes shouldn't occur beyond this because users will just define all metrics they want via parameter file.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
