### PR TITLE
Document osb shorthand command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,20 @@ Quick Start
 
 Want to get started with OpenSearch Benchmark quickly? See [OpenSearch Benchmark's Quick Start guide in the documentation](https://opensearch.org/docs/latest/benchmark/index/).
 
+**Shorthand Command:** You can use `osb` as a shorthand for `opensearch-benchmark`:
+
+```bash
+# Full command
+opensearch-benchmark execute-test --workload=geonames
+
+# Shorthand equivalent
+osb execute-test --workload=geonames
+```
+
 Getting help
 ------------
 
-* Quick help: ``opensearch-benchmark --help``
+* Quick help: ``opensearch-benchmark --help`` or ``osb --help``
 * Want to contribute? Look at [OpenSearch Benchmark's Developer Guide](<https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md>) for more information
 * For any questions or answers, visit our [community forum](<https://discuss.opendistrocommunity.dev/>) and Slack community channel [#performance-benchmarking](https://opensearch.slack.com/archives/C082PLA3VPW).
 * File improvements or bug reports in our [Github repo](<https://github.com/opensearch-project/OpenSearch-Benchmark/issues>).

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -72,7 +72,7 @@ Add backport labels to PRs and commits so that changes can be added to `main` br
     2. Install it with `pip install`.
     3. Run `opensearch-benchmark --version` to ensure that it is the correct version
     4. Run `opensearch-benchmark --help`
-    5. Run `opensearch-benchmark list workloads`
+    5. Run `opensearch-benchmark list workloads` (or `osb list workloads`)
     6. Run a basic workload on Linux and MacOS:  `opensearch-benchmark run --workload pmc --test-mode`
     7. If you are fastidious, you can check the installed source files at `` `python3 -m site --user-site`/osbenchmark `` to verify that a recent change is indeed present.
 


### PR DESCRIPTION
Addresses #744

## Changes
Add documentation for the `osb` shorthand command that can be used as an alias for `opensearch-benchmark`.

## Documentation Added
- Example showing both full and shorthand commands
- Updated help command reference to include `osb --help`

## Example
```bash
# Full command
opensearch-benchmark execute-test --workload=geonames

# Shorthand equivalent
osb execute-test --workload=geonames
```

This makes it easier and faster for users to invoke OpenSearch Benchmark.