### PR TITLE
add lint checker for 2.X terms in 1.X branch

### DIFF
--- a/.ci/scripts/check_for_2-X_terms.py
+++ b/.ci/scripts/check_for_2-X_terms.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+
+DEPRECATED_TERMS = [
+    "cluster-configs",
+    "reporting",
+    "worker-hosts",
+    "run-test",
+    "test-run",
+]
+
+SKIP_DIRS = [".git", "venv", "__pycache__", ".pytest_cache"]
+VALID_EXTENSIONS = (".py", ".yml", ".yaml", ".md", ".sh", ".json", ".txt")
+
+VARIANT_PATTERNS = []
+
+def generate_variants(term):
+    base = term.replace("-", " ").replace("_", " ")
+    words = base.split()
+    variants = set()
+
+    # kebab-case, snake_case, PascalCase, camelCase
+    variants.add("-".join(words))
+    variants.add("_".join(words))
+    variants.add("".join([w.capitalize() for w in words]))        # PascalCase
+    variants.add(words[0] + "".join([w.capitalize() for w in words[1:]]))  # camelCase
+
+    # Word order flip for 2-word terms
+    if len(words) == 2:
+        variants.add("-".join(words[::-1]))
+        variants.add("_".join(words[::-1]))
+        variants.add(words[1] + words[0].capitalize())  # camelCase reverse
+
+    return variants
+
+for term in DEPRECATED_TERMS:
+    for variant in generate_variants(term):
+        VARIANT_PATTERNS.append(re.compile(re.escape(variant), re.IGNORECASE))
+
+def should_check_file(filename):
+    return filename.endswith(VALID_EXTENSIONS)
+
+def main():
+    error_found = False
+
+    for root, _, files in os.walk("."):
+        if any(skip in root for skip in SKIP_DIRS):
+            continue
+
+        for f in files:
+            full_path = os.path.join(root, f)
+            if not should_check_file(full_path):
+                continue
+
+            try:
+                with open(full_path, "r", encoding="utf-8") as file:
+                    for i, line in enumerate(file, 1):
+                        for pattern in VARIANT_PATTERNS:
+                            if pattern.search(line):
+                                print(f"[Deprecated Term] {full_path}:{i}: {line.strip()}")
+                                error_found = True
+            except Exception as e:
+                print(f"[Warning] Skipped file {full_path}: {e}")
+
+    if error_found:
+        print("\n❌ Deprecated terms found. Please remove or rename them.")
+        sys.exit(1)
+
+    print("✅ No deprecated terms found.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,3 +24,7 @@ jobs:
 
       - name: Run the CI build script
         run: bash .ci/build.sh build_and_unit_test
+
+      - name: Run 2.X term lint checker
+        run: .ci/scripts/check_for_2-X_terms.py
+        if: contains(github.event.pull_request.labels.*.name, '1.x-terms-only')


### PR DESCRIPTION
### Description
Adds lint checker to check for 2.X terms in a 1.X branch

### Issues Resolved
#892 

### Testing
- [x] New functionality includes testing

Tested by running lint checker against OSB mainline

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
