### PR TITLE
only append success message if file format is not CSV

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -1367,7 +1367,7 @@ def main():
     message = message + f" (took {int(round(end - start))} seconds)"
     console.println("")
     console.info(message, overline="-", underline="-")
-    if hasattr(args, "results_file") and args.results_file and args.results_format != "csv":
+    if hasattr(args, "results_file") and args.results_file and getattr(args, "results_format", None) != "csv":
         with open(args.results_file, "a") as fh:
             print("\n", message, file=fh)
 


### PR DESCRIPTION
### Description
appending success messages to CSV files breaks the format of the file. This change only appends the message if the file format is _not_ CSV

### Issues Resolved
#1001 

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where summary messages were being appended to CSV result files, causing formatting inconsistencies. Summary information is now only written to non-CSV result formats, ensuring CSV output remains clean and properly formatted for data processing while preserving complete summary details in other result formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->