### PR TITLE
Add individual doc retries to BulkVectorDataSet runner

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -965,24 +965,13 @@ class BulkVectorDataSet(Runner):
                     meta_data["error-type"] = "bulk"
                     if detailed_results:
                         failed_indices = stats.get("failed-indices", [])
-                        failed_docs = stats.get("failed-documents", [])
                         if failed_indices:
-                            self.logger.warning(
-                                "Bulk vector attempt %d failed with %d docs. Retrying indices %s.",
-                                attempt + 1,
+                            self.logger.info(
+                                "%d documents failed during ingestion. Retrying.",
                                 len(failed_indices),
-                                failed_indices[: min(10, len(failed_indices))],
                             )
-                            if failed_docs:
-                                sample_preview = failed_docs[: min(3, len(failed_docs))]
-                                self.logger.debug("Sample failed docs: %s", sample_preview)
                             current_body = self._build_retry_body(current_body, failed_indices, with_action_metadata)
                             continue
-                        else:
-                            self.logger.error(
-                                "Bulk vector attempt %d failed but no failed indices were recorded; cannot retry.",
-                                attempt + 1,
-                            )
                 return meta_data
             except ConnectionTimeout:
                 self.logger.warning("Bulk vector ingestion timed out. Retrying attempt: %d", attempt)
@@ -1107,11 +1096,6 @@ class BulkVectorDataSet(Runner):
                     )
                 else:
                     retry_lines.append(lines[idx])
-            self.logger.info(
-                "Retrying %d string docs, indices=%s",
-                len(failed_indices),
-                failed_indices[: min(10, len(failed_indices))],
-            )
             return "\n".join(retry_lines) + ("\n" if retry_lines else "")
 
         retry_body = []
@@ -1122,11 +1106,6 @@ class BulkVectorDataSet(Runner):
         else:
             for idx in failed_indices:
                 retry_body.append(body[idx])
-        self.logger.info(
-            "Retrying %d structured docs, indices=%s",
-            len(failed_indices),
-            failed_indices[: min(10, len(failed_indices))],
-        )
         return retry_body
 
     def simple_stats(self, size, unit, response):

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -941,6 +941,7 @@ class BulkVectorDataSet(Runner):
         current_params = dict(params)
 
         for attempt in range(retries):
+            print("Retrying failed documents...")
             docs_in_request = self._doc_count(current_body, with_action_metadata)
             current_params["body"] = current_body
             current_params["size"] = docs_in_request

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -932,7 +932,7 @@ class BulkVectorDataSet(Runner):
         with_action_metadata = params.get("action-metadata-present", True)
         unit = params.get("unit", "docs")
         retries = parse_int_parameter("retries", params, 0) + 1
-        detailed_results = params.get("detailed-results", False)
+        detailed_results = params.get("detailed-results", True)
 
         if not detailed_results:
             opensearch.return_raw_response()

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1093,8 +1093,6 @@ class BulkVectorDataSet(Runner):
             len(failed_indices),
             with_action_metadata,
         )
-        self.logger.info(f"Body is of type: {type(body)}")
-        self.logger.info(f"Body printout: {body}")
         if isinstance(body, str):
             lines = [line for line in body.split("\n") if line]
             retry_lines = []

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -945,7 +945,7 @@ class BulkVectorDataSet(Runner):
                 )
                 request_context_holder.on_client_request_end()
 
-                stats = self.detailed_stats(params, response) if detailed_results else self.simple_stats(bulk_size, unit, response)
+                stats = self.detailed_stats(params, response) if detailed_results else self.simple_stats(size, unit, response)
 
                 meta_data = {
                     "size": size,

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -929,7 +929,7 @@ class BulkVectorDataSet(Runner):
     NAME = "bulk-vector-data-set"
 
     async def __call__(self, opensearch, params):
-        with_action_metadata = True
+        with_action_metadata = params.get("action-metadata-present", True)
         unit = params.get("unit", "docs")
         retries = parse_int_parameter("retries", params, 0) + 1
         detailed_results = params.get("detailed-results", True)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1093,6 +1093,8 @@ class BulkVectorDataSet(Runner):
             len(failed_indices),
             with_action_metadata,
         )
+        self.logger.info(f"Body is of type: {type(body)}")
+        self.logger.info(f"Body printout: ", body)
         if isinstance(body, str):
             lines = [line for line in body.split("\n") if line]
             retry_lines = []

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -950,7 +950,7 @@ class BulkVectorDataSet(Runner):
                 meta_data = {
                     "size": size,
                     "index": params.get("index"),
-                    "weight": bulk_size,
+                    "weight": size,
                     "unit": unit,
                 }
                 meta_data.update(stats)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1073,7 +1073,8 @@ class BulkVectorDataSet(Runner):
         raise exceptions.DataError("bulk body is neither string nor list")
 
     def _build_retry_body(self, body, failed_indices, with_action_metadata):
-        print("Building retry bodies...")
+        print("Building retry body...")
+        self.logger.info("Building retry body...")
         if isinstance(body, str):
             lines = [line for line in body.split("\n") if line]
             retry_lines = []
@@ -1089,6 +1090,7 @@ class BulkVectorDataSet(Runner):
                 else:
                     retry_lines.append(lines[idx])
             print(f"retrying {retry_lines} documents")
+            self.logger.info(f"Retrying {retry_lines} documents...")
             return "\n".join(retry_lines) + ("\n" if retry_lines else "")
 
         retry_body = []

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -930,14 +930,12 @@ class BulkVectorDataSet(Runner):
 
     async def __call__(self, opensearch, params):
         size = parse_int_parameter("size", params)
+        unit = "docs"
         retries = parse_int_parameter("retries", params, 0) + 1
         detailed_results = params.get("detailed-results", False)
 
         if not detailed_results:
             opensearch.return_raw_response()
-
-        bulk_size = mandatory(params, "bulk-size", self)
-        unit = mandatory(params, "unit", self)
 
         for attempt in range(retries):
             try:
@@ -1035,8 +1033,8 @@ class BulkVectorDataSet(Runner):
 
         return stats
 
-    def simple_stats(self, bulk_size, unit, response):
-        bulk_success_count = bulk_size if unit == "docs" else None
+    def simple_stats(self, size, unit, response):
+        bulk_success_count = size if unit == "docs" else None
         bulk_error_count = 0
         error_details = set()
         # parse lazily on the fast path

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1094,7 +1094,7 @@ class BulkVectorDataSet(Runner):
             with_action_metadata,
         )
         self.logger.info(f"Body is of type: {type(body)}")
-        self.logger.info(f"Body printout: ", body)
+        self.logger.info(f"Body printout: {body}")
         if isinstance(body, str):
             lines = [line for line in body.split("\n") if line]
             retry_lines = []

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -929,7 +929,7 @@ class BulkVectorDataSet(Runner):
     NAME = "bulk-vector-data-set"
 
     async def __call__(self, opensearch, params):
-        with_action_metadata = params.get("action-metadata-present", True)
+        with_action_metadata = True
         unit = params.get("unit", "docs")
         retries = parse_int_parameter("retries", params, 0) + 1
         detailed_results = params.get("detailed-results", True)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1063,6 +1063,23 @@ class BulkVectorDataSet(Runner):
             stats["error-type"] = "bulk"
             stats["error-description"] = self.error_description(error_details)
         return stats
+    
+    def extract_error_details(self, error_details, data):
+        error_data = data.get("error", {})
+        error_reason = error_data.get("reason") if isinstance(error_data, dict) else str(error_data)
+        if error_data:
+            error_details.add((data["status"], error_reason))
+        else:
+            error_details.add((data["status"], None))
+
+    def error_description(self, error_details):
+        error_description = ""
+        for status, reason in error_details:
+            if reason:
+                error_description += "HTTP status: %s, message: %s" % (str(status), reason)
+            else:
+                error_description += "HTTP status: %s" % str(status)
+        return error_description
 
     def __repr__(self, *args, **kwargs):
         return self.NAME

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1109,7 +1109,7 @@ class BulkVectorDataSet(Runner):
                     )
                 else:
                     retry_lines.append(lines[idx])
-            self.logger.debug(
+            self.logger.info(
                 "Retrying %d string docs, indices=%s",
                 len(failed_indices),
                 failed_indices[: min(10, len(failed_indices))],
@@ -1124,7 +1124,7 @@ class BulkVectorDataSet(Runner):
         else:
             for idx in failed_indices:
                 retry_body.append(body[idx])
-        self.logger.debug(
+        self.logger.info(
             "Retrying %d structured docs, indices=%s",
             len(failed_indices),
             failed_indices[: min(10, len(failed_indices))],

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -941,7 +941,6 @@ class BulkVectorDataSet(Runner):
         current_params = dict(params)
 
         for attempt in range(retries):
-            print("Retrying failed documents...")
             docs_in_request = self._doc_count(current_body, with_action_metadata)
             current_params["body"] = current_body
             current_params["size"] = docs_in_request
@@ -1074,6 +1073,7 @@ class BulkVectorDataSet(Runner):
         raise exceptions.DataError("bulk body is neither string nor list")
 
     def _build_retry_body(self, body, failed_indices, with_action_metadata):
+        print("Building retry bodies...")
         if isinstance(body, str):
             lines = [line for line in body.split("\n") if line]
             retry_lines = []
@@ -1088,6 +1088,7 @@ class BulkVectorDataSet(Runner):
                     )
                 else:
                     retry_lines.append(lines[idx])
+            print(f"retrying {retry_lines} documents")
             return "\n".join(retry_lines) + ("\n" if retry_lines else "")
 
         retry_body = []

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -189,7 +189,7 @@ class Runner:
     async def __aenter__(self):
         return self
 
-    async def __call__(self, opensearch, params):
+    async def __call__(self, opensearch, params):  # pylint: disable=too-many-nested-blocks
         """
         Runs the actual method that should be benchmarked.
 
@@ -928,7 +928,7 @@ class BulkVectorDataSet(Runner):
 
     NAME = "bulk-vector-data-set"
 
-    async def __call__(self, opensearch, params):
+    async def __call__(self, opensearch, params): # pylint: disable=too-many-nested-blocks
         with_action_metadata = params.get("action-metadata-present", True)
         unit = params.get("unit", "docs")
         retries = parse_int_parameter("retries", params, 0) + 1
@@ -989,7 +989,7 @@ class BulkVectorDataSet(Runner):
 
         raise TimeoutError("Failed to submit bulk request in specified number "
                            "of retries: {}".format(retries))
-    
+
     def detailed_stats(self, params, response):
         docs = []
         failed_docs = []
@@ -1039,7 +1039,7 @@ class BulkVectorDataSet(Runner):
                 self.extract_error_details(error_details, data)
             else:
                 bulk_success_count += 1
-            
+
             doc_idx += 1
 
         stats = {
@@ -1159,7 +1159,7 @@ class BulkVectorDataSet(Runner):
             stats["error-type"] = "bulk"
             stats["error-description"] = self.error_description(error_details)
         return stats
-    
+
     def extract_error_details(self, error_details, data):
         error_data = data.get("error", {})
         error_reason = error_data.get("reason") if isinstance(error_data, dict) else str(error_data)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -967,7 +967,7 @@ class BulkVectorDataSet(Runner):
                     meta_data["error-type"] = "bulk"
                     if detailed_results:
                         failed_indices = stats.get("failed-indices", [])
-                        if failed_indices:
+                        if failed_indices and attempt < retries - 1:
                             backoff = min(retry_wait_period * (2 ** attempt), retry_max_wait_period)
                             self.logger.info(
                                 "%d documents failed during ingestion. Retrying in [%.2f] seconds.",

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1504,7 +1504,7 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
             self.current += size
         self.task_progress = (self.current / self.total, '%')
 
-        return {"body": body, "retries": self.retries, "size": size}
+        return {"body": body, "retries": self.retries, "size": size, "with-action-metadata": True}
 
 
 def get_target(workload, params):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1504,7 +1504,7 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
             self.current += size
         self.task_progress = (self.current / self.total, '%')
 
-        return {"body": body, "retries": self.retries, "size": size, "with-action-metadata": True}
+        return {"body": body, "retries": self.retries, "size": size, "action-metadata-present": True}
 
 
 def get_target(workload, params):


### PR DESCRIPTION
### Description
Adds simple/detailed stats methods to the BulkVectorDataSet runner and also changes the retry logic.

Rather than retrying the entire bulk upon failure, this PR adds logic to parse through failed documents and retry only those failed ones rather than the entire bulk. 
```
2025-11-13 01:32:47,15 ActorAddr-(T|:41429)/PID:616400 osbenchmark.worker_coordinator.runner INFO Retrying 54 structured docs, indices=[0, 1, 2, 5, 8, 9, 11, 12, 13, 15]
```

Ingested documents using a 1M dataset with these changes:
```
[ec2-user@ip-172-31-0-197 ~]$ ~/.local/bin/awscurl --service aoss --region "$REGION"   --access_key "$AWS_ACCESS_KEY_ID"   --secret_key "$AWS_SECRET_ACCESS_KEY"   --security_token "$AWS_SESSION_TOKEN"   -X GET "$AOSS_ENDPOINT/${INDEX}/_count?pretty"
{
  "count" : 999990,
  "_shards" : {
    "total" : 0,
    "successful" : 0,
    "skipped" : 0,
    "failed" : 0
  }
}
```

vs without the changes:
```
[ec2-user@ip-172-31-0-197 ~]$ ~/.local/bin/awscurl --service aoss --region "$REGION"   --access_key "$AWS_ACCESS_KEY_ID"   --secret_key "$AWS_SECRET_ACCESS_KEY"   --security_token "$AWS_SESSION_TOKEN"   -X GET "$AOSS_ENDPOINT/${INDEX}/_count?pretty"
{
  "count" : 525869,
  "_shards" : {
    "total" : 0,
    "successful" : 0,
    "skipped" : 0,
    "failed" : 0
  }
}
```

### Issues Resolved
#979 

### Testing
- [x] New functionality includes testing

Running ingestion of 1M documents on AOSS vectorsearch collection

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
