### PR TITLE
Add: apply HNSW_EF_SEARCH paramter when run vector-search query

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1122,7 +1122,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
-        self.ef_search = parse_int_parameter(self.PARAMS_NAME_EF_SEARCH, params)
+        self.ef_search = self.query_params.get(self.PARAMS_NAME_EF_SEARCH)
         if self.PARAMS_NAME_FILTER in params:
             self.query_params.update({
                 self.PARAMS_NAME_FILTER:  params.get(self.PARAMS_NAME_FILTER)

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1097,6 +1097,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_REQUEST_PARAMS = "request-params"
     PARAMS_NAME_SOURCE = "_source"
     PARAMS_NAME_ALLOW_PARTIAL_RESULTS = "allow_partial_search_results"
+    PARAMS_NAME_EF_SEARCH = "hnsw_ef_search"
 
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
@@ -1121,7 +1122,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
-
+        self.ef_search = params.get(self.PARAMS_NAME_EF_SEARCH)
 
         if self.PARAMS_NAME_FILTER in params:
             self.query_params.update({
@@ -1226,6 +1227,10 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             "vector": vector,
             "k": self.k,
         }
+        if self.ef_search is not None:
+            query["method_parameters"] = {
+                "ef_search": self.ef_search
+            }
         if efficient_filter:
             query.update({
                 "filter": efficient_filter,

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1100,6 +1100,14 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_EF_SEARCH = "hnsw_ef_search"
 
     def __init__(self, workloads, params, query_params, **kwargs):
+        """
+        Initialize the vector-search parameter source, validate neighbor dataset configuration, and populate query-related instance attributes.
+        
+        Parameters:
+            workloads (Workload or list): Workload definition(s) used to resolve corpora and datasets.
+            params (dict): User-provided parameters for vector search (e.g., k, repetitions, neighbors dataset settings, filters, ef_search).
+            query_params (dict): Mutable mapping of query settings that will be updated with resolved fields (k, operation type, id field name, filters).
+        """
         super().__init__(workloads, params, Context.QUERY, **kwargs)
         self.logger = logging.getLogger(__name__)
         self.k = parse_int_parameter(self.PARAMS_NAME_K, params)
@@ -1216,12 +1224,17 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         return self.query_params
 
     def _build_vector_search_query_body(self, vector, efficient_filter=None, filter_type=None, filter_body=None) -> dict:
-        """Builds a k-NN request that can be used to execute an approximate nearest
-        neighbor search against a k-NN plugin index
-        Args:
-            vector: vector used for query
+        """
+        Constructs the k-NN query body for a vector search, including optional ef_search and filters.
+        
+        Parameters:
+            vector (Sequence[float] | numpy.ndarray): The query vector used for nearest-neighbor scoring.
+            efficient_filter (dict | None): An efficient (pre-search) filter expressed as a query DSL fragment to be applied by the k-NN plugin.
+            filter_type (str | None): If provided and not "post_filter", specifies how to combine a non-efficient filter with the k-NN query (e.g., "script" or "boolean").
+            filter_body (dict | None): The filter definition used when `filter_type` is set and an efficient filter is not supplied.
+        
         Returns:
-            A dictionary containing the body used for search query
+            dict: The request body for the k-NN portion of a search request. When the target field is nested, the returned body is wrapped in a `nested` query; when `ef_search` is configured it is included under `method_parameters`.
         """
         query = {
             "vector": vector,

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1122,9 +1122,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
-        
         self.ef_search = parse_int_parameter(self.PARAMS_NAME_EF_SEARCH, params)
-        
         if self.PARAMS_NAME_FILTER in params:
             self.query_params.update({
                 self.PARAMS_NAME_FILTER:  params.get(self.PARAMS_NAME_FILTER)


### PR DESCRIPTION
### Description

OpenSearch Benchmark can't dynamically change `hnsw_ef_search` parameter. With this change, we can change `hnsw_ef_search` parameter in vector search phase.


### Issues Resolved

#994 

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

I tested with following command:

```bash
opensearch-benchmark run  \
  --kill-running-processes  \
  --pipeline benchmark-only \
  --results-file ~/vectorsearch_default.log \
  --offline  \
  --target-hosts *** \
  --workload-params ~/wparams.json \
  --workload-path ~/workloads/vectorsearch \
  --test-procedure search-only
```

- ~/wparams.json
```json
{
    "target_index_name": "hnsw_benchmark_lucene_m16_efc500",
    "target_index_bulk_index_data_set_path": "~/dataset.h5",
    "target_index_bulk_index_data_set_format": "hdf5",
    "target_field_name": "target_field",
    "target_index_dimension": 128,
    "target_index_space_type": "cosinesimil",
    "query_data_set_format": "hdf5",
    "query_data_set_path": "~/dataset.h5",
    "query_k": 40,
    "query_count": 10000,
    "target_index_bulk_size": 256,
    "target_index_bulk_indexing_clients": 4,
    "search_clients": 16,
    "hnsw_m": 16,
    "hnsw_ef_construction": 500,
    "hnsw_ef_search": 500
}
```

- ~/workloads/vectorsearch/test_procedures/common/search-only-schedule.json (I used [opensearch-benchmark-workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads), but change only this file)

```json
{
    "name" : "warmup-indices",
    "operation" : "warmup-indices",
    "index": "{{ target_index_name | default(target_index) }}"
},
{
    "operation": {
        "name": "prod-queries",
        "operation-type": "vector-search",
        "index": "{{ target_index_name | default(target_index) }}",
        "detailed-results": true,
        {% if query_k is defined %}
        "k": {{ query_k }},
        {% endif %}
        {% if query_max_distance is defined %}
        "max_distance": {{ query_max_distance }},
        {% endif %}
        {% if query_min_score is defined %}
        "min_score": {{ query_min_score }},
        {% endif %}
        "field" : "{{ target_field_name | default(target_field) }}",
        "data_set_format" : "{{ query_data_set_format | default(hdf5) }}",
        "data_set_path" : "{{ query_data_set_path }}",
        "data_set_corpus" : "{{ query_data_set_corpus }}",
        "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
        "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
        "neighbors_data_set_format" : "{{ neighbors_data_set_format | default(hdf5) }}",
        "num_vectors" : {{ query_count | default(-1) }},
        "id-field-name": "{{ id_field_name }}",
        "body": {{ query_body | default ({}) | tojson }},
        "filter_body": {{ filter_body | default ({}) | tojson }},
        "filter_type": {{filter_type  | default ({}) | tojson }},
        "hnsw_ef_search": {{ hnsw_ef_search }} // 👈 I only add this line
    },
    "clients": {{ search_clients | default(1)}}
}
```

(Result)

[BEFORE]
```bash
------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |           Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------:|------------:|-------:|
|                                                  Mean recall@k |   prod-queries |        0.34 |        |
|                                                  Mean recall@1 |   prod-queries |        0.56 |        |
```
[AFTER]
```bash
------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |           Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------:|------------:|-------:|
|                                                  Mean recall@k |   prod-queries |        0.91 |        |
|                                                  Mean recall@1 |   prod-queries |        0.98 |        |

```








---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector search requests can now include an optional ef_search parameter. When provided, it is included in the query payload so users can tune retrieval behavior—trading search speed for recall—to get finer control over search performance and result quality.
  * This setting is honored automatically for searches that specify ef_search.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->