### PR TITLE
Change run-test to run

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -1198,7 +1198,8 @@ def handle_command_suggestions():
     Check for common command mistakes and provide helpful suggestions
     Returns True if suggestion was provided, False otherwise
     """
-    if len(sys.argv) > 1 and sys.argv[1] == "execute-test":
+    DEPRECATED_SUBCOMMANDS = ["execute-test", "execute"]
+    if len(sys.argv) > 1 and sys.argv[1] in DEPRECATED_SUBCOMMANDS:
         console.info("Did you mean 'run'?")
         console.info("Example: opensearch-benchmark run --workload=geonames --test-mode")
         console.info("For more information, run: opensearch-benchmark run --help")
@@ -1218,7 +1219,7 @@ def main():
 
     # Handle command suggestions before argument parsing
     if handle_command_suggestions():
-        return
+        sys.exit(1)
 
     arg_parser = create_arg_parser()
     args = arg_parser.parse_args()


### PR DESCRIPTION
### Description
Updates the CLI command from run-test to run for OpenSearch Benchmark 2.0.0. Legacy command suggestions are maintained for users who might still try the old "execute-test" command, providing helpful guidance to use the new "run" command.

- CLI command updated from 'run-test' to 'run'
- Legacy 'execute-test' command shows helpful suggestion to use 'run'

### Issues Resolved
#875 

### Testing
- [x] New functionality includes testing

Unit Tests: All 1317 unit tests pass, 5 skipped - confirms no regression in core functionality

Integration Tests: 15 out of 19 integration tests pass - core benchmark functionality working correctly (4 failures are infrastructure-related, not CLI-related)

End-to-End CLI Testing:
Verified opensearch-benchmark run --help works correctly
Verified opensearch-benchmark --help shows "run" as primary command
Verified legacy command suggestion: opensearch-benchmark execute-test shows "Did you mean 'run'?" message
Tested basic CLI functionality with workload listing and command parsing

Manual Testing: Confirmed CLI command structure is correct and user-friendly error messages are displayed for legacy commands

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
