### PR TITLE
auto-refresh aws creds using boto3

### DIFF
--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2253,7 +2253,7 @@ class AsyncExecutor:
 
         # Client options are fetched once during initialization, not on every request.
         self.client_options = self._get_client_options()
-        self.base_timeout = int(self.client_options.get("base_timeout", 10))
+        self.base_timeout = int(self.client_options.get("timeout", 10))
 
         # Variables to keep track of during execution
         self.expected_scheduled_time = 0
@@ -2266,7 +2266,7 @@ class AsyncExecutor:
         try:
             if self.cfg is not None:
                 client_options_obj = self.cfg.opts("client", "options")
-                return getattr(client_options_obj, "all_client_options", {}) or {}
+                return client_options_obj.default or {}
             else:
                 return {}
         except exceptions.ConfigError:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "opensearch-py[async]>=2.5.0",
+    "opensearch-py[async]>=2.5.0,<3.0.0",
     # License: BSD
     "psutil>=5.8.0",
     # License: MIT

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -73,6 +73,7 @@ class WorkerCoordinatorTests(TestCase):
             self.all_hosts = all_hosts
             self.all_client_options = all_client_options
             self.uses_static_responses = False
+            self.default = all_client_options.get('default', {}) if all_client_options else {}
 
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
@@ -1908,7 +1909,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         """Test that _get_client_options returns correct options from config."""
         options = self.executor._get_client_options()
         self.assertIsInstance(options, dict)
-        self.assertEqual(options.get("default", {}).get("base_timeout"), 10)
+        self.assertEqual(options.get("timeout"), None)
 
     def test_get_client_options_with_no_config(self):
         """Test that _get_client_options returns empty dict when config is None."""


### PR DESCRIPTION
### Description
This PR: 

* Fixes a bug where latest major version 3.0.0 of opensearch-py is getting installed that has breaking changes and failing OSB run. 
* Adds new `session` parameter for `amazon_aws_log_in` to use boto3 session credentials to auto-refresh before expiry. 
* Fixes a bug in AsyncExecutor class which was wrongly referring the client options from config object. 

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
