### PR TITLE
Update OSB with 3.5 gRPC schema changes

### DIFF
--- a/docs/grpc-support.md
+++ b/docs/grpc-support.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: gRPC Support
+parent: OSB
+nav_order: 20
+---
+
+# gRPC Support
+
+OpenSearch Benchmark supports benchmarking OpenSearch clusters via gRPC transport using the `--grpc-target-hosts` option. gRPC support requires the [transport-grpc](https://github.com/opensearch-project/OpenSearch/tree/main/modules/transport-grpc) module to be enabled on the OpenSearch cluster.
+
+## Compatibility Matrix
+
+| OpenSearch Benchmark Version | OpenSearch Version | opensearch-protobufs Version | Notes |
+|------------------------------|-------------------|------------------------------|-------|
+| 2.0.0                        | 3.3, 3.4          | 0.19.0                       | Initial gRPC support |
+| 2.1.0                        | 3.5+              | 1.2.0                        | Updated for OpenSearch 3.5 protobuf changes |
+
+## Supported Operations
+
+- Bulk ingestion
+- Match queries
+- Term queries
+- KNN queries
+
+## Usage
+
+To benchmark with gRPC, specify both REST and gRPC endpoints:
+
+```bash
+opensearch-benchmark run \
+    --target-hosts=localhost:9200 \
+    --grpc-target-hosts=localhost:9401 \
+    --workload=http_logs \
+    --test-procedure=grpc-append-no-conflicts-index-only
+```
+
+The `--target-hosts` option is still required for cluster management operations (index creation, health checks, etc.), while `--grpc-target-hosts` is used for bulk ingestion and search operations when available.
+
+## Workload Support
+
+Not all workloads have gRPC test procedures defined. Check the workload documentation for gRPC-specific test procedures (typically prefixed with `grpc-`).

--- a/osbenchmark/context.py
+++ b/osbenchmark/context.py
@@ -43,19 +43,22 @@ class RequestContextManager:
 
     @property
     def request_start(self):
-        return self.ctx["request_start"]
+        return self.ctx.get("request_start")
 
     @property
     def request_end(self):
-        return max((value for value in self.ctx["request_end_list"] if value < self.client_request_end))
+        client_end = self.client_request_end
+        if client_end is None or "request_end_list" not in self.ctx:
+            return None
+        return max((value for value in self.ctx["request_end_list"] if value < client_end))
 
     @property
     def client_request_start(self):
-        return self.ctx["client_request_start"]
+        return self.ctx.get("client_request_start")
 
     @property
     def client_request_end(self):
-        return self.ctx["client_request_end"]
+        return self.ctx.get("client_request_end")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # propagate earliest request start and most recent request end to parent

--- a/osbenchmark/worker_coordinator/proto_helpers/ProtoBulkHelper.py
+++ b/osbenchmark/worker_coordinator/proto_helpers/ProtoBulkHelper.py
@@ -1,4 +1,4 @@
-from opensearch.protobufs.schemas import document_pb2
+from opensearch.protobufs.schemas import common_pb2
 
 def _parse_docs_from_body(body):
     index_op_lines = body.decode('utf-8').split('\n')
@@ -17,16 +17,16 @@ class ProtoBulkHelper:
         index = params.get("index")
         body = params.get("body")
         doc_list = _parse_docs_from_body(body)
-        request = document_pb2.BulkRequest()
+        request = common_pb2.BulkRequest()
         request.index = index
         # All bulk requests here are index ops
-        op_container = document_pb2.OperationContainer()
-        op_container.index.CopyFrom(document_pb2.IndexOperation())
+        op_container = common_pb2.OperationContainer()
+        op_container.index.CopyFrom(common_pb2.IndexOperation())
         for doc in doc_list:
-            request_body = document_pb2.BulkRequestBody()
+            request_body = common_pb2.BulkRequestBody()
             request_body.object = doc.encode('utf-8')
             request_body.operation_container.CopyFrom(op_container)
-            request.request_body.append(request_body)
+            request.bulk_request_body.append(request_body)
         return request
 
     # Parse stats from protobuf response.
@@ -36,7 +36,7 @@ class ProtoBulkHelper:
     # ``unit``: in the case of bulk always 'ops'
     # ``detailed-results``: gRPC/Protobuf does not support detailed results at this time.
     @staticmethod
-    def build_stats(response : document_pb2.BulkResponse, params):
+    def build_stats(response : common_pb2.BulkResponse, params):
         if params.get("detailed-results"):
             raise Exception("Detailed results not supported for gRPC bulk requests")
 

--- a/osbenchmark/worker_coordinator/proto_helpers/ProtoQueryHelper.py
+++ b/osbenchmark/worker_coordinator/proto_helpers/ProtoQueryHelper.py
@@ -1,4 +1,3 @@
-from opensearch.protobufs.schemas import search_pb2
 from opensearch.protobufs.schemas import common_pb2
 
 # In some cases (KNN) we set stored fields explicitly to "_none_" to disable
@@ -86,7 +85,7 @@ class ProtoQueryHelper:
         body = params.get("body")
         size = body.get("size") if "size" in body else None
         fetch_source = is_true(body.get("_source"))
-        source_config = common_pb2.SourceConfigParam(bool=fetch_source)
+        source_config = common_pb2.SourceConfigParam(fetch=fetch_source)
         index = [params.get("index")]
         timeout = None if params.get("request-timeout") is None else str(params.get("request-timeout")) + "ms"
 
@@ -97,8 +96,8 @@ class ProtoQueryHelper:
         else:
             cache = None
 
-        return search_pb2.SearchRequest(
-            request_body=search_pb2.SearchRequestBody(
+        return common_pb2.SearchRequest(
+            search_request_body=common_pb2.SearchRequestBody(
                 query=ProtoQueryHelper.query_body_to_proto(body),
                 timeout=timeout,
                 size = size
@@ -137,7 +136,7 @@ class ProtoQueryHelper:
         fetch_source = is_true(request_params.get("_source"))
         profile_query = is_true(params.get("profile_query"))
         partial_results = is_true(request_params.get("allow_partial_search_results"))
-        source_config = common_pb2.SourceConfigParam(bool=fetch_source)
+        source_config = common_pb2.SourceConfigParam(fetch=fetch_source)
         timeout = params.get("request-timeout")
 
         stored_fields = body.get("stored_fields")
@@ -166,26 +165,26 @@ class ProtoQueryHelper:
             )
 
         knn_query_proto = knn_query_to_proto(body.get("query"))
-        return search_pb2.SearchRequest(
-            request_body=search_pb2.SearchRequestBody(
+        return common_pb2.SearchRequest(
+            search_request_body=common_pb2.SearchRequestBody(
                 query=common_pb2.QueryContainer(knn=knn_query_proto),
                 timeout=timeout,
                 profile=profile_query,
-                size = size
+                size = size,
+                stored_fields=stored_fields
             ),
             index=index,
             x_source=source_config,
             request_cache=cache,
             allow_partial_search_results=partial_results,
-            docvalue_fields=doc_value_fields,
-            stored_fields=stored_fields
+            docvalue_fields=doc_value_fields
         )
 
     # Parse stats from protobuf response.
     # ``detailed-results``: return detailed results, hits, took, hits_relation
     @staticmethod
     def build_stats(response, params):
-        if not isinstance(response, search_pb2.SearchResponse):
+        if not isinstance(response, common_pb2.SearchResponse):
             raise Exception("Unknown response proto: " + response)
 
         if params.get("detailed-results"):

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ install_requires = [
     "pydantic_core>=2.27.2",
     # License: Apache 2.0
     # gRPC & proto deps
-    "opensearch-protobufs==0.19.0"
+    "opensearch-protobufs==1.2.0"
 ]
 
 tests_require = [

--- a/tests/worker_coordinator/proto_bulk_helper_test.py
+++ b/tests/worker_coordinator/proto_bulk_helper_test.py
@@ -24,7 +24,7 @@
 
 from unittest import TestCase
 
-from opensearch.protobufs.schemas import document_pb2
+from opensearch.protobufs.schemas import common_pb2
 from osbenchmark.worker_coordinator.proto_helpers.ProtoBulkHelper import ProtoBulkHelper
 
 class ProtoBulkHelperTests(TestCase):
@@ -36,11 +36,11 @@ class ProtoBulkHelperTests(TestCase):
 
         result = ProtoBulkHelper.build_proto_request(params)
 
-        self.assertIsInstance(result, document_pb2.BulkRequest)
+        self.assertIsInstance(result, common_pb2.BulkRequest)
         self.assertEqual(result.index, "test-index")
-        self.assertEqual(len(result.request_body), 1)
-        self.assertEqual(result.request_body[0].object, b'{"field1": "value1", "field2": "value2"}')
-        self.assertTrue(result.request_body[0].operation_container.HasField("index"))
+        self.assertEqual(len(result.bulk_request_body), 1)
+        self.assertEqual(result.bulk_request_body[0].object, b'{"field1": "value1", "field2": "value2"}')
+        self.assertTrue(result.bulk_request_body[0].operation_container.HasField("index"))
 
     def test_build_proto_request_multiple_documents(self):
         params = {
@@ -53,18 +53,18 @@ class ProtoBulkHelperTests(TestCase):
 
         result = ProtoBulkHelper.build_proto_request(params)
 
-        self.assertIsInstance(result, document_pb2.BulkRequest)
+        self.assertIsInstance(result, common_pb2.BulkRequest)
         self.assertEqual(result.index, "test-index")
-        self.assertEqual(len(result.request_body), 2)
-        self.assertEqual(result.request_body[0].object, b'{"field1": "value1"}')
-        self.assertEqual(result.request_body[1].object, b'{"field1": "value2"}')
+        self.assertEqual(len(result.bulk_request_body), 2)
+        self.assertEqual(result.bulk_request_body[0].object, b'{"field1": "value1"}')
+        self.assertEqual(result.bulk_request_body[1].object, b'{"field1": "value2"}')
 
     def test_build_stats_success_response(self):
-        mock_bulk_response = document_pb2.BulkResponse()
+        mock_bulk_response = common_pb2.BulkResponse()
         mock_bulk_response.took = 100
 
         for _ in range(3):
-            item = document_pb2.Item()
+            item = common_pb2.Item()
             item.index.status = 201
             mock_bulk_response.items.append(item)
 
@@ -89,7 +89,7 @@ class ProtoBulkHelperTests(TestCase):
         self.assertEqual(result, expected)
 
     def test_build_stats_bulk_error_response_status(self):
-        mock_bulk_response = document_pb2.BulkResponse()
+        mock_bulk_response = common_pb2.BulkResponse()
         mock_bulk_response.errors = True
 
         params = {
@@ -114,7 +114,7 @@ class ProtoBulkHelperTests(TestCase):
         self.assertEqual(result, expected)
 
     def test_build_stats_detailed_results_raises_exception(self):
-        mock_bulk_response = document_pb2.BulkResponse()
+        mock_bulk_response = common_pb2.BulkResponse()
 
         params = {"detailed-results": True}
 

--- a/tests/worker_coordinator/proto_query_helper_test.py
+++ b/tests/worker_coordinator/proto_query_helper_test.py
@@ -25,7 +25,7 @@
 from unittest import TestCase
 
 import numpy as np
-from opensearch.protobufs.schemas import search_pb2
+from opensearch.protobufs.schemas import common_pb2
 
 from osbenchmark.worker_coordinator.proto_helpers.ProtoQueryHelper import ProtoQueryHelper
 
@@ -46,13 +46,13 @@ class ProtoQueryHelperTests(TestCase):
 
         request = ProtoQueryHelper.build_proto_request(params)
 
-        self.assertIsInstance(request, search_pb2.SearchRequest)
+        self.assertIsInstance(request, common_pb2.SearchRequest)
         self.assertEqual(request.index, ["test-index"])
-        self.assertEqual(request.request_body.size, 10)
-        self.assertEqual(request.request_body.timeout, "5000ms")
+        self.assertEqual(request.search_request_body.size, 10)
+        self.assertEqual(request.search_request_body.timeout, "5000ms")
         self.assertTrue(request.request_cache)
-        self.assertTrue(request.x_source.bool)
-        self.assertTrue(request.request_body.query.HasField("match_all"))
+        self.assertTrue(request.x_source.fetch)
+        self.assertTrue(request.search_request_body.query.HasField("match_all"))
 
     def test_build_proto_request_term_query(self):
         params = {
@@ -70,10 +70,10 @@ class ProtoQueryHelperTests(TestCase):
 
         result = ProtoQueryHelper.build_proto_request(params)
 
-        self.assertIsInstance(result, search_pb2.SearchRequest)
-        self.assertTrue(result.request_body.query.HasField("term"))
-        self.assertEqual(result.request_body.query.term.field, "log.file.path")
-        self.assertEqual(result.request_body.query.term.value.string, "/var/log/messages/birdknight")
+        self.assertIsInstance(result, common_pb2.SearchRequest)
+        self.assertTrue(result.search_request_body.query.HasField("term"))
+        self.assertEqual(result.search_request_body.query.term.field, "log.file.path")
+        self.assertEqual(result.search_request_body.query.term.value.string, "/var/log/messages/birdknight")
 
     def test_build_proto_request_term_query_multi_field_fails(self):
         params = {
@@ -122,24 +122,24 @@ class ProtoKNNQueryHelperTests(TestCase):
 
         request = ProtoQueryHelper.build_vector_search_proto_request(params)
 
-        self.assertIsInstance(request, search_pb2.SearchRequest)
-        self.assertTrue(request.request_body.query.HasField('knn'))
-        self.assertEqual(request.request_body.query.knn.field, 'target_field')
-        self.assertAlmostEqual(request.request_body.query.knn.vector[0], 1.49081022e-01, places=5)
-        self.assertEqual(request.request_body.query.knn.k, 100)
+        self.assertIsInstance(request, common_pb2.SearchRequest)
+        self.assertTrue(request.search_request_body.query.HasField('knn'))
+        self.assertEqual(request.search_request_body.query.knn.field, 'target_field')
+        self.assertAlmostEqual(request.search_request_body.query.knn.vector[0], 1.49081022e-01, places=5)
+        self.assertEqual(request.search_request_body.query.knn.k, 100)
 
-        self.assertEqual(request.request_body.size, 100)
+        self.assertEqual(request.search_request_body.size, 100)
         self.assertEqual(request.docvalue_fields, ['_id'])
 
-        self.assertEqual(request.stored_fields, ["_none_"])
+        self.assertEqual(request.search_request_body.stored_fields, ["_none_"])
 
-        self.assertFalse(request.x_source.bool)
+        self.assertFalse(request.x_source.fetch)
         self.assertFalse(request.allow_partial_search_results)
 
         self.assertEqual(request.index, ['target_index'])
         self.assertEqual(request.request_cache, False)
-        self.assertEqual(request.timeout, '')
-        self.assertEqual(request.request_body.profile, False)
+        self.assertEqual(request.search_request_body.timeout, '')
+        self.assertEqual(request.search_request_body.profile, False)
 
     def test_build_vector_search_proto_defaults_with_optional_fields_empty(self):
         params = {
@@ -160,22 +160,22 @@ class ProtoKNNQueryHelperTests(TestCase):
 
         request = ProtoQueryHelper.build_vector_search_proto_request(params)
 
-        self.assertIsInstance(request, search_pb2.SearchRequest)
-        self.assertTrue(request.request_body.query.HasField('knn'))
-        self.assertEqual(request.request_body.query.knn.field, 'knn_field')
-        self.assertAlmostEqual(request.request_body.query.knn.vector[0], 1.49081022e-01, places=5)
-        self.assertEqual(request.request_body.query.knn.k, 100)
+        self.assertIsInstance(request, common_pb2.SearchRequest)
+        self.assertTrue(request.search_request_body.query.HasField('knn'))
+        self.assertEqual(request.search_request_body.query.knn.field, 'knn_field')
+        self.assertAlmostEqual(request.search_request_body.query.knn.vector[0], 1.49081022e-01, places=5)
+        self.assertEqual(request.search_request_body.query.knn.k, 100)
         self.assertEqual(request.index, ['index_required'])
 
         # expected defaults when these fields are not set
-        self.assertEqual(request.request_body.size, 0)
+        self.assertEqual(request.search_request_body.size, 0)
         self.assertEqual(request.docvalue_fields, [])
-        self.assertEqual(request.stored_fields, ["_none_"])
-        self.assertFalse(request.x_source.bool)
+        self.assertEqual(request.search_request_body.stored_fields, ["_none_"])
+        self.assertFalse(request.x_source.fetch)
         self.assertFalse(request.allow_partial_search_results)
         self.assertEqual(request.request_cache, False)
-        self.assertEqual(request.timeout, '')
-        self.assertEqual(request.request_body.profile, False)
+        self.assertEqual(request.search_request_body.timeout, '')
+        self.assertEqual(request.search_request_body.profile, False)
 
     def test_build_vector_search_proto_stored_fields_non_list_parsing(self):
         params = {
@@ -198,12 +198,12 @@ class ProtoKNNQueryHelperTests(TestCase):
 
         request = ProtoQueryHelper.build_vector_search_proto_request(params)
 
-        self.assertEqual(request.stored_fields, ["_none_"])
+        self.assertEqual(request.search_request_body.stored_fields, ["_none_"])
 
         params['body']['stored_fields'] = ['field1', 'field2']
         request = ProtoQueryHelper.build_vector_search_proto_request(params)
 
-        self.assertEqual(request.stored_fields, ['field1', 'field2'])
+        self.assertEqual(request.search_request_body.stored_fields, ['field1', 'field2'])
 
         params['body']['stored_fields'] = 'field1'
 
@@ -236,18 +236,18 @@ class ProtoKNNQueryHelperTests(TestCase):
 
         request = ProtoQueryHelper.build_vector_search_proto_request(params)
 
-        self.assertIsInstance(request, search_pb2.SearchRequest)
-        self.assertTrue(request.request_body.query.HasField('knn'))
-        self.assertEqual(request.request_body.query.knn.field, 'target_field')
-        self.assertAlmostEqual(request.request_body.query.knn.vector[0], 1.49081022e-01, places=5)
-        self.assertEqual(request.request_body.query.knn.k, 100)
+        self.assertIsInstance(request, common_pb2.SearchRequest)
+        self.assertTrue(request.search_request_body.query.HasField('knn'))
+        self.assertEqual(request.search_request_body.query.knn.field, 'target_field')
+        self.assertAlmostEqual(request.search_request_body.query.knn.vector[0], 1.49081022e-01, places=5)
+        self.assertEqual(request.search_request_body.query.knn.k, 100)
         self.assertEqual(request.index, ['target_index'])
 
         # bools are provided in several forms: True/False/None/"True"/"False"/"true"/"false"
-        self.assertTrue(request.x_source.bool)
+        self.assertTrue(request.x_source.fetch)
         self.assertFalse(request.allow_partial_search_results)
         self.assertEqual(request.request_cache, False)
-        self.assertEqual(request.request_body.profile, False)
+        self.assertEqual(request.search_request_body.profile, False)
 
     def test_build_vector_search_proto_ignore_params(self):
         params = {


### PR DESCRIPTION
### Description
Update OSB to the newest protobuf schema - 1.2.0.
Add compatibility matrix.

2.0.0 -> OpenSearch 3.3, 3.4
2.1.0 -> OpenSearch 3.5

### Issues Resolved
N/A

### Testing
- [x] New functionality includes testing

Updated unit tests.

Manual testing with httplogs, big5, vectorsearch gRPC test procedures.
```
opensearch-benchmark run \
    --pipeline=benchmark-only \
    --target-hosts=localhost:9200 \
    --grpc-target-hosts=localhost:9400 \
    --workload="http_logs" \
    --test-procedure="grpc-append-no-conflicts-index-only" \
    --workload-params '{"number_of_shards":"1","number_of_replicas":"0", "ingest_percentage":"1.0", "bulk_size":"500"}' \
    --kill-running-processes
```

```
opensearch-benchmark run \
    --pipeline=benchmark-only \
    --target-hosts=${HOST}:9200 \
    --grpc-target-hosts=${HOST}:9400 \
    --workload="big5" \
    --test-procedure="grpc-big5" \
    --workload-params '{"number_of_shards":"1","number_of_replicas":"0", "ingest_percentage":"1.0", "bulk_size":"500"}' \
    --kill-running-processes
```

```
PARAMS_FILE=~/projs/test-params-cohere-1k.json
opensearch-benchmark run \
    --pipeline=benchmark-only \
    --target-hosts=localhost:9200 \
    --grpc-target-hosts=localhost:9400 \
    --test-procedure="grpc-no-train-test" \
    --workload-params="${PARAMS_FILE}" \
    --workload=vectorsearch \
    --kill-running-processes
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
