### PR TITLE
Add database abstraction layer for multi-database support

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -33,7 +33,8 @@ import datetime
 
 import pytest
 
-from osbenchmark import client, config, version, paths
+from osbenchmark.database.clients.opensearch import opensearch as client
+from osbenchmark import config, version, paths
 from osbenchmark.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "os-it"]

--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -34,7 +34,8 @@ from collections import defaultdict
 import thespian.actors
 from opensearchpy.exceptions import NotFoundError
 
-from osbenchmark import (PROGRAM_NAME, actor, client, config, exceptions,
+from osbenchmark.database.clients.opensearch import opensearch as client
+from osbenchmark import (PROGRAM_NAME, actor, config, exceptions,
                          metrics, paths)
 from osbenchmark.builder import (launcher, provisioner,
                                  supplier)

--- a/osbenchmark/database/__init__.py
+++ b/osbenchmark/database/__init__.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Database abstraction layer for OpenSearch Benchmark.
+
+This package provides a unified interface for multiple database backends,
+allowing OSB to benchmark different search engines and databases while
+maintaining compatibility with existing workloads and runners.
+
+Architecture:
+- interface.py: Abstract base classes defining the contract
+- registry.py: Database type registry and enumeration
+- factory.py: Factory for creating database clients
+- clients/: Database-specific implementations
+
+Usage:
+    from osbenchmark.database.factory import DatabaseClientFactory
+
+    # Create a client factory
+    factory = DatabaseClientFactory.create_client_factory(
+        "opensearch",
+        [{"host": "localhost", "port": 9200}],
+        {"use_ssl": True}
+    )
+
+    # Create the async client
+    client = factory.create_async()
+
+    # Use the client (same API for all databases)
+    await client.bulk(body=documents)
+    results = await client.search(index="test", body=query)
+"""
+
+# Register database implementations on module import
+from osbenchmark.database.registry import register_database, DatabaseType
+from osbenchmark.database.factory import DatabaseClientFactory
+from osbenchmark.database.clients.opensearch.opensearch import OpenSearchClientFactory
+
+# Register OpenSearch as the default database type
+register_database(DatabaseType.OPENSEARCH, OpenSearchClientFactory)
+
+# Note: Other database types (Vespa, Milvus, etc.) will be registered
+# when their implementations are added in future PRs.
+
+# Public API exports
+__all__ = [
+    'DatabaseType',
+    'DatabaseClientFactory',
+]

--- a/osbenchmark/database/clients/__init__.py
+++ b/osbenchmark/database/clients/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""Database client implementations for OpenSearch Benchmark."""

--- a/osbenchmark/database/clients/milvus/__init__.py
+++ b/osbenchmark/database/clients/milvus/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""Milvus client implementation."""

--- a/osbenchmark/database/clients/milvus/milvus.py
+++ b/osbenchmark/database/clients/milvus/milvus.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Milvus client implementation (placeholder for future development)."""

--- a/osbenchmark/database/clients/opensearch/__init__.py
+++ b/osbenchmark/database/clients/opensearch/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""OpenSearch client implementation."""
+
+from osbenchmark.database.clients.opensearch.opensearch import OpenSearchClientFactory
+
+__all__ = ["OpenSearchClientFactory"]

--- a/osbenchmark/database/clients/opensearch/opensearch.py
+++ b/osbenchmark/database/clients/opensearch/opensearch.py
@@ -1,0 +1,657 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import time
+
+import certifi
+import opensearchpy
+import urllib3
+from urllib3.util.ssl_ import is_ipaddress
+
+import grpc
+from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub
+from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub
+
+from osbenchmark.kafka_client import KafkaMessageProducer
+from osbenchmark import exceptions, doc_link, async_connection
+from osbenchmark.context import RequestContextHolder
+from osbenchmark.utils import console, convert
+from osbenchmark.cloud_provider import CloudProviderFactory
+
+class OsClientFactory:
+    """
+    Abstracts how the OpenSearch client is created. Intended for testing.
+    """
+    def __init__(self, hosts, client_options):
+        self.hosts = hosts
+        self.client_options = dict(client_options)
+        self.ssl_context = None
+        self.provider = CloudProviderFactory.get_provider_from_client_options(self.client_options)
+        self.logger = logging.getLogger(__name__)
+
+        masked_client_options = dict(client_options)
+        if "basic_auth_password" in masked_client_options:
+            masked_client_options["basic_auth_password"] = "*****"
+        if "http_auth" in masked_client_options:
+            masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
+        if self.provider:
+            self.provider.parse_log_in_params(client_options=self.client_options)
+            self.provider.mask_client_options(masked_client_options, self.client_options)
+            self.logger.info("Masking client options with cloud provider: [%s]", self.provider)
+
+        self.logger.info("Creating OpenSearch client connected to %s with options [%s]", hosts, masked_client_options)
+        # we're using an SSL context now and it is not allowed to have use_ssl present in client options anymore
+        if self.client_options.pop("use_ssl", False):
+            # pylint: disable=import-outside-toplevel
+            import ssl
+            self.logger.info("SSL support: on")
+            self.client_options["scheme"] = "https"
+
+            self.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH,
+                                                          cafile=self.client_options.pop("ca_certs", certifi.where()))
+
+            if not self.client_options.pop("verify_certs", True):
+                self.logger.info("SSL certificate verification: off")
+                # order matters to avoid ValueError: check_hostname needs a SSL context with either CERT_OPTIONAL or CERT_REQUIRED
+                self.ssl_context.check_hostname = False
+                self.ssl_context.verify_mode = ssl.CERT_NONE
+
+                self.logger.warning("User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a "
+                                    "benchmark. Disabling urllib warnings now to avoid a logging storm. "
+                                    "See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings for details.")
+                # disable:  "InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly \
+                # advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings"
+                urllib3.disable_warnings()
+            else:
+                # The peer's hostname can be matched if only a hostname is provided.
+                # In other words, hostname checking is disabled if an IP address is
+                # found in the host lists.
+                self.ssl_context.check_hostname = self._has_only_hostnames(hosts)
+                self.ssl_context.verify_mode=ssl.CERT_REQUIRED
+                self.logger.info("SSL certificate verification: on")
+
+            # When using SSL_context, all SSL related kwargs in client options get ignored
+            client_cert = self.client_options.pop("client_cert", False)
+            client_key = self.client_options.pop("client_key", False)
+
+            if not client_cert and not client_key:
+                self.logger.info("SSL client authentication: off")
+            elif bool(client_cert) != bool(client_key):
+                self.logger.error(
+                    "Supplied client-options contain only one of client_cert/client_key. "
+                )
+                defined_client_ssl_option = "client_key" if client_key else "client_cert"
+                missing_client_ssl_option = "client_cert" if client_key else "client_key"
+                console.println(
+                    "'{}' is missing from client-options but '{}' has been specified.\n"
+                    "If your OpenSearch setup requires client certificate verification both need to be supplied.\n"
+                    "Read the documentation at {}\n".format(
+                        missing_client_ssl_option,
+                        defined_client_ssl_option,
+                        console.format.link(doc_link("command_line_reference.html#client-options")))
+                )
+                raise exceptions.SystemSetupError(
+                    "Cannot specify '{}' without also specifying '{}' in client-options.".format(
+                        defined_client_ssl_option,
+                        missing_client_ssl_option))
+            elif client_cert and client_key:
+                self.logger.info("SSL client authentication: on")
+                self.ssl_context.load_cert_chain(certfile=client_cert,
+                                                 keyfile=client_key)
+        else:
+            self.logger.info("SSL support: off")
+            self.client_options["scheme"] = "http"
+
+        if self._is_set(self.client_options, "basic_auth_user") and self._is_set(self.client_options, "basic_auth_password"):
+            self.logger.info("HTTP basic authentication: on")
+            self.client_options["http_auth"] = (self.client_options.pop("basic_auth_user"), self.client_options.pop("basic_auth_password"))
+        else:
+            self.logger.info("HTTP basic authentication: off")
+
+        if self._is_set(self.client_options, "compressed"):
+            console.warn("You set the deprecated client option 'compressed'. Please use 'http_compress' instead.", logger=self.logger)
+            self.client_options["http_compress"] = self.client_options.pop("compressed")
+
+        if self._is_set(self.client_options, "http_compress"):
+            self.logger.info("HTTP compression: on")
+        else:
+            self.logger.info("HTTP compression: off")
+
+        if self._is_set(self.client_options, "enable_cleanup_closed"):
+            self.client_options["enable_cleanup_closed"] = convert.to_bool(self.client_options.pop("enable_cleanup_closed"))
+
+    @staticmethod
+    def _has_only_hostnames(hosts):
+        logger = logging.getLogger(__name__)
+        has_ip, has_hostname = False, False
+        for host in hosts:
+            if is_ipaddress(host["host"]):
+                has_ip = True
+            else:
+                has_hostname = True
+
+        if has_ip and has_hostname:
+            console.warn("Although certificate verification is enabled, "
+                "peer hostnames will not be matched since the host list is a mix "
+                "of names and IP addresses", logger=logger)
+            return False
+
+        return has_hostname
+
+    def _is_set(self, client_opts, k):
+        try:
+            return client_opts[k]
+        except KeyError:
+            return False
+
+    def create(self):
+        if self.provider:
+            self.logger.info("Creating OpenSearch client with provider %s", self.provider)
+            return self.provider.create_client(self.hosts, self.client_options)
+
+        else:
+            return opensearchpy.OpenSearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
+
+    def create_async(self):
+        # pylint: disable=import-outside-toplevel
+        import io
+        import aiohttp
+        from opensearchpy.serializer import JSONSerializer
+
+        class BenchmarkAsyncOpenSearch(opensearchpy.AsyncOpenSearch, RequestContextHolder):
+            pass
+
+        class LazyJSONSerializer(JSONSerializer):
+            def loads(self, s):
+                meta = BenchmarkAsyncOpenSearch.request_context.get()
+                if "raw_response" in meta:
+                    return io.BytesIO(s)
+                else:
+                    return super().loads(s)
+
+        async def on_request_start(session, trace_config_ctx, params):
+            BenchmarkAsyncOpenSearch.on_request_start()
+
+        async def on_request_end(session, trace_config_ctx, params):
+            BenchmarkAsyncOpenSearch.on_request_end()
+
+        trace_config = aiohttp.TraceConfig()
+        trace_config.on_request_start.append(on_request_start)
+        trace_config.on_request_end.append(on_request_end)
+        # ensure that we also stop the timer when a request "ends" with an exception (e.g. a timeout)
+        trace_config.on_request_exception.append(on_request_end)
+
+        # override the builtin JSON serializer
+        self.client_options["serializer"] = LazyJSONSerializer()
+        self.client_options["trace_config"] = trace_config
+
+        if self.provider:
+            self.logger.info("Creating OpenSearch Async Client with provider %s", self.provider)
+            return self.provider.create_client(self.hosts, self.client_options,
+                                               client_class=BenchmarkAsyncOpenSearch, use_async=True)
+        else:
+            return BenchmarkAsyncOpenSearch(hosts=self.hosts,
+                                            connection_class=async_connection.AIOHttpConnection,
+                                            ssl_context=self.ssl_context,
+                                            **self.client_options)
+
+
+def wait_for_rest_layer(opensearch, max_attempts=40):
+    """
+    Waits for ``max_attempts`` until OpenSearch's REST API is available.
+
+    :param opensearch: OpenSearch client to use for connecting.
+    :param max_attempts: The maximum number of attempts to check whether the REST API is available.
+    :return: True iff OpenSearch's REST API is available.
+    """
+    # assume that at least the hosts that we expect to contact should be available. Note that this is not 100%
+    # bullet-proof as a cluster could have e.g. dedicated masters which are not contained in our list of target hosts
+    # but this is still better than just checking for any random node's REST API being reachable.
+    expected_node_count = len(opensearch.transport.hosts)
+    logger = logging.getLogger(__name__)
+    for attempt in range(max_attempts):
+        logger.debug("REST API is available after %s attempts", attempt)
+        # pylint: disable=import-outside-toplevel
+        try:
+            # see also WaitForHttpResource in OpenSearch tests. Contrary to the ES tests we consider the API also
+            # available when the cluster status is RED (as long as all required nodes are present)
+            opensearch.cluster.health(wait_for_nodes=">={}".format(expected_node_count))
+            logger.info("REST API is available for >= [%s] nodes after [%s] attempts.", expected_node_count, attempt)
+            return True
+        except opensearchpy.ConnectionError as e:
+            if "SSL: UNKNOWN_PROTOCOL" in str(e):
+                raise exceptions.SystemSetupError("Could not connect to cluster via https. Is this an https endpoint?", e)
+            else:
+                logger.debug("Got connection error on attempt [%s]. Sleeping...", attempt)
+                time.sleep(3)
+        except opensearchpy.TransportError as e:
+            # cluster block, our wait condition is not reached
+            if e.status_code in (503, 401, 408):
+                logger.debug("Got status code [%s] on attempt [%s]. Sleeping...", e.status_code, attempt)
+                time.sleep(3)
+            elif e.status_code == 404:
+                # Serverless does not support the cluster-health API.  Test with _cat/indices for now.
+                catclient = opensearchpy.client.cat.CatClient(opensearch)
+                try:
+                    catclient.indices()
+                    return True
+                except Exception as e:
+                    logger.warning("Encountered exception %s when attempting to probe endpoint health", e)
+                    raise e
+            else:
+                logger.warning("Got unexpected status code [%s] on attempt [%s].", e.status_code, attempt)
+                raise e
+    return False
+
+
+class MessageProducerFactory:
+    @staticmethod
+    async def create(params):
+        """
+        Creates and returns a message producer based on the ingestion source.
+        Currently supports Kafka. Ingestion source should be a dict like:
+            {'type': 'kafka', 'param': {'topic': 'test', 'bootstrap-servers': 'localhost:34803'}}
+        """
+        ingestion_source = params.get("ingestion-source", {})
+        producer_type = ingestion_source.get("type", "kafka").lower()
+        if producer_type == "kafka":
+            return await KafkaMessageProducer.create(params)
+        else:
+            raise ValueError(f"Unsupported ingestion source type: {producer_type}")
+
+
+class GrpcClientFactory:
+    """
+    Factory for creating gRPC client stubs.
+    Note gRPC channels must default `use_local_subchannel_pool` to true.
+    Sub channels manage the underlying connection with the server. When the global sub channel pool is used gRPC will
+    re-use sub channels and their underlying connections which does not appropriately reflect a multi client scenario.
+    """
+    def __init__(self, grpc_hosts):
+        self.grpc_hosts = grpc_hosts
+        self.logger = logging.getLogger(__name__)
+        self.grpc_channel_options = [
+            ('grpc.use_local_subchannel_pool', 1),
+            ('grpc.max_send_message_length', 10 * 1024 * 1024),  # 10 MB
+            ('grpc.max_receive_message_length', 10 * 1024 * 1024)  # 10 MB
+        ]
+
+    def create_grpc_stubs(self):
+        """
+        Create gRPC service stubs.
+        Returns a dict of {cluster_name: {service_name: stub}} structure.
+        """
+        stubs = {}
+
+        if len(self.grpc_hosts.all_hosts.items()) > 1:
+            raise NotImplementedError("Only one gRPC cluster is supported.")
+
+        if len(self.grpc_hosts.all_hosts["default"]) > 1:
+            raise NotImplementedError("Only one gRPC host is supported.")
+
+        host = self.grpc_hosts.all_hosts["default"][0]
+        grpc_addr = f"{host['host']}:{host['port']}"
+
+        self.logger.info("Creating gRPC channel for cluster default cluster at %s", grpc_addr)
+        channel = grpc.aio.insecure_channel(
+            target=grpc_addr,
+            options=self.grpc_channel_options,
+            compression=None
+        )
+
+        # Retain a reference to underlying channel in our stubs dictionary for graceful shutdown.
+        stubs["default"] = {
+            'document_service': DocumentServiceStub(channel),
+            'search_service': SearchServiceStub(channel),
+            '_channel': channel
+        }
+
+        return stubs
+
+
+class UnifiedClient:
+    """
+    Unified client that wraps both OpenSearch REST client and gRPC stubs.
+    This provides a single interface for runners to access both protocols.
+    Acts as a transparent proxy to the OpenSearch client while adding gRPC capabilities.
+    """
+    def __init__(self, opensearch_client, grpc_stubs=None):
+        self._opensearch = opensearch_client
+        self._grpc_stubs = grpc_stubs
+        self._logger = logging.getLogger(__name__)
+
+    def __getattr__(self, name):
+        """Delegate all unknown attributes to the underlying OpenSearch client."""
+        return getattr(self._opensearch, name)
+
+    def document_service(self, cluster_name="default"):
+        """Get the gRPC DocumentService stub for the specified cluster."""
+        if cluster_name in self._grpc_stubs:
+            return self._grpc_stubs[cluster_name].get('document_service')
+        else:
+            raise exceptions.SystemSetupError(
+                "gRPC DocumentService not available. Please configure --grpc-target-hosts.")
+
+    def search_service(self, cluster_name="default"):
+        """Get the gRPC SearchService stub for the specified cluster."""
+        if cluster_name in self._grpc_stubs:
+            return self._grpc_stubs[cluster_name].get('search_service')
+        else:
+            raise exceptions.SystemSetupError(
+                "gRPC SearchService not available. Please configure --grpc-target-hosts.")
+
+    def __del__(self):
+        """Close all gRPC channels."""
+        for cluster_stubs in self._grpc_stubs.values():
+            if '_channel' in cluster_stubs:
+                try:
+                    cluster_stubs['_channel'].close()
+                except Exception as e:
+                    self._logger.warning("Error closing gRPC channel: %s", e)
+        self._opensearch.close()
+
+    @property
+    def opensearch(self):
+        """Provide access to the underlying OpenSearch client for explicit access."""
+        return self._opensearch
+
+
+class UnifiedClientFactory:
+    """
+    Factory that creates UnifiedClient instances with both REST and gRPC support.
+    """
+    def __init__(self, rest_client_factory, grpc_hosts=None):
+        self.rest_client_factory = rest_client_factory
+        self.grpc_hosts = grpc_hosts
+        self.logger = logging.getLogger(__name__)
+
+    def create(self):
+        """Non async client is deprecated."""
+        raise NotImplementedError()
+
+    def create_async(self):
+        """Create a UnifiedClient with async REST client."""
+        opensearch_client = self.rest_client_factory.create_async()
+        grpc_stubs = None
+
+        if self.grpc_hosts:
+            grpc_factory = GrpcClientFactory(self.grpc_hosts)
+            grpc_stubs = grpc_factory.create_grpc_stubs()
+
+        return UnifiedClient(opensearch_client, grpc_stubs)
+
+
+# ============================================================================
+# DatabaseClient Interface Implementation for OpenSearch
+# ============================================================================
+
+# pylint: disable=wrong-import-position
+from osbenchmark.database.interface import (
+    DatabaseClient,
+    IndicesNamespace,
+    ClusterNamespace,
+    TransportNamespace,
+    NodesNamespace
+)
+
+
+class OpenSearchIndicesNamespace(IndicesNamespace):
+    """Wrapper for opensearchpy indices namespace"""
+
+    def __init__(self, opensearch_indices):
+        self._indices = opensearch_indices
+
+    async def create(self, index, body=None, **kwargs):
+        return await self._indices.create(index=index, body=body, **kwargs)
+
+    async def delete(self, index, **kwargs):
+        return await self._indices.delete(index=index, **kwargs)
+
+    async def exists(self, index, **kwargs):
+        return await self._indices.exists(index=index, **kwargs)
+
+    async def refresh(self, index=None, **kwargs):
+        return await self._indices.refresh(index=index, **kwargs)
+
+    async def stats(self, index=None, metric=None, **kwargs):  # pylint: disable=invalid-overridden-method
+        return await self._indices.stats(index=index, metric=metric, **kwargs)
+
+    async def forcemerge(self, index=None, **kwargs):  # pylint: disable=invalid-overridden-method
+        return await self._indices.forcemerge(index=index, **kwargs)
+
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying indices namespace"""
+        return getattr(self._indices, name)
+
+
+class OpenSearchClusterNamespace(ClusterNamespace):
+    """Wrapper for opensearchpy cluster namespace"""
+
+    def __init__(self, opensearch_cluster):
+        self._cluster = opensearch_cluster
+
+    async def health(self, **kwargs):
+        return await self._cluster.health(**kwargs)
+
+    async def put_settings(self, body, **kwargs):
+        return await self._cluster.put_settings(body=body, **kwargs)
+
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying cluster namespace"""
+        return getattr(self._cluster, name)
+
+
+class OpenSearchTransportNamespace(TransportNamespace):
+    """Wrapper for opensearchpy transport namespace"""
+
+    def __init__(self, opensearch_transport):
+        self._transport = opensearch_transport
+
+    async def perform_request(self, method, url, params=None, body=None, headers=None):
+        return await self._transport.perform_request(
+            method=method,
+            url=url,
+            params=params,
+            body=body,
+            headers=headers
+        )
+
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying transport namespace"""
+        return getattr(self._transport, name)
+
+
+class OpenSearchNodesNamespace(NodesNamespace):
+    """Wrapper for opensearchpy nodes namespace"""
+
+    def __init__(self, opensearch_nodes):
+        self._nodes = opensearch_nodes
+
+    def stats(self, node_id=None, metric=None, **kwargs):
+        return self._nodes.stats(node_id=node_id, metric=metric, **kwargs)
+
+    def info(self, node_id=None, metric=None, **kwargs):
+        return self._nodes.info(node_id=node_id, metric=metric, **kwargs)
+
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying nodes namespace"""
+        return getattr(self._nodes, name)
+
+
+class OpenSearchDatabaseClient(DatabaseClient):
+    """
+    DatabaseClient implementation for OpenSearch.
+
+    This is a transparent wrapper around the opensearchpy client that implements
+    the DatabaseClient interface. It delegates all operations to the underlying
+    opensearchpy client with minimal overhead.
+    """
+
+    def __init__(self, opensearch_client):
+        """
+        Initialize with an opensearchpy client instance.
+
+        Args:
+            opensearch_client: An instance of opensearchpy.AsyncOpenSearch or UnifiedClient
+        """
+        self._client = opensearch_client
+
+        # Wrap namespaces
+        self._indices_ns = OpenSearchIndicesNamespace(opensearch_client.indices)
+        self._cluster_ns = OpenSearchClusterNamespace(opensearch_client.cluster)
+        self._transport_ns = OpenSearchTransportNamespace(opensearch_client.transport)
+        self._nodes_ns = OpenSearchNodesNamespace(opensearch_client.nodes)
+
+    @property
+    def indices(self):
+        return self._indices_ns
+
+    @property
+    def cluster(self):
+        return self._cluster_ns
+
+    @property
+    def transport(self):
+        return self._transport_ns
+
+    @property
+    def nodes(self):
+        return self._nodes_ns
+
+    async def bulk(self, body, index=None, doc_type=None, params=None, **kwargs):
+        # Note: doc_type is deprecated and removed in opensearchpy 2.x
+        # We accept it for backwards compatibility but don't pass it through
+        return await self._client.bulk(
+            body=body,
+            index=index,
+            params=params,
+            **kwargs
+        )
+
+    async def index(self, index, body, id=None, doc_type=None, **kwargs):
+        # Note: doc_type is deprecated and removed in opensearchpy 2.x
+        # We accept it for backwards compatibility but don't pass it through
+        return await self._client.index(
+            index=index,
+            body=body,
+            id=id,
+            **kwargs
+        )
+
+    async def search(self, index=None, body=None, doc_type=None, **kwargs):
+        # Note: doc_type is deprecated and removed in opensearchpy 2.x
+        # We accept it for backwards compatibility but don't pass it through
+        return await self._client.search(
+            index=index,
+            body=body,
+            **kwargs
+        )
+
+    def info(self):
+        """Get cluster information from OpenSearch"""
+        return self._client.info()
+
+    def return_raw_response(self):
+        """Delegate to underlying client if method exists"""
+        if hasattr(self._client, 'return_raw_response'):
+            return self._client.return_raw_response()
+
+    def close(self):
+        """Delegate to underlying client if method exists"""
+        if hasattr(self._client, 'close'):
+            return self._client.close()
+
+    def __getattr__(self, name):
+        """
+        Delegate any unknown attributes to the underlying OpenSearch client.
+        This ensures full compatibility with operations that aren't in the interface.
+        """
+        return getattr(self._client, name)
+
+
+class OpenSearchClientFactory:
+    """
+    Factory for creating OpenSearch database clients.
+
+    This factory wraps the legacy OsClientFactory and UnifiedClientFactory
+    to create clients that implement the DatabaseClient interface.
+    """
+
+    def __init__(self, hosts, client_options):
+        """
+        Initialize factory with connection parameters.
+
+        Args:
+            hosts: List of host dictionaries with "host" and "port" keys
+            client_options: Dictionary of client-specific options
+        """
+        self.hosts = hosts
+        self.client_options = client_options
+        self.logger = logging.getLogger(__name__)
+
+    def create_async(self):
+        """
+        Create an async OpenSearch client that implements DatabaseClient interface.
+
+        Returns:
+            OpenSearchDatabaseClient wrapping an async opensearchpy client
+        """
+        # Use legacy OsClientFactory to create the actual client
+        os_factory = OsClientFactory(self.hosts, self.client_options)
+        opensearch_client = os_factory.create_async()
+
+        # Wrap it in our DatabaseClient interface
+        return OpenSearchDatabaseClient(opensearch_client)
+
+    def create(self):
+        """
+        Create a synchronous OpenSearch client.
+
+        Used for telemetry and pre-benchmark operations.
+        Returns the native opensearchpy sync client (not wrapped) since
+        telemetry expects synchronous methods.
+
+        Returns:
+            opensearchpy.OpenSearch sync client
+        """
+        os_factory = OsClientFactory(self.hosts, self.client_options)
+        return os_factory.create()
+
+    def wait_for_rest_layer(self, max_attempts=40):
+        """
+        Wait for OpenSearch's REST API to become available.
+
+        Args:
+            max_attempts: Maximum number of attempts to check availability.
+
+        Returns:
+            True if REST API is available, False otherwise.
+        """
+        # Use legacy OsClientFactory to create a sync client for health check
+        os_factory = OsClientFactory(self.hosts, self.client_options)
+        opensearch_client = os_factory.create()
+
+        # Use the module-level wait_for_rest_layer function
+        return wait_for_rest_layer(opensearch_client, max_attempts)

--- a/osbenchmark/database/clients/vespa/__init__.py
+++ b/osbenchmark/database/clients/vespa/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/osbenchmark/database/clients/vespa/vespa.py
+++ b/osbenchmark/database/clients/vespa/vespa.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Vespa database client implementation will be added in a future PR.
+# This file is a placeholder for the database abstraction layer.

--- a/osbenchmark/database/factory.py
+++ b/osbenchmark/database/factory.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Database client factory for creating database-specific clients.
+
+This module provides the main entry point for creating database clients
+based on configuration. It uses the registry to look up the appropriate
+client factory for each database type.
+"""
+from typing import Any, Dict, List
+from osbenchmark.database.registry import DatabaseType, get_client_factory
+from osbenchmark import exceptions
+
+
+class DatabaseClientFactory:
+    """
+    Factory for creating database clients based on configuration.
+
+    This is the main entry point used by OSB to create database clients.
+    It determines which database type to use and delegates to the
+    appropriate database-specific factory.
+    """
+
+    @staticmethod
+    def create_client_factory(database_type: str, hosts: List[Dict], client_options: Dict) -> Any:
+        """
+        Create the appropriate database client factory.
+
+        Args:
+            database_type: String identifier for database type (e.g., "opensearch")
+            hosts: List of host dictionaries with "host" and "port" keys
+            client_options: Dictionary of client-specific options
+
+        Returns:
+            A database-specific client factory instance
+
+        Raises:
+            ValueError: If database_type is not supported
+            exceptions.SystemSetupError: If no factory is registered for the database type
+
+        Example:
+            factory = DatabaseClientFactory.create_client_factory(
+                "opensearch",
+                [{"host": "localhost", "port": 9200}],
+                {"use_ssl": True}
+            )
+            client = factory.create_async()
+        """
+        try:
+            db_enum = DatabaseType(database_type.lower())
+        except ValueError:
+            valid_types = [db.value for db in DatabaseType]
+            raise ValueError(
+                f"Unsupported database type: '{database_type}'. "
+                f"Valid types are: {', '.join(valid_types)}"
+            )
+
+        factory_class = get_client_factory(db_enum)
+
+        if not factory_class:
+            raise exceptions.SystemSetupError(
+                f"No client factory registered for database type: {database_type}. "
+                f"This database type may not be fully implemented yet."
+            )
+
+        return factory_class(hosts, client_options)
+
+    @staticmethod
+    def detect_database_type(client_options: Dict) -> str:
+        """
+        Detect database type from client options.
+
+        Args:
+            client_options: Dictionary of client options
+
+        Returns:
+            String identifier for database type (defaults to "opensearch")
+
+        Example:
+            # Explicit database type in options
+            db_type = DatabaseClientFactory.detect_database_type(
+                {"database_type": "vespa"}
+            )  # Returns "vespa"
+
+            # Default to OpenSearch
+            db_type = DatabaseClientFactory.detect_database_type({})
+            # Returns "opensearch"
+        """
+        # Check for explicit database type in client options
+        if "database_type" in client_options:
+            return client_options["database_type"]
+
+        # Default to OpenSearch for backward compatibility
+        return DatabaseType.OPENSEARCH.value

--- a/osbenchmark/database/interface.py
+++ b/osbenchmark/database/interface.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Defines the contract that all database clients must implement.
+
+This interface mirrors the opensearchpy.OpenSearch client structure to ensure
+compatibility with OSB runners while allowing different database backends.
+
+The interface uses a pass-through wrapper pattern:
+- For OpenSearch: delegates directly to opensearchpy client
+- For other databases: translates operations to database-specific APIs
+"""
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+
+class IndicesNamespace(ABC):
+    """Namespace for index management operations"""
+
+    @abstractmethod
+    async def create(self, index: str, body: Optional[Dict] = None, **kwargs) -> Dict:
+        """Create an index"""
+
+    @abstractmethod
+    async def delete(self, index: str, **kwargs) -> Dict:
+        """Delete an index"""
+
+    @abstractmethod
+    async def exists(self, index: str, **kwargs) -> bool:
+        """Check if index exists"""
+
+    @abstractmethod
+    async def refresh(self, index: Optional[str] = None, **kwargs) -> Dict:
+        """Refresh one or more indices"""
+
+    @abstractmethod
+    def stats(self, index: Optional[str] = None, metric: Optional[str] = None, **kwargs) -> Dict:
+        """Get index statistics (sync - called by telemetry)"""
+
+    @abstractmethod
+    def forcemerge(self, index: Optional[str] = None, **kwargs) -> Dict:
+        """Force merge index segments (sync - called by telemetry)"""
+
+
+class ClusterNamespace(ABC):
+    """Namespace for cluster-level operations"""
+
+    @abstractmethod
+    async def health(self, **kwargs) -> Dict:
+        """Get cluster health status"""
+
+    @abstractmethod
+    async def put_settings(self, body: Dict, **kwargs) -> Dict:
+        """Update cluster settings"""
+
+
+class TransportNamespace(ABC):
+    """Low-level transport for custom API endpoints"""
+
+    @abstractmethod
+    async def perform_request(self, method: str, url: str,
+                             params: Optional[Dict] = None,
+                             body: Optional[Any] = None,
+                             headers: Optional[Dict] = None) -> Any:
+        """Perform a raw HTTP request"""
+
+
+class NodesNamespace(ABC):
+    """Namespace for node-level operations and statistics"""
+
+    @abstractmethod
+    def stats(self, node_id: Optional[str] = None,
+              metric: Optional[str] = None,
+              **kwargs) -> Dict:
+        """Get node statistics"""
+
+    @abstractmethod
+    def info(self, node_id: Optional[str] = None,
+             metric: Optional[str] = None,
+             **kwargs) -> Dict:
+        """Get node information"""
+
+
+class DatabaseClient(ABC):
+    """
+    Abstract interface for database clients.
+
+    All database implementations must provide this interface to be compatible
+    with OSB runners. The interface is designed to match opensearchpy.OpenSearch
+    structure but can be implemented by any search/database engine.
+    """
+
+    # Namespaced APIs (properties that return namespace objects)
+    @property
+    @abstractmethod
+    def indices(self) -> IndicesNamespace:
+        """Access to indices namespace"""
+
+    @property
+    @abstractmethod
+    def cluster(self) -> ClusterNamespace:
+        """Access to cluster namespace"""
+
+    @property
+    @abstractmethod
+    def transport(self) -> TransportNamespace:
+        """Access to transport namespace"""
+
+    @property
+    @abstractmethod
+    def nodes(self) -> NodesNamespace:
+        """Access to nodes namespace"""
+
+    # Core document operations
+    @abstractmethod
+    async def bulk(self, body: Union[str, List],
+                   index: Optional[str] = None,
+                   doc_type: Optional[str] = None,
+                   params: Optional[Dict] = None,
+                   **kwargs) -> Dict:
+        """Bulk index/update/delete documents"""
+
+    @abstractmethod
+    async def index(self, index: str, body: Dict,
+                   id: Optional[str] = None,
+                   doc_type: Optional[str] = None,
+                   **kwargs) -> Dict:
+        """Index a single document"""
+
+    @abstractmethod
+    async def search(self, index: Optional[str] = None,
+                    body: Optional[Dict] = None,
+                    doc_type: Optional[str] = None,
+                    **kwargs) -> Dict:
+        """Execute a search query"""
+
+    def info(self) -> Dict:
+        """
+        Get cluster/database information.
+
+        Returns version, build info, etc. Similar to OpenSearch's root endpoint.
+        """
+        return {}
+
+    # Additional methods used by runners
+    def return_raw_response(self):
+        """
+        Configure client to return raw responses (for performance).
+        Optional method - implementations can provide no-op.
+        """
+
+    def close(self):
+        """
+        Close client connections.
+        Optional method - implementations can provide no-op.
+        """

--- a/osbenchmark/database/registry.py
+++ b/osbenchmark/database/registry.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Database client registry for managing multiple database backends.
+
+This module provides:
+- DatabaseType enum for supported database types
+- Registry for mapping database types to client factory classes
+- Functions to register and retrieve database implementations
+"""
+from enum import Enum
+from typing import Dict, Type, Optional
+
+
+class DatabaseType(Enum):
+    """Supported database types for benchmarking"""
+    OPENSEARCH = "opensearch"
+    MILVUS = "milvus"
+    VESPA = "vespa"
+
+
+# Global registry mapping database types to their factory classes
+_DATABASE_REGISTRY: Dict[DatabaseType, Type] = {}
+
+
+def register_database(db_type: DatabaseType, client_factory_class: Type) -> None:
+    """
+    Register a database client factory.
+
+    Args:
+        db_type: The database type enum value
+        client_factory_class: The factory class for creating clients
+
+    Example:
+        register_database(DatabaseType.OPENSEARCH, OpenSearchClientFactory)
+    """
+    _DATABASE_REGISTRY[db_type] = client_factory_class
+
+
+def get_client_factory(db_type: DatabaseType) -> Optional[Type]:
+    """
+    Retrieve the registered client factory for a database type.
+
+    Args:
+        db_type: The database type enum value
+
+    Returns:
+        The factory class, or None if not registered
+    """
+    return _DATABASE_REGISTRY.get(db_type)
+
+
+def list_registered_databases() -> list:
+    """
+    Get list of all registered database types.
+
+    Returns:
+        List of DatabaseType enum values
+    """
+    return list(_DATABASE_REGISTRY.keys())

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -47,7 +47,7 @@ from opensearchpy import NotFoundError
 
 from osbenchmark import exceptions, workload
 from osbenchmark.utils import convert
-from osbenchmark.client import RequestContextHolder
+from osbenchmark.context import RequestContextHolder
 # Mapping from operation type to specific runner
 from osbenchmark.utils.parse import parse_int_parameter, parse_string_parameter, parse_float_parameter
 from osbenchmark.worker_coordinator.proto_helpers.ProtoBulkHelper import ProtoBulkHelper

--- a/osbenchmark/workload_generator/workload_generator.py
+++ b/osbenchmark/workload_generator/workload_generator.py
@@ -10,7 +10,7 @@ import logging
 import os
 
 from osbenchmark import PROGRAM_NAME, exceptions
-from osbenchmark.client import OsClientFactory
+from osbenchmark.database.clients.opensearch.opensearch import OsClientFactory
 from osbenchmark.workload_generator.config import CustomWorkload
 from osbenchmark.workload_generator.helpers import QueryProcessor, CustomWorkloadWriter, process_indices, validate_index_documents_map, validate_sample_frequency_mapping
 from osbenchmark.workload_generator.extractors import IndexExtractor, SequentialCorpusExtractor

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -34,7 +34,8 @@ import opensearchpy
 import pytest
 import urllib3.exceptions
 
-from osbenchmark import client, exceptions, doc_link
+from osbenchmark.database.clients.opensearch import opensearch as client
+from osbenchmark import exceptions, doc_link
 from osbenchmark.utils import console
 from tests import run_async
 
@@ -68,7 +69,7 @@ class OsClientFactoryTests(TestCase):
         # make a copy, so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([
@@ -106,7 +107,7 @@ class OsClientFactoryTests(TestCase):
         # make a copy, so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([
@@ -146,7 +147,7 @@ class OsClientFactoryTests(TestCase):
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([
@@ -221,7 +222,7 @@ class OsClientFactoryTests(TestCase):
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = dict(client_options)
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([
@@ -268,7 +269,7 @@ class OsClientFactoryTests(TestCase):
             role_based_client_options
         ]
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
 
         for client_options in client_options_list:
             # make a copy so we can verify later that the factory did not modify it
@@ -315,7 +316,7 @@ class OsClientFactoryTests(TestCase):
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
 
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([
@@ -400,7 +401,7 @@ class OsClientFactoryTests(TestCase):
         mock_session.return_value = mock_session_instance
 
         original_client_options = dict(client_options)
-        logger = logging.getLogger("osbenchmark.client")
+        logger = logging.getLogger("osbenchmark.database.clients.opensearch.opensearch")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.OsClientFactory(hosts, client_options)
         mocked_info_logger.assert_has_calls([

--- a/tests/kafka_client_test.py
+++ b/tests/kafka_client_test.py
@@ -25,7 +25,7 @@
 from unittest import TestCase, mock
 
 from osbenchmark.kafka_client import KafkaMessageProducer
-from osbenchmark.client import MessageProducerFactory
+from osbenchmark.database.clients.opensearch.opensearch import MessageProducerFactory
 from tests import run_async
 
 

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -31,7 +31,8 @@ from unittest import TestCase
 
 import opensearchpy
 import pytest
-from osbenchmark import client, exceptions
+from osbenchmark.database.clients.opensearch import opensearch as client
+from osbenchmark import exceptions
 from osbenchmark.worker_coordinator import runner
 from tests import run_async, as_future
 

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1966,7 +1966,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         context_mock = mock.Mock()
         message_producer_mock.new_request_context.return_value = context_mock
 
-        with mock.patch('osbenchmark.client.MessageProducerFactory.create',
+        with mock.patch('osbenchmark.database.clients.opensearch.opensearch.MessageProducerFactory.create',
                         new=mock.AsyncMock(return_value=message_producer_mock)) as factory_mock:
             result = await self.executor._prepare_context_manager(params)
             factory_mock.assert_called_once_with(params)


### PR DESCRIPTION
### Description
Sets up abstraction layer in OSB and moves OS client/runner logic into appropriate folders

The goal is to set up OSB that can allow it to support any DB that supports similar operations. This PR creates the package structure, defines interfaces and contracts, refactors the existing OS code into the new structure, and updates imports. There are no functional changes to OSB here, just a reorganization of the existing code. 

Here we introduce:
`registry.py`, which defines the pattern for managing different DB's and their factories
`factory.py`, which is the interface for creating DB clients without needing to know which implementation to use
A couple classes in clients/opensearch/opensearch.py, which just wrap the current opensearchpy client so it conforms to the new DatabaseClient interface as well as provide an `OpenSearchclientFactory` class to create the OS clients.

Switches around a few things like checking for DB when loading config, client factory selection with a default of OS client, removes hardcoding for using OS client, skips telemetry for non OS clients. 

### Issues Resolved
#1006 

### Testing
- [x] New functionality includes testing

Tested with big5 workload to ensure no breaking changes

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
