### PR TITLE
fix: prevent __aexit__ from masking original runner exceptions

### DIFF
--- a/osbenchmark/context.py
+++ b/osbenchmark/context.py
@@ -62,18 +62,30 @@ class RequestContextManager:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # propagate earliest request start and most recent request end to parent
-        client_request_start = self.client_request_start
-        client_request_end = self.client_request_end
-        request_start = self.request_start
-        request_end = self.request_end
-        self.ctx_holder.restore_context(self.token)
-        # don't attempt to restore these values on the top-level context as they don't exist
-        if self.token.old_value != contextvars.Token.MISSING:
-            self.ctx_holder.update_request_start(request_start)
-            self.ctx_holder.update_request_end(request_end)
-            self.ctx_holder.update_client_request_start(client_request_start)
-            self.ctx_holder.update_client_request_end(client_request_end)
-        self.token = None
+        try:
+            client_request_start = self.client_request_start
+            client_request_end = self.client_request_end
+            request_start = self.request_start
+            request_end = self.request_end
+
+            self.ctx_holder.restore_context(self.token)
+            # don't attempt to restore these values on the top-level context as they don't exist
+            if self.token.old_value != contextvars.Token.MISSING:
+                self.ctx_holder.update_request_start(request_start)
+                self.ctx_holder.update_request_end(request_end)
+                self.ctx_holder.update_client_request_start(client_request_start)
+                self.ctx_holder.update_client_request_end(client_request_end)
+        except Exception:
+            # Never mask the original exception from the runner.
+            # If context propagation fails, ensure the context is still restored.
+            pass
+        finally:
+            if self.token is not None:
+                try:
+                    self.ctx_holder.restore_context(self.token)
+                except Exception:
+                    pass
+                self.token = None
         return False
 
 

--- a/osbenchmark/context.py
+++ b/osbenchmark/context.py
@@ -63,13 +63,17 @@ class RequestContextManager:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # propagate earliest request start and most recent request end to parent
+        client_request_start = self.client_request_start
+        client_request_end = self.client_request_end
+        request_start = self.request_start
+        request_end = self.request_end
+        self.ctx_holder.restore_context(self.token)
         # don't attempt to restore these values on the top-level context as they don't exist
         if self.token.old_value != contextvars.Token.MISSING:
-            self.ctx_holder.update_request_start(self.request_start)
-            self.ctx_holder.update_request_end(self.request_end)
-            self.ctx_holder.update_client_request_start(self.client_request_start)
-            self.ctx_holder.update_client_request_end(self.client_request_end)
-        self.ctx_holder.restore_context(self.token)
+            self.ctx_holder.update_client_request_start(client_request_start)
+            self.ctx_holder.update_request_start(request_start)
+            self.ctx_holder.update_request_end(request_end)
+            self.ctx_holder.update_client_request_end(client_request_end)
         self.token = None
         return False
 

--- a/osbenchmark/context.py
+++ b/osbenchmark/context.py
@@ -50,7 +50,8 @@ class RequestContextManager:
         client_end = self.client_request_end
         if client_end is None or "request_end_list" not in self.ctx:
             return None
-        return max((value for value in self.ctx["request_end_list"] if value < client_end))
+        request_ends = [value for value in self.ctx["request_end_list"] if value is not None and value < client_end]
+        return max(request_ends) if request_ends else None
 
     @property
     def client_request_start(self):
@@ -62,18 +63,21 @@ class RequestContextManager:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # propagate earliest request start and most recent request end to parent
-        client_request_start = self.client_request_start
-        client_request_end = self.client_request_end
-        request_start = self.request_start
-        request_end = self.request_end
-        self.ctx_holder.restore_context(self.token)
-        # don't attempt to restore these values on the top-level context as they don't exist
-        if self.token.old_value != contextvars.Token.MISSING:
-            self.ctx_holder.update_request_start(request_start)
-            self.ctx_holder.update_request_end(request_end)
-            self.ctx_holder.update_client_request_start(client_request_start)
-            self.ctx_holder.update_client_request_end(client_request_end)
-        self.token = None
+        try:
+            client_request_start = self.client_request_start
+            client_request_end = self.client_request_end
+            request_start = self.request_start
+            request_end = self.request_end
+            # don't attempt to restore these values on the top-level context as they don't exist
+            if self.token.old_value != contextvars.Token.MISSING:
+                self.ctx_holder.update_request_start(request_start)
+                self.ctx_holder.update_request_end(request_end)
+                self.ctx_holder.update_client_request_start(client_request_start)
+                self.ctx_holder.update_client_request_end(client_request_end)
+        finally:
+            if self.token is not None:
+                self.ctx_holder.restore_context(self.token)
+                self.token = None
         return False
 
 
@@ -98,6 +102,8 @@ class RequestContextHolder:
 
     @classmethod
     def update_request_start(cls, new_request_start):
+        if new_request_start is None:
+            return
         meta = cls.request_context.get()
         # this can happen if multiple requests are sent on the wire for one logical request (e.g. scrolls)
         if "request_start" not in meta and "client_request_start" in meta:
@@ -105,6 +111,8 @@ class RequestContextHolder:
 
     @classmethod
     def update_request_end(cls, new_request_end):
+        if new_request_end is None:
+            return
         meta = cls.request_context.get()
         if "request_end_list" not in meta:
             meta["request_end_list"] = []
@@ -112,12 +120,16 @@ class RequestContextHolder:
 
     @classmethod
     def update_client_request_start(cls, new_client_request_start):
+        if new_client_request_start is None:
+            return
         meta = cls.request_context.get()
         if "client_request_start" not in meta:
             meta["client_request_start"] = new_client_request_start
 
     @classmethod
     def update_client_request_end(cls, new_client_request_end):
+        if new_client_request_end is None:
+            return
         meta = cls.request_context.get()
         meta["client_request_end"] = new_client_request_end
 

--- a/osbenchmark/context.py
+++ b/osbenchmark/context.py
@@ -63,21 +63,14 @@ class RequestContextManager:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # propagate earliest request start and most recent request end to parent
-        try:
-            client_request_start = self.client_request_start
-            client_request_end = self.client_request_end
-            request_start = self.request_start
-            request_end = self.request_end
-            # don't attempt to restore these values on the top-level context as they don't exist
-            if self.token.old_value != contextvars.Token.MISSING:
-                self.ctx_holder.update_request_start(request_start)
-                self.ctx_holder.update_request_end(request_end)
-                self.ctx_holder.update_client_request_start(client_request_start)
-                self.ctx_holder.update_client_request_end(client_request_end)
-        finally:
-            if self.token is not None:
-                self.ctx_holder.restore_context(self.token)
-                self.token = None
+        # don't attempt to restore these values on the top-level context as they don't exist
+        if self.token.old_value != contextvars.Token.MISSING:
+            self.ctx_holder.update_request_start(self.request_start)
+            self.ctx_holder.update_request_end(self.request_end)
+            self.ctx_holder.update_client_request_start(self.client_request_start)
+            self.ctx_holder.update_client_request_end(self.client_request_end)
+        self.ctx_holder.restore_context(self.token)
+        self.token = None
         return False
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -504,6 +504,45 @@ class RequestContextManagerTests(TestCase):
         # nested request should only cover nested duration
         self.assertAlmostEqual(nested_duration, 0.1, delta=0.05)
 
+    @run_async
+    async def test_nested_context_without_request_end_preserves_original_exception(self):
+        test_client = client.RequestContextHolder()
+        with self.assertRaisesRegex(RuntimeError, "runner failed"):
+            async with test_client.new_request_context():
+                test_client.on_client_request_start()
+                async with test_client.new_request_context():
+                    test_client.on_client_request_start()
+                    raise RuntimeError("runner failed")
+
+    def test_request_end_ignores_none_values(self):
+        test_client = client.RequestContextHolder()
+        ctx, token = test_client.init_request_context()
+        try:
+            ctx["client_request_end"] = 2.0
+            ctx["request_end_list"] = [None, 1.0]
+            manager = test_client.new_request_context()
+            manager.ctx = ctx
+
+            self.assertEqual(1.0, manager.request_end)
+        finally:
+            test_client.restore_context(token)
+
+    def test_update_end_methods_ignore_none(self):
+        test_client = client.RequestContextHolder()
+        ctx, token = test_client.init_request_context()
+        try:
+            test_client.update_request_start(None)
+            test_client.update_request_end(None)
+            test_client.update_client_request_start(None)
+            test_client.update_client_request_end(None)
+
+            self.assertNotIn("request_start", ctx)
+            self.assertNotIn("request_end_list", ctx)
+            self.assertNotIn("client_request_start", ctx)
+            self.assertNotIn("client_request_end", ctx)
+        finally:
+            test_client.restore_context(token)
+
 
 class RestLayerTests(TestCase):
     @mock.patch("opensearchpy.OpenSearch")

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -545,6 +545,21 @@ class RequestContextManagerTests(TestCase):
         finally:
             test_client.restore_context(token)
 
+    @run_async
+    async def test_nested_context_propagates_to_parent(self):
+        test_client = client.RequestContextHolder()
+        async with test_client.new_request_context() as top_level_ctx:
+            async with test_client.new_request_context():
+                test_client.on_client_request_start()
+                test_client.on_request_start()
+                await asyncio.sleep(0.01)
+                test_client.on_request_end()
+                test_client.on_client_request_end()
+            self.assertIsNotNone(top_level_ctx.client_request_start)
+            self.assertIsNotNone(top_level_ctx.client_request_end)
+            self.assertIsNotNone(top_level_ctx.request_start)
+            self.assertIsNotNone(top_level_ctx.request_end)
+
 
 class RestLayerTests(TestCase):
     @mock.patch("opensearchpy.OpenSearch")

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -31,7 +31,6 @@ from copy import deepcopy
 from unittest import TestCase, mock
 
 import opensearchpy
-import pytest
 import urllib3.exceptions
 
 from osbenchmark import client, exceptions, doc_link
@@ -484,19 +483,22 @@ class OsClientFactoryTests(TestCase):
 
 
 class RequestContextManagerTests(TestCase):
-    @pytest.mark.skip(reason="latency is system-dependent")
     @run_async
     async def test_propagates_nested_context(self):
         test_client = client.RequestContextHolder()
         async with test_client.new_request_context() as top_level_ctx:
+            test_client.on_client_request_start()
             test_client.on_request_start()
             await asyncio.sleep(0.1)
             async with test_client.new_request_context() as nested_ctx:
+                test_client.on_client_request_start()
                 test_client.on_request_start()
                 await asyncio.sleep(0.1)
                 test_client.on_request_end()
+                test_client.on_client_request_end()
                 nested_duration = nested_ctx.request_end - nested_ctx.request_start
             test_client.on_request_end()
+            test_client.on_client_request_end()
             top_level_duration = top_level_ctx.request_end - top_level_ctx.request_start
 
         # top level request should cover total duration


### PR DESCRIPTION
Fixes #1028

When a runner throws before completing its request (HTTP 404,
connection error, etc.), timing keys like client_request_start and
client_request_end may not be set in the context. The __aexit__
method attempts to propagate these timing values, which can raise
a KeyError that replaces the original exception from the runner.

This wraps the timing propagation in a try/except so context cleanup
failures never mask the real error. The context token is always
restored in a finally block to prevent context leaks.