### PR TITLE
Catch failing integration tests in GitHub workflows

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -31,8 +31,8 @@ function setup {
 
 function build_and_unit_test {
   setup
-
   set -e
+
   make develop
   make lint
   make test
@@ -40,6 +40,7 @@ function build_and_unit_test {
 
 function run_it {
   setup
+  set -e
 
   docker pull ubuntu/squid:latest
 


### PR DESCRIPTION
### Description

Failures in integration tests did not terminate the GitHub workflow, leading to bugs creeping into the codebase.

```
=========================== short test summary info ============================
FAILED it/distribution_test.py::test_tar_distributions[in-memory-it] - assert 2 == 0
FAILED it/distribution_test.py::test_docker_distribution[os-it] - assert 2 == 0
FAILED it/sources_test.py::test_sources[os-it] - AssertionError: assert 2 == 0
FAILED it/tracker_test.py::test_create_workload[in-memory-it] - AssertionError: assert 2 == 0
=================== 4 failed, 15 passed in 100.84s (0:01:40) ===================
py38: exit 1 (101.51 seconds) /home/runner/work/opensearch-benchmark/opensearch-benchmark> pytest -s it --junitxml=junit-py38-it.xml pid=55755
  py38: FAIL code 1 (131.58=setup[30.07]+cmd[0.00,101.51] seconds)
  evaluation failed :( (131.65 seconds)
make: *** [Makefile:93: it38] Error 1
Switched back to Java 17
openjdk version "17.0.15" 2025-04-15
OpenJDK Runtime Environment Temurin-17.0.15+6 (build 17.0.15+6)
8m 36s
 ```

### Testing
- [ ] Unit and integ tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
