### PR TITLE
Address pkg_resources deprecation

### DIFF
--- a/osbenchmark/__init__.py
+++ b/osbenchmark/__init__.py
@@ -26,9 +26,9 @@ import os
 import sys
 import urllib
 
-import pkg_resources
+from importlib.metadata import version as get_version
 
-__version__ = pkg_resources.require("opensearch-benchmark")[0].version
+__version__ = get_version("opensearch-benchmark")
 
 # Allow an alternative program name be set in case OSB is invoked a wrapper script
 PROGRAM_NAME = os.getenv("BENCHMARK_ALTERNATIVE_BINARY_NAME", os.path.basename(sys.argv[0]))

--- a/osbenchmark/version.py
+++ b/osbenchmark/version.py
@@ -24,13 +24,14 @@
 
 import re
 from importlib import resources
+from importlib.metadata import version as get_version
 
-import pkg_resources
+
 
 from osbenchmark import paths
 from osbenchmark.utils import git, io
 
-__version__ = pkg_resources.require("opensearch-benchmark")[0].version
+__version__ = get_version("opensearch-benchmark")
 
 __BENCHMARK_VERSION_PATTERN = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:.(.+))?$")
 

--- a/osbenchmark/version.py
+++ b/osbenchmark/version.py
@@ -26,8 +26,6 @@ import re
 from importlib import resources
 from importlib.metadata import version as get_version
 
-
-
 from osbenchmark import paths
 from osbenchmark.utils import git, io
 


### PR DESCRIPTION
### Description
Adding a quick fix for removing pkg-resources

### Issues Resolved
#867 

### Testing
- [x] New functionality includes testing

Ran unittests and synthetic data generator and confirmed that warning does not show up anymore. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
