### PR TITLE
Add qat_zstd as a supported index codec.

### DIFF
--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -809,6 +809,7 @@ class IndexCodec(Enum):
     ZSTDNODICT = "zstd_no_dict"
     QATDEFLATE = "qat_deflate"
     QATLZ4 = "qat_lz4"
+    QATZSTD = "qat_zstd"
 
     @classmethod
     def is_codec_valid(cls, codec):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1862,7 +1862,7 @@ class CreateIndexParamSourceTests(TestCase):
 
         self.assertEqual(str(context.exception),
                          "Please set the value properly for the create-index operation. Invalid index.codec value " +
-                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstd_no_dict', 'qat_deflate', 'qat_lz4']")
+                         "'invalid_codec'. Choose from available codecs: ['default', 'best_compression', 'zstd', 'zstd_no_dict', 'qat_deflate', 'qat_lz4', 'qat_zstd']")
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):


### PR DESCRIPTION
### Description
Adds `qat_zstd` as a supported `index.codec`. Intel® QAT (Quick Assist Technology) accelerated Zstandard compression has been available in OpenSearch since version 2.19.3: https://github.com/opensearch-project/custom-codecs/pull/238

### Issues Resolved
No more "index.codec not found" error when index.codec is set to `qat_zstd`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
