### PR TITLE
Add 'fire and forget' mode to OSB

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -792,6 +792,12 @@ def create_arg_parser():
     help="Path where the HTML visualization should be saved when --visualize is enabled. If not specified, it will be saved in the test run directory.",
     default=None
     )
+    test_run_parser.add_argument(
+        "--no-await",
+        help="Enable unhinged mode for maximum throughput without response handling or metrics collection (search queries only).",
+        action="store_true",
+        default=False
+    )
 
     ###############################################################################
     #
@@ -1141,6 +1147,7 @@ def configure_test(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.alpha", args.randomization_alpha)
     cfg.add(config.Scope.applicationOverride, "workload", "visualize", args.visualize)
     cfg.add(config.Scope.applicationOverride, "workload", "visualize.output.path", args.visualize_output_path)
+    cfg.add(config.Scope.applicationOverride, "worker_coordinator", "no_await", args.no_await)
     configure_workload_params(arg_parser, args, cfg)
     configure_connection_params(arg_parser, args, cfg)
     configure_telemetry_params(args, cfg)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1589,6 +1589,43 @@ class Query(Runner):
             result["recall_time_ms"] = recall_processing_time
             return result
 
+        async def _fire_and_forget_query(opensearch, params):
+            """
+            Fire-and-forget search execution.
+
+            The caller (AsyncNoAwaitExecutor) has already wrapped this call in an
+            asyncio.Task so the dispatch loop returns immediately. We do the HTTP
+            call inline here (NOT as another nested task) so the executor's drain
+            at end-of-run waits for the actual HTTP request to finish — otherwise
+            the aiohttp session is torn down before the request completes and we
+            get "Session is closed" errors for every request.
+            """
+            doc_type = params.get("type")
+
+            # Modify request_params to disable timeouts for fire-and-forget mode
+            ff_request_params = request_params.copy()
+            ff_request_params.pop("timeout", None)
+            ff_request_params.pop("request_timeout", None)
+
+            try:
+                await self._raw_search(opensearch, doc_type, index, body, ff_request_params, headers=headers)
+            except Exception:
+                # Silently consume all exceptions in fire-and-forget mode
+                pass
+
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "fire_and_forget": True
+            }
+
+        # Check if fire-and-forget mode is enabled
+        fire_and_forget = params.get("fire_and_forget", False)
+        if fire_and_forget:
+            return await _fire_and_forget_query(opensearch, params)
+
+
         search_method = params.get("operation-type")
         if search_method == "paginated-search":
             return await _search_after_query(opensearch, params)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1610,7 +1610,7 @@ class Query(Runner):
             try:
                 await self._raw_search(opensearch, doc_type, index, body, ff_request_params, headers=headers)
             except Exception:
-                # Silently consume all exceptions in fire-and-forget mode
+                # Silently swallow errors in fire-and-forget mode
                 pass
 
             return {

--- a/osbenchmark/worker_coordinator/scheduler.py
+++ b/osbenchmark/worker_coordinator/scheduler.py
@@ -246,7 +246,6 @@ class UnhingedScheduler(SimpleScheduler):
         return f"unhinged (target_interval={self.wait_time:.6f}s)"
 
 
-
 class DeterministicScheduler(SimpleScheduler):
     """
     Schedules the next execution according to a

--- a/osbenchmark/worker_coordinator/scheduler.py
+++ b/osbenchmark/worker_coordinator/scheduler.py
@@ -227,6 +227,26 @@ class Unthrottled(Scheduler):
         return "unthrottled"
 
 
+class UnhingedScheduler(SimpleScheduler):
+    """
+    Fire-and-forget scheduler that maintains consistent timing without waiting for responses.
+    Designed for maximum throughput scenarios where response handling is disabled.
+    """
+    name = "unhinged"
+
+    def __init__(self, task, target_throughput):
+        super().__init__()
+        self.wait_time = 1 / target_throughput
+
+    def next(self, current):
+        """Return next scheduled time based on target interval."""
+        return current + self.wait_time
+
+    def __str__(self):
+        return f"unhinged (target_interval={self.wait_time:.6f}s)"
+
+
+
 class DeterministicScheduler(SimpleScheduler):
     """
     Schedules the next execution according to a

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -47,6 +47,7 @@ import thespian.actors
 
 from osbenchmark.utils import opts
 from osbenchmark import actor, config, exceptions, metrics, workload, client, paths, PROGRAM_NAME, telemetry
+from osbenchmark.context import RequestContextHolder
 from osbenchmark.worker_coordinator import runner, scheduler
 from osbenchmark.database.factory import DatabaseClientFactory
 from osbenchmark.database.registry import DatabaseType, get_client_factory
@@ -2244,7 +2245,8 @@ class AsyncIoAdapter:
                 client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
                 task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
-            aws.append(final_executor())
+            executor_task = final_executor()
+            aws.append(executor_task)
         run_start = time.perf_counter()
         try:
             _ = await asyncio.gather(*aws)
@@ -2575,6 +2577,153 @@ class AsyncExecutor:
                 self.complete.set()
             await self._cleanup()
 
+class UnhingedExecutor:
+    def __init__(self, client_id, task, schedule, opensearch, sampler, profile_sampler, cancel, complete, on_error,
+                 config=None, shared_states=None, feedback_actor=None, error_queue=None, queue_lock=None):
+        """
+        Fire-and-forget executor for maximum throughput without response handling or metrics collection.
+        Only supports search queries.
+        """
+        self.client_id = client_id
+        self.task = task
+        self.op = task.operation
+        self.schedule_handle = schedule
+        self.opensearch = opensearch
+        self.cancel = cancel
+        self.complete = complete
+        self.logger = logging.getLogger(__name__)
+        self.cfg = config
+        self.shared_states = shared_states
+        self.is_0 = int(self.client_id) == 0
+
+        # Variables to keep track of during execution
+        self.expected_scheduled_time = 0
+        self.sample_type = None
+        self.runner = None
+        self.task_completes_parent = False
+
+        # Use shared state for global TPS tracking if available (redline testing only)
+        if self.shared_states and 'global_tps_tracking' not in self.shared_states:
+            self.shared_states['global_tps_tracking'] = {
+                'total_requests': 0,
+                'current_second_requests': 0,
+                'current_second_start': time.perf_counter(),
+                'tps_history': [],
+                'start_time': None,
+                'last_display_time': 0,
+                'lock': asyncio.Lock()
+            }
+
+    async def _wait_for_rampup(self, rampup_wait_time: float) -> None:
+        """Wait for the ramp-up phase if needed."""
+        if rampup_wait_time:
+            self.logger.info("client id [%s] waiting [%.2f]s for ramp-up.", self.client_id, rampup_wait_time)
+            await asyncio.sleep(rampup_wait_time)
+            self.logger.info("Client id [%s] is running now.", self.client_id)
+
+
+    async def _fire_and_forget_request(self, params: dict, expected_scheduled_time: float, total_start: float) -> None:
+        """Execute a request in fire-and-forget mode - no response handling or metrics collection."""
+        absolute_expected_schedule_time = total_start + expected_scheduled_time
+        throughput_throttled = expected_scheduled_time > 0
+
+        if throughput_throttled:
+            rest = absolute_expected_schedule_time - time.perf_counter()
+            if rest > 0:
+                self.logger.debug("Client [%s] sleeping [%s]s for throttling", self.client_id, rest)
+                await asyncio.sleep(rest)
+
+        processing_start = time.perf_counter()
+        self.logger.debug("Client [%s] executing request at processing_start [%s]", self.client_id, processing_start)
+        self.schedule_handle.before_request(processing_start)
+
+        # Fire and forget - create async task to execute request without waiting
+        try:
+            # Add fire_and_forget flag to params for the runner
+            if params is None:
+                params = {}
+            params["fire_and_forget"] = True
+            # Remove any timeout settings to prevent timeout errors
+            params.pop("request-timeout", None)
+
+            # Create fire-and-forget task directly - no nested task creation
+            self.logger.debug("Client [%s] creating direct fire-and-forget task", self.client_id)
+            async def fire_and_forget_runner():
+                try:
+
+                    # Initialize request context for the fire-and-forget task
+                    ctx, token = RequestContextHolder.init_request_context()
+                    try:
+                        async with self.runner:
+                            await self.runner(self.opensearch, params)
+                    finally:
+                        # Clean up the context
+                        RequestContextHolder.restore_context(token)
+
+                except Exception as e:
+                    # Log errors for debugging
+                    pass
+
+            # Create task but don't await - true fire and forget
+            task = asyncio.create_task(fire_and_forget_runner())
+            # Suppress exceptions for fire-and-forget mode
+            def handle_task_completion(t):
+                if not t.cancelled():
+                    t.exception()  # Consume exception to prevent logging
+            task.add_done_callback(handle_task_completion)
+
+        except Exception:
+            # Silently ignore all errors in fire-and-forget mode
+            pass
+
+        processing_end = time.perf_counter()
+        # Minimal metrics - just mark the request as sent
+        self.schedule_handle.after_request(processing_end, 1, "ops", {"success": True, "fire_and_forget": True})
+
+    async def __call__(self, *args, **kwargs):
+        self.task_completes_parent = self.task.completes_parent
+        total_start = time.perf_counter()
+
+        self.logger.debug("Initializing unhinged schedule for client id [%s].", self.client_id)
+        schedule = self.schedule_handle()
+        self.schedule_handle.start()
+        rampup_wait_time = self.schedule_handle.ramp_up_wait_time
+
+        await self._wait_for_rampup(rampup_wait_time)
+
+        self.logger.debug("Entering unhinged main loop for client id [%s].", self.client_id)
+        try:
+            async for expected_scheduled_time, sample_type, percent_completed, runner, params in schedule:
+                self.expected_scheduled_time = expected_scheduled_time
+                self.sample_type = sample_type
+                self.runner = runner
+
+
+                if self.cancel.is_set():
+                    self.logger.info("User cancelled execution.")
+                    break
+
+                # UnhingedScheduler should provide consistent timing, no override needed
+
+                # Fire and forget mode - don't wait for responses
+                await self._fire_and_forget_request(params, expected_scheduled_time, total_start)
+
+                # Check completion status
+                if self.complete.is_set():
+                    self.logger.info("Task [%s] is considered completed due to external event.", self.task)
+                    break
+        except BaseException as e:
+            self.logger.exception("Could not execute unhinged schedule")
+            raise exceptions.BenchmarkError(f"Cannot run task [{self.task}]: {e}") from None
+        finally:
+            if self.task_completes_parent:
+                self.logger.info(
+                    "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion.",
+                    self.task, self.client_id
+                )
+                self.complete.set()
+
+
 request_context_holder = client.RequestContextHolder()
 
 
@@ -2675,6 +2824,8 @@ async def execute_single(runner, opensearch, params, on_error, redline_enabled=F
         request_context_holder.on_request_end()
         request_context_holder.on_client_request_end()
     return total_ops, total_ops_unit, request_meta_data
+
+
 
 
 class JoinPoint:
@@ -2910,6 +3061,54 @@ def schedule_for(task_allocation, parameter_source):
             logger.info("Parameter source will determine when the schedule for [%s] terminates.", task.name)
         else:
             logger.info("%s schedule will determine when the schedule for [%s] terminates.", str(loop_control), task.name)
+
+    return ScheduleHandle(task_allocation, sched, loop_control, runner_for_op, params_for_op)
+
+
+def schedule_for_unhinged(task_allocation, parameter_source):
+    """
+    Creates a schedule for fire-and-forget mode using the UnhingedScheduler.
+    This scheduler maintains consistent timing without waiting for responses.
+    """
+    logger = logging.getLogger(__name__)
+    task = task_allocation.task
+    op = task.operation
+
+    # Force use of UnhingedScheduler for fire-and-forget mode by setting the schedule
+    task.schedule = "unhinged"
+    sched = scheduler.scheduler_for(task)
+
+    client_index = task_allocation.client_index_in_task
+    if client_index == 0:
+        logger.info("Choosing [%s] for [%s] (fire-and-forget mode).", sched, task)
+    runner_for_op = runner.runner_for(op.type)
+    params_for_op = parameter_source.partition(client_index, task.clients)
+
+    if hasattr(sched, "parameter_source"):
+        if client_index == 0:
+            logger.debug("Setting parameter source [%s] for scheduler [%s]", params_for_op, sched)
+        sched.parameter_source = params_for_op
+
+    if requires_time_period_schedule(task, runner_for_op, params_for_op):
+        warmup_time_period = task.warmup_time_period if task.warmup_time_period else 0
+        if client_index == 0:
+            logger.info("Creating time-period based schedule with [%s] distribution for [%s] with a warmup period of [%s] "
+                       "second(s) and a time period of [%s] second(s).", sched, task, warmup_time_period, task.time_period)
+
+        loop_control = TimePeriodBased(warmup_time_period, task.time_period)
+    else:
+        warmup_iterations = task.warmup_iterations if task.warmup_iterations else 0
+        if task.iterations:
+            iterations = task.iterations
+        elif params_for_op.infinite:
+            iterations = 1
+        else:
+            iterations = None
+        if client_index == 0:
+            logger.info("Creating iteration-count based schedule with [%s] distribution for [%s] with [%s] warmup iteration(s) "
+                       "and [%s] iteration(s).", sched, task, warmup_iterations, iterations)
+
+        loop_control = IterationBased(warmup_iterations, iterations)
 
     return ScheduleHandle(task_allocation, sched, loop_control, runner_for_op, params_for_op)
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2657,9 +2657,8 @@ class AsyncNoAwaitExecutor:
                     finally:
                         # Clean up the context
                         RequestContextHolder.restore_context(token)
-
                 except Exception:
-                    # Log errors for debugging
+                    # Silently swallow errors in fire-and-forget mode
                     pass
 
             # Create task but don't await - true fire and forget

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2246,8 +2246,8 @@ class AsyncIoAdapter:
             schedule = schedule_for(task_allocation, params_per_task[task], fire_and_forget)
 
             if fire_and_forget:
-                # Use UnhingedExecutor for fire-and-forget mode
-                async_executor = UnhingedExecutor(
+                # Use AsyncNoAwaitExecutor for fire-and-forget mode
+                async_executor = AsyncNoAwaitExecutor(
                     client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
                     task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
             else:
@@ -2588,7 +2588,7 @@ class AsyncExecutor:
                 self.complete.set()
             await self._cleanup()
 
-class UnhingedExecutor:
+class AsyncNoAwaitExecutor:
     def __init__(self, client_id, task, schedule, opensearch, sampler, profile_sampler, cancel, complete, on_error,
                  config=None, shared_states=None, feedback_actor=None, error_queue=None, queue_lock=None):
         """
@@ -2621,7 +2621,7 @@ class UnhingedExecutor:
             self.logger.info("Client id [%s] is running now.", self.client_id)
 
 
-    async def _fire_and_forget_request(self, params: dict, expected_scheduled_time: float, total_start: float) -> None:
+    async def _async_no_await_request(self, params: dict, expected_scheduled_time: float, total_start: float) -> None:
         """Execute a request in fire-and-forget mode - no response handling or metrics collection."""
         absolute_expected_schedule_time = total_start + expected_scheduled_time
         throughput_throttled = expected_scheduled_time > 0
@@ -2701,7 +2701,7 @@ class UnhingedExecutor:
                     break
 
                 # Fire and forget mode - don't wait for responses
-                await self._fire_and_forget_request(params, expected_scheduled_time, total_start)
+                await self._async_no_await_request(params, expected_scheduled_time, total_start)
 
                 # Check completion status
                 if self.complete.is_set():

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2711,6 +2711,18 @@ class AsyncNoAwaitExecutor:
             self.logger.exception("Could not execute unhinged schedule")
             raise exceptions.BenchmarkError(f"Cannot run task [{self.task}]: {e}") from None
         finally:
+            # Drain any in-flight fire-and-forget tasks before exiting. The dispatch
+            # loop completes very quickly (it just creates background tasks), so without
+            # this drain the event loop would be torn down and pending HTTP requests
+            # would be destroyed mid-flight. This also keeps metric samples flowing
+            # while the requests complete.
+            if self._inflight_tasks:
+                self.logger.info(
+                    "Client [%s] draining [%d] in-flight fire-and-forget tasks before exit...",
+                    self.client_id, len(self._inflight_tasks)
+                )
+                await asyncio.gather(*self._inflight_tasks, return_exceptions=True)
+
             if self.task_completes_parent:
                 self.logger.info(
                     "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion.",

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2257,8 +2257,7 @@ class AsyncIoAdapter:
                     task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
 
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
-            executor_task = final_executor()
-            aws.append(executor_task)
+            aws.append(final_executor())
         run_start = time.perf_counter()
         try:
             _ = await asyncio.gather(*aws)
@@ -2820,9 +2819,6 @@ async def execute_single(runner, opensearch, params, on_error, redline_enabled=F
         request_context_holder.on_request_end()
         request_context_holder.on_client_request_end()
     return total_ops, total_ops_unit, request_meta_data
-
-
-
 
 class JoinPoint:
     def __init__(self, id, clients_executing_completing_task=None):

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2650,7 +2650,7 @@ class UnhingedExecutor:
                 try:
 
                     # Initialize request context for the fire-and-forget task
-                    ctx, token = RequestContextHolder.init_request_context()
+                    _, token = RequestContextHolder.init_request_context()
                     try:
                         async with self.runner:
                             await self.runner(self.opensearch, params)
@@ -2658,7 +2658,7 @@ class UnhingedExecutor:
                         # Clean up the context
                         RequestContextHolder.restore_context(token)
 
-                except Exception as e:
+                except Exception:
                     # Log errors for debugging
                     pass
 
@@ -2691,7 +2691,7 @@ class UnhingedExecutor:
 
         self.logger.debug("Entering unhinged main loop for client id [%s].", self.client_id)
         try:
-            async for expected_scheduled_time, sample_type, percent_completed, runner, params in schedule:
+            async for expected_scheduled_time, sample_type, _, runner, params in schedule:
                 self.expected_scheduled_time = expected_scheduled_time
                 self.sample_type = sample_type
                 self.runner = runner

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -2240,10 +2240,22 @@ class AsyncIoAdapter:
             #
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
-            schedule = schedule_for(task_allocation, params_per_task[task])
-            async_executor = AsyncExecutor(
-                client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
-                task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+
+            # Check if fire-and-forget mode is enabled and use appropriate schedule
+            fire_and_forget = self.cfg.opts("worker_coordinator", "fire_and_forget", mandatory=False, default_value=False)
+            schedule = schedule_for(task_allocation, params_per_task[task], fire_and_forget)
+
+            if fire_and_forget:
+                # Use UnhingedExecutor for fire-and-forget mode
+                async_executor = UnhingedExecutor(
+                    client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
+                    task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+            else:
+                # Use regular AsyncExecutor
+                async_executor = AsyncExecutor(
+                    client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
+                    task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
             executor_task = final_executor()
             aws.append(executor_task)
@@ -2602,18 +2614,6 @@ class UnhingedExecutor:
         self.runner = None
         self.task_completes_parent = False
 
-        # Use shared state for global TPS tracking if available (redline testing only)
-        if self.shared_states and 'global_tps_tracking' not in self.shared_states:
-            self.shared_states['global_tps_tracking'] = {
-                'total_requests': 0,
-                'current_second_requests': 0,
-                'current_second_start': time.perf_counter(),
-                'tps_history': [],
-                'start_time': None,
-                'last_display_time': 0,
-                'lock': asyncio.Lock()
-            }
-
     async def _wait_for_rampup(self, rampup_wait_time: float) -> None:
         """Wait for the ramp-up phase if needed."""
         if rampup_wait_time:
@@ -2630,7 +2630,6 @@ class UnhingedExecutor:
         if throughput_throttled:
             rest = absolute_expected_schedule_time - time.perf_counter()
             if rest > 0:
-                self.logger.debug("Client [%s] sleeping [%s]s for throttling", self.client_id, rest)
                 await asyncio.sleep(rest)
 
         processing_start = time.perf_counter()
@@ -2698,12 +2697,9 @@ class UnhingedExecutor:
                 self.sample_type = sample_type
                 self.runner = runner
 
-
                 if self.cancel.is_set():
                     self.logger.info("User cancelled execution.")
                     break
-
-                # UnhingedScheduler should provide consistent timing, no override needed
 
                 # Fire and forget mode - don't wait for responses
                 await self._fire_and_forget_request(params, expected_scheduled_time, total_start)
@@ -3003,25 +2999,34 @@ class Allocator:
 
 # Runs a concrete schedule on one worker client
 # Needs to determine the runners and concrete iterations per client.
-def schedule_for(task_allocation, parameter_source):
+def schedule_for(task_allocation, parameter_source, fire_and_forget=False):
     """
     Calculates a client's schedule for a given task.
 
     :param task: The task that should be executed.
     :param client_index: The current client index.  Must be in the range [0, `task.clients').
     :param parameter_source: The parameter source that should be used for this task.
+    :param fire_and_forget: If True, forces deterministic scheduling for fire-and-forget mode.
     :return: A generator for the operations the given client needs to perform for this task.
     """
     logger = logging.getLogger(__name__)
     task = task_allocation.task
     op = task.operation
+
+    # Force deterministic scheduler for fire-and-forget mode
+    if fire_and_forget and not task.schedule:
+        task.schedule = "deterministic"
+
     sched = scheduler.scheduler_for(task)
 
     client_index = task_allocation.client_index_in_task
     # guard all logging statements with the client index and only emit them for the first client. This information is
     # repetitive and may cause issues in thespian with many clients (an excessive number of actor messages is sent).
     if client_index == 0:
-        logger.info("Choosing [%s] for [%s].", sched, task)
+        if fire_and_forget:
+            logger.info("Choosing [%s] for [%s] (fire-and-forget mode).", sched, task)
+        else:
+            logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = parameter_source.partition(client_index, task.clients)
     if hasattr(sched, "parameter_source"):
@@ -3063,55 +3068,6 @@ def schedule_for(task_allocation, parameter_source):
             logger.info("%s schedule will determine when the schedule for [%s] terminates.", str(loop_control), task.name)
 
     return ScheduleHandle(task_allocation, sched, loop_control, runner_for_op, params_for_op)
-
-
-def schedule_for_unhinged(task_allocation, parameter_source):
-    """
-    Creates a schedule for fire-and-forget mode using the UnhingedScheduler.
-    This scheduler maintains consistent timing without waiting for responses.
-    """
-    logger = logging.getLogger(__name__)
-    task = task_allocation.task
-    op = task.operation
-
-    # Force use of UnhingedScheduler for fire-and-forget mode by setting the schedule
-    task.schedule = "unhinged"
-    sched = scheduler.scheduler_for(task)
-
-    client_index = task_allocation.client_index_in_task
-    if client_index == 0:
-        logger.info("Choosing [%s] for [%s] (fire-and-forget mode).", sched, task)
-    runner_for_op = runner.runner_for(op.type)
-    params_for_op = parameter_source.partition(client_index, task.clients)
-
-    if hasattr(sched, "parameter_source"):
-        if client_index == 0:
-            logger.debug("Setting parameter source [%s] for scheduler [%s]", params_for_op, sched)
-        sched.parameter_source = params_for_op
-
-    if requires_time_period_schedule(task, runner_for_op, params_for_op):
-        warmup_time_period = task.warmup_time_period if task.warmup_time_period else 0
-        if client_index == 0:
-            logger.info("Creating time-period based schedule with [%s] distribution for [%s] with a warmup period of [%s] "
-                       "second(s) and a time period of [%s] second(s).", sched, task, warmup_time_period, task.time_period)
-
-        loop_control = TimePeriodBased(warmup_time_period, task.time_period)
-    else:
-        warmup_iterations = task.warmup_iterations if task.warmup_iterations else 0
-        if task.iterations:
-            iterations = task.iterations
-        elif params_for_op.infinite:
-            iterations = 1
-        else:
-            iterations = None
-        if client_index == 0:
-            logger.info("Creating iteration-count based schedule with [%s] distribution for [%s] with [%s] warmup iteration(s) "
-                       "and [%s] iteration(s).", sched, task, warmup_iterations, iterations)
-
-        loop_control = IterationBased(warmup_iterations, iterations)
-
-    return ScheduleHandle(task_allocation, sched, loop_control, runner_for_op, params_for_op)
-
 
 def requires_time_period_schedule(task, task_runner, params):
     if task.warmup_time_period is not None or task.time_period is not None:

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -2476,3 +2476,147 @@ class TaskRampDownTests(TestCase):
 
         # Different ramp_down should produce different hashes
         self.assertNotEqual(hash(task1), hash(task2))
+
+
+class UnhingedExecutorTests(TestCase):
+    def setUp(self):
+        params.register_param_source_for_name("worker-coordinator-test-param-source", WorkerCoordinatorTestParamSource)
+
+        self.cfg = config.Config()
+        self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
+        self.cfg.add(config.Scope.application, "system", "available.cores", 8)
+        self.cfg.add(config.Scope.application, "workload", "test.mode.enabled", True)
+
+        all_client_options = {"default": {"base_timeout": 10}}
+        self.cfg.add(config.Scope.application, "client", "options",
+                     WorkerCoordinatorTests.Holder(all_client_options=all_client_options))
+
+        self.task = workload.Task("test-task",
+                                  workload.Operation("test-op", workload.OperationType.Bulk),
+                                  clients=2)
+        self.sampler = mock.Mock()
+        self.profile_sampler = mock.Mock()
+        self.cancel = threading.Event()
+        self.complete = threading.Event()
+        self.schedule_handle = mock.Mock()
+
+        opensearch_mock = mock.Mock()
+        opensearch_mock.new_request_context.return_value = mock.Mock()
+        self.opensearch = {"default": opensearch_mock}
+
+    def test_unhinged_executor_initialization(self):
+        executor = worker_coordinator.UnhingedExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        self.assertEqual(0, executor.client_id)
+        self.assertEqual(self.task, executor.task)
+        self.assertEqual(self.schedule_handle, executor.schedule_handle)
+        self.assertEqual(self.opensearch, executor.opensearch)
+        self.assertTrue(executor.is_0)
+
+    def test_unhinged_executor_client_id_not_zero(self):
+        executor = worker_coordinator.UnhingedExecutor(
+            client_id=1,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        self.assertEqual(1, executor.client_id)
+        self.assertFalse(executor.is_0)
+
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_fire_and_forget_request_creates_task(self, mock_create_task, mock_context_holder):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+
+        executor = worker_coordinator.UnhingedExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._fire_and_forget_request({}, 1.0, 0.0)
+
+        mock_create_task.assert_called_once()
+
+    @mock.patch('time.perf_counter')
+    @mock.patch('asyncio.sleep')
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_fire_and_forget_request_with_throttling(self, mock_create_task, mock_context_holder,
+                                                          mock_sleep, mock_perf_counter):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+        mock_perf_counter.return_value = 0.5  # Current time less than expected schedule time
+
+        executor = worker_coordinator.UnhingedExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._fire_and_forget_request({}, 1.0, 0.0)  # expected_scheduled_time = 1.0
+
+        mock_sleep.assert_called_once_with(0.5)  # Should sleep for the difference
+        mock_create_task.assert_called_once()
+
+    @mock.patch('time.perf_counter')
+    @mock.patch('asyncio.sleep')
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_fire_and_forget_request_no_throttling_needed(self, mock_create_task, mock_context_holder,
+                                                               mock_sleep, mock_perf_counter):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+        mock_perf_counter.return_value = 1.5  # Current time exceeds expected schedule time
+
+        executor = worker_coordinator.UnhingedExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._fire_and_forget_request({}, 1.0, 0.0)  # expected_scheduled_time = 1.0
+
+        mock_sleep.assert_not_called()  # No sleep needed
+        mock_create_task.assert_called_once()

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -2559,7 +2559,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)
+        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access
 
         mock_create_task.assert_called_once()
 
@@ -2587,7 +2587,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)  # expected_scheduled_time = 1.0
+        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
 
         mock_sleep.assert_called_once_with(0.5)  # Should sleep for the difference
         mock_create_task.assert_called_once()
@@ -2616,7 +2616,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)  # expected_scheduled_time = 1.0
+        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
 
         mock_sleep.assert_not_called()  # No sleep needed
         mock_create_task.assert_called_once()

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -2478,7 +2478,7 @@ class TaskRampDownTests(TestCase):
         self.assertNotEqual(hash(task1), hash(task2))
 
 
-class UnhingedExecutorTests(TestCase):
+class AsyncNoAwaitExecutorTests(TestCase):
     def setUp(self):
         params.register_param_source_for_name("worker-coordinator-test-param-source", WorkerCoordinatorTestParamSource)
 
@@ -2505,7 +2505,7 @@ class UnhingedExecutorTests(TestCase):
         self.opensearch = {"default": opensearch_mock}
 
     def test_unhinged_executor_initialization(self):
-        executor = worker_coordinator.UnhingedExecutor(
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
             client_id=0,
             task=self.task,
             schedule=self.schedule_handle,
@@ -2524,7 +2524,7 @@ class UnhingedExecutorTests(TestCase):
         self.assertTrue(executor.is_0)
 
     def test_unhinged_executor_client_id_not_zero(self):
-        executor = worker_coordinator.UnhingedExecutor(
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
             client_id=1,
             task=self.task,
             schedule=self.schedule_handle,
@@ -2542,10 +2542,10 @@ class UnhingedExecutorTests(TestCase):
     @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
     @mock.patch('asyncio.create_task')
     @run_async
-    async def test_fire_and_forget_request_creates_task(self, mock_create_task, mock_context_holder):
+    async def test_async_no_await_request_creates_task(self, mock_create_task, mock_context_holder):
         mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
 
-        executor = worker_coordinator.UnhingedExecutor(
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
             client_id=0,
             task=self.task,
             schedule=self.schedule_handle,
@@ -2559,7 +2559,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access
 
         mock_create_task.assert_called_once()
 
@@ -2568,12 +2568,12 @@ class UnhingedExecutorTests(TestCase):
     @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
     @mock.patch('asyncio.create_task')
     @run_async
-    async def test_fire_and_forget_request_with_throttling(self, mock_create_task, mock_context_holder,
+    async def test_async_no_await_request_with_throttling(self, mock_create_task, mock_context_holder,
                                                           mock_sleep, mock_perf_counter):
         mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
         mock_perf_counter.return_value = 0.5  # Current time less than expected schedule time
 
-        executor = worker_coordinator.UnhingedExecutor(
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
             client_id=0,
             task=self.task,
             schedule=self.schedule_handle,
@@ -2587,7 +2587,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
 
         mock_sleep.assert_called_once_with(0.5)  # Should sleep for the difference
         mock_create_task.assert_called_once()
@@ -2597,12 +2597,12 @@ class UnhingedExecutorTests(TestCase):
     @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
     @mock.patch('asyncio.create_task')
     @run_async
-    async def test_fire_and_forget_request_no_throttling_needed(self, mock_create_task, mock_context_holder,
+    async def test_async_no_await_request_no_throttling_needed(self, mock_create_task, mock_context_holder,
                                                                mock_sleep, mock_perf_counter):
         mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
         mock_perf_counter.return_value = 1.5  # Current time exceeds expected schedule time
 
-        executor = worker_coordinator.UnhingedExecutor(
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
             client_id=0,
             task=self.task,
             schedule=self.schedule_handle,
@@ -2616,7 +2616,7 @@ class UnhingedExecutorTests(TestCase):
 
         executor.runner = mock.AsyncMock()
 
-        await executor._fire_and_forget_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
 
         mock_sleep.assert_not_called()  # No sleep needed
         mock_create_task.assert_called_once()


### PR DESCRIPTION
### Description
Adds new 'fire and forget' mode to OSB. 

Rather than OSB's traditional client model of 'fire request -> await request -> record metrics -> move on', this mode allows each client to fire requests without needing to worry about awaiting responses or recording metrics. This allows OSB to easily sustain high throughput values when load testing cluster, and is intended for those who don't necessarily want precise measurements on each request, but would rather test their clusters against very high sustained throughput levels.

The drawback here is of course that there is no information returned to the user on how their cluster is performing aside from outside forms of polling/measurements, like the performance charts than can be viewed in the AWS console for their cluster.

The PR introduces a new flag, `--fire-and-forget`, which tells OSB to choose the [DeterministicScheduler](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/worker_coordinator/scheduler.py#L230-L246). Unlike the UnitAwareScheduler used for most benchmarks, this scheduler doesn't care about request metadata, it only calculates throughput for each client and tells them to send requests at a certain rate.

The flag also tells OSB to make use of a new request executor, called the UnhingedExecutor. This executor, unlike the AsyncExecutor, creates separate asynchronous tasks to send requests without awaiting them, ensuring requests are sent at the specified rate no matter the latency or failure rates. To sum it up, if each executor needs to send 2 RPS, this mode tells them to create 2 async tasks per second, each of which will send the request, rather than trying to send 1 request every 0.5 seconds on its own.

This mode can consume resources very quickly, and users should ensure their hardware is able to handle the thousands of async processes that are created when using this flag. It's also likely they will run into an OSerror `too many open files` with all of the connections being established.

The max number of network sockets can be checked with `ulimit -n` and changed with the same command, like: `ulimit -n 2048`

### Issues Resolved
#958 

### Testing
- [x] New functionality includes testing

New unit tests + running tests in 'fire and forget' mode against OS cluster at 500 TPS:

<img width="2411" height="1034" alt="Screenshot 2025-09-24 at 11 48 18 AM" src="https://github.com/user-attachments/assets/fc7e2bc1-4077-4e80-a58c-80d8331fe067" />
<img width="2428" height="974" alt="Screenshot 2025-09-24 at 11 47 55 AM" src="https://github.com/user-attachments/assets/a4d3806c-f531-4c29-a108-0f7efd04585c" />

Unit tests produce this warning since we don't await the async tasks:
```
sys:1: RuntimeWarning: coroutine 'UnhingedExecutor._fire_and_forget_request.<locals>.fire_and_forget_runner' was never awaited
Coroutine created at (most recent call last)
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "/Users/mikeovi/workplace/opensearch-benchmark/tests/__init__.py", line 35, in async_wrapper
    asyncio.run(t(*args, **kwargs), debug=True)
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 603, in run_until_complete
    self.run_forever()
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 570, in run_forever
    self._run_once()
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 1851, in _run_once
    handle._run()
  File "/Users/mikeovi/.pyenv/versions/3.8.12/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/mikeovi/workplace/opensearch-benchmark/tests/worker_coordinator/worker_coordinator_test.py", line 2454, in test_fire_and_forget_request_no_throttling_needed
    await executor._fire_and_forget_request({}, 1.0, 0.0)  # expected_scheduled_time = 1.0
  File "/Users/mikeovi/workplace/opensearch-benchmark/osbenchmark/worker_coordinator/worker_coordinator.py", line 2603, in _fire_and_forget_request
    task = asyncio.create_task(fire_and_forget_runner())
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
