### PR TITLE
add pandas as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,8 @@ install_requires = [
     # License: MIT
     # This version is required for Python 3.8 and 3.9 to work
     "mimesis==11.1.0",
+    # License: BSD-3-Clause
+    "pandas>=1.5.0",
     # Licence: BSD-3-Clause
     "dask",
     # Licence: BSD-3-Clause


### PR DESCRIPTION
### Description
getting unit test failures on other PR's:
```
************* Module osbenchmark.synthetic_data_generator.timeseries_partitioner
osbenchmark/synthetic_data_generator/timeseries_partitioner.py:15:0: E0401: Unable to import 'pandas' (import-error)
```

This adds pandas as a requirement so it gets installed during the CI and stops this failure

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
