### PR TITLE
Add support for Milvus in OSB

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -600,7 +600,7 @@ def create_arg_parser():
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
     test_run_parser.add_argument(
         "--database-type",
-        help="Define the target database type (default: opensearch). Supported types: opensearch, vespa.",
+        help="Define the target database type (default: opensearch). Supported types: opensearch, vespa, milvus.",
         default="opensearch")
     test_run_parser.add_argument("--on-error",
                              choices=["continue", "abort"],

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -30,10 +30,6 @@ import opensearchpy
 import urllib3
 from urllib3.util.ssl_ import is_ipaddress
 
-import grpc
-from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub
-from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub
-
 from osbenchmark.kafka_client import KafkaMessageProducer
 from osbenchmark import exceptions, doc_link, async_connection
 from osbenchmark.context import RequestContextHolder
@@ -303,6 +299,14 @@ class GrpcClientFactory:
         Create gRPC service stubs.
         Returns a dict of {cluster_name: {service_name: stub}} structure.
         """
+        # Import grpc and protobuf stubs lazily — loading the grpc C extension
+        # initializes background threads. If that happens in the main process
+        # before Thespian forks actor children, the forked processes inherit
+        # broken gRPC thread state and may deadlock.
+        import grpc  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub  # pylint: disable=import-outside-toplevel
+
         stubs = {}
 
         if len(self.grpc_hosts.all_hosts.items()) > 1:

--- a/osbenchmark/database/__init__.py
+++ b/osbenchmark/database/__init__.py
@@ -58,12 +58,19 @@ from osbenchmark.database.registry import register_database, DatabaseType
 from osbenchmark.database.factory import DatabaseClientFactory
 from osbenchmark.database.clients.opensearch.opensearch import OpenSearchClientFactory
 from osbenchmark.database.clients.vespa.vespa import VespaClientFactory
+from osbenchmark.database.clients.milvus.milvus import MilvusClientFactory
 
 # Register OpenSearch as the default database type
 register_database(DatabaseType.OPENSEARCH, OpenSearchClientFactory)
 
 # Register Vespa database type
 register_database(DatabaseType.VESPA, VespaClientFactory)
+
+# Register Milvus database type
+# Note: pymilvus initializes gRPC at import time. This MUST happen at module
+# level (before Thespian forks actors) so all child processes inherit the same
+# gRPC state. Importing after some forks but before others causes deadlock.
+register_database(DatabaseType.MILVUS, MilvusClientFactory)
 
 # Public API exports
 __all__ = [

--- a/osbenchmark/database/clients/milvus/__init__.py
+++ b/osbenchmark/database/clients/milvus/__init__.py
@@ -4,4 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-"""Milvus client implementation."""
+from osbenchmark.database.clients.milvus.milvus import MilvusClientFactory, MilvusDatabaseClient, PYMILVUS_AVAILABLE
+
+__all__ = [
+    'MilvusClientFactory',
+    'MilvusDatabaseClient',
+    'PYMILVUS_AVAILABLE',
+]

--- a/osbenchmark/database/clients/milvus/helpers.py
+++ b/osbenchmark/database/clients/milvus/helpers.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Milvus helper functions for OpenSearch Benchmark.
+
+Pure functions for schema translation, response conversion, and
+parameter mapping. No network calls — all I/O is in milvus.py.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# OpenSearch distance metrics -> Milvus metric types
+METRIC_TYPE_MAP = {
+    "cosinesimil": "COSINE",
+    "l2": "L2",
+    "innerproduct": "IP",
+    "ip": "IP",
+    "cosine": "COSINE",
+    "angular": "COSINE",
+    "COSINE": "COSINE",
+    "L2": "L2",
+    "IP": "IP",
+}
+
+
+def get_metric_type(space_type):
+    """Convert OpenSearch space_type to Milvus metric type."""
+    return METRIC_TYPE_MAP.get(space_type, "COSINE")
+
+
+def build_collection_schema(client, params, client_options=None):
+    """Build a Milvus CollectionSchema from vectorsearch workload params.
+
+    Args:
+        client: MilvusDatabaseClient instance (exposes create_schema/prepare_index_params)
+        params: Workload params dict
+        client_options: Client options dict
+
+    Returns:
+        tuple: (schema, index_params, collection_name)
+    """
+    from pymilvus import DataType  # pylint: disable=import-outside-toplevel
+
+    client_options = client_options or {}
+    dimension = int(params.get("target_index_dimension", 768))
+    space_type = (client_options.get("metric_type")
+                  or client_options.get("space_type")
+                  or params.get("target_index_space_type", "cosinesimil"))
+    metric_type = get_metric_type(space_type)
+    vector_field = params.get("target_field_name", "embedding")
+    collection_name = params.get("target_index_name", "target_index")
+
+    hnsw_m = int(params.get("hnsw_m", client_options.get("hnsw_m", 16)))
+    ef_construction = int(params.get(
+        "hnsw_ef_construction",
+        client_options.get("hnsw_ef_construction", 200)
+    ))
+    index_type = client_options.get("index_type", "HNSW").upper()
+
+    schema = client.create_schema()
+    schema.add_field(
+        field_name="doc_id",
+        datatype=DataType.INT64,
+        is_primary=True,
+        auto_id=False,
+    )
+    schema.add_field(
+        field_name=vector_field,
+        datatype=DataType.FLOAT_VECTOR,
+        dim=dimension,
+    )
+
+    index_params = client.prepare_index_params()
+    index_params.add_index(
+        field_name=vector_field,
+        index_type=index_type,
+        metric_type=metric_type,
+        params={"M": hnsw_m, "efConstruction": ef_construction},
+    )
+
+    return schema, index_params, collection_name
+
+
+def build_search_params(params, client_options=None):
+    """Build Milvus search parameters from workload params.
+
+    metric_type is intentionally omitted — the server infers it from the index.
+    """
+    client_options = client_options or {}
+    k = int(params.get("k", params.get("query_k", 100)))
+    index_type = client_options.get("index_type", "HNSW").upper()
+
+    ef_search = int(
+        client_options.get("hnsw_ef_search")
+        or params.get("hnsw_ef_search")
+        or max(k, 256)
+    )
+
+    if index_type == "HNSW":
+        search_params = {"params": {"ef": ef_search}}
+    elif index_type.startswith("IVF"):
+        nprobe = int(client_options.get("nprobe", params.get("nprobe", 128)))
+        search_params = {"params": {"nprobe": nprobe}}
+    elif index_type == "DISKANN":
+        search_params = {"params": {"search_list": ef_search}}
+    else:
+        search_params = {"params": {}}
+
+    return {"k": k, "search_params": search_params, "ef_search": ef_search}
+
+
+def convert_milvus_search_response(results, collection_name="default"):
+    """Convert pymilvus search results to OpenSearch-compatible format.
+
+    pymilvus MilvusClient.search() returns List[List[Hit]].
+    Hit fields are accessed by key: h["doc_id"], h["distance"].
+    The primary key is accessed via its FIELD NAME ("doc_id"), not "id".
+    """
+    if not results or len(results) == 0:
+        return {
+            "took": 0,
+            "timed_out": False,
+            "hits": {"total": {"value": 0, "relation": "eq"}, "hits": []},
+        }
+
+    hits_list = results[0]
+    os_hits = []
+    for hit in hits_list:
+        os_hits.append({
+            "_index": collection_name,
+            "_id": str(hit.get("doc_id", hit.get("id", ""))),
+            "_score": hit.get("distance", 0.0),
+        })
+
+    return {
+        "took": 0,
+        "timed_out": False,
+        "hits": {
+            "total": {"value": len(os_hits), "relation": "eq"},
+            "hits": os_hits,
+        },
+    }
+
+
+def parse_vector_body(body, vector_field="embedding"):
+    """Parse vectorsearch workload body into documents for Milvus insert.
+
+    Input: alternating action/doc pairs from BulkVectorDataSetParamSource:
+        [{"index": {"_index": "idx", "_id": 0}}, {"embedding": [...]}, ...]
+
+    Returns:
+        tuple: (list of {"doc_id": int, "embedding": list}, index_name)
+    """
+    prepared = []
+    index = None
+
+    if not isinstance(body, list):
+        return prepared, index
+
+    i = 0
+    while i < len(body) - 1:
+        action_meta = body[i]
+        doc_body = body[i + 1]
+        if action_meta is None or doc_body is None:
+            i += 2
+            continue
+
+        action_type = list(action_meta.keys())[0]
+        meta = action_meta[action_type]
+        raw_id = meta.get("_id", i // 2)
+        try:
+            doc_id = int(raw_id)
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"Milvus INT64 primary key requires integer _id, got: {raw_id!r}"
+            )
+        if index is None:
+            index = meta.get("_index")
+
+        doc = {"doc_id": doc_id}
+        for k, v in doc_body.items():
+            doc[k] = v.tolist() if hasattr(v, 'tolist') else v
+        prepared.append(doc)
+        i += 2
+
+    return prepared, index
+
+
+def calculate_topk_recall(predictions, neighbors, top_k):
+    """Calculate recall@k by comparing predictions against ground truth neighbors.
+
+    Both predictions and neighbors are coerced to strings to avoid type mismatch.
+    Milvus returns INT64 IDs, HDF5 neighbors are numpy int64, and various code
+    paths may deliver str, int, or np.int64. Coercing both to str eliminates
+    this entire class of bugs.
+    """
+    if neighbors is None:
+        return 0.0
+    min_results = min(top_k, len(neighbors))
+    truth_set = set(str(n) for n in neighbors[:min_results] if str(n) != "-1")
+    if not truth_set:
+        return 1.0
+    correct = sum(1.0 for p in predictions[:min_results] if str(p) in truth_set)
+    return correct / len(truth_set)

--- a/osbenchmark/database/clients/milvus/helpers.py
+++ b/osbenchmark/database/clients/milvus/helpers.py
@@ -63,7 +63,7 @@ def build_collection_schema(client, params, client_options=None):
     Returns:
         tuple: (schema, index_params, collection_name)
     """
-    from pymilvus import DataType  # pylint: disable=import-outside-toplevel
+    from pymilvus import DataType  # pylint: disable=import-outside-toplevel,import-error
 
     client_options = client_options or {}
     dimension = int(params.get("target_index_dimension", 768))

--- a/osbenchmark/database/clients/milvus/milvus.py
+++ b/osbenchmark/database/clients/milvus/milvus.py
@@ -171,7 +171,7 @@ class MilvusDatabaseClient(DatabaseClient, RequestContextHolder):
                 os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "0")
                 os.environ.setdefault("GRPC_VERBOSITY", "ERROR")
                 try:
-                    from pymilvus import MilvusClient as _PyMilvusClient  # pylint: disable=import-outside-toplevel
+                    from pymilvus import MilvusClient as _PyMilvusClient  # pylint: disable=import-outside-toplevel,import-error
                     PyMilvusClient = _PyMilvusClient
                     PYMILVUS_AVAILABLE = True
                 except ImportError:
@@ -187,7 +187,7 @@ class MilvusDatabaseClient(DatabaseClient, RequestContextHolder):
                 # gRPC channels. Setting _instance = None forces a fresh singleton
                 # on next access. We do NOT call _reset_instance()/close_all()
                 # because calling close() on dead channels can hang.
-                from pymilvus.client.connection_manager import ConnectionManager  # pylint: disable=import-outside-toplevel
+                from pymilvus.client.connection_manager import ConnectionManager  # pylint: disable=import-outside-toplevel,import-error
                 ConnectionManager._instance = None
 
                 self._client = PyMilvusClient(uri=self.uri, timeout=self._timeout_admin, dedicated=True)
@@ -549,8 +549,8 @@ class MilvusIndicesNamespace(IndicesNamespace):
 
     def _send_flush_rpc(self, collection_name, timeout):
         """Send Flush RPC directly, bypassing pymilvus's _wait_for_flushed()."""
-        from pymilvus.client.prepare import Prepare  # pylint: disable=import-outside-toplevel
-        from pymilvus.client.utils import check_status  # pylint: disable=import-outside-toplevel
+        from pymilvus.client.prepare import Prepare  # pylint: disable=import-outside-toplevel,import-error
+        from pymilvus.client.utils import check_status  # pylint: disable=import-outside-toplevel,import-error
 
         handler = self._client._client._get_connection()
         request = Prepare.flush_param([collection_name])

--- a/osbenchmark/database/clients/milvus/milvus.py
+++ b/osbenchmark/database/clients/milvus/milvus.py
@@ -22,4 +22,695 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Milvus client implementation (placeholder for future development)."""
+"""
+Milvus database client implementation for OpenSearch Benchmark.
+
+Wraps pymilvus's synchronous MilvusClient, dispatching all calls through
+a dedicated ThreadPoolExecutor for non-blocking operation within OSB's
+async runner framework.
+"""
+# pylint: disable=protected-access
+
+import asyncio
+import concurrent.futures
+import functools
+import logging
+import os
+import threading
+import time
+
+from osbenchmark import exceptions
+from osbenchmark.context import RequestContextHolder
+from osbenchmark.database.interface import (
+    DatabaseClient,
+    IndicesNamespace,
+    ClusterNamespace,
+    TransportNamespace,
+    NodesNamespace,
+)
+
+# pymilvus is imported lazily inside _ensure_client(), NOT at module level.
+# Importing pymilvus triggers gRPC C-core initialization (threads, channels).
+# If this happens in the main process before Thespian forks actor processes,
+# the forked children inherit corrupted gRPC state and hang. By deferring the
+# import to _ensure_client() (which only runs inside worker processes after
+# all forks are complete), we avoid this entirely.
+PyMilvusClient = None
+PYMILVUS_AVAILABLE = None  # None = not yet checked, True/False after first check
+
+
+class MilvusClientFactory:
+    """Factory for creating Milvus client instances."""
+
+    def __init__(self, hosts, client_options):
+        self.hosts = hosts
+        self.client_options = dict(client_options)
+        self.logger = logging.getLogger(__name__)
+        self.logger.info("Creating Milvus client connected to %s with options [%s]", hosts, dict(client_options))
+
+    def create(self):
+        return self.create_async()
+
+    def create_async(self):
+        if not self.hosts:
+            raise exceptions.SystemSetupError("No Milvus hosts configured")
+        host_config = (self.hosts[0] if isinstance(self.hosts, list)
+                       else self.hosts.get("default", [{}])[0])
+        host = host_config.get("host", "localhost")
+        port = host_config.get("port", 19530)
+        return MilvusDatabaseClient(host=host, port=port, **self.client_options)
+
+    def wait_for_rest_layer(self, max_attempts=40):
+        """Wait for Milvus to become available.
+
+        Uses a simple HTTP health check instead of creating a full pymilvus
+        client. Creating and closing a pymilvus client poisons the shared
+        connection manager — the next real client gets a stale closed channel.
+        """
+        import requests as req  # pylint: disable=import-outside-toplevel
+        host_config = (self.hosts[0] if isinstance(self.hosts, list)
+                       else self.hosts.get("default", [{}])[0])
+        host = host_config.get("host", "localhost")
+        health_port = host_config.get("health_port", 9091)
+        health_url = f"http://{host}:{health_port}/healthz"
+
+        for attempt in range(max_attempts):
+            try:
+                resp = req.get(health_url, timeout=5)
+                if resp.status_code == 200:
+                    return True
+            except Exception as e:
+                if attempt >= max_attempts - 1:
+                    raise exceptions.SystemSetupError(
+                        f"Milvus not available after {max_attempts} attempts: {e}"
+                    )
+            time.sleep(3)
+
+
+class MilvusDatabaseClient(DatabaseClient, RequestContextHolder):
+    """Async Milvus client implementing the DatabaseClient interface.
+
+    Threading model:
+    - A dedicated ThreadPoolExecutor isolates Milvus gRPC calls from the
+      event loop and other async work.
+    - run_in_executor() overhead is ~20-80us per call (<1% of gRPC latency).
+
+    Retry policy:
+    - bulk()/insert(): retries transient gRPC errors (3 attempts, exponential backoff)
+    - search(): NO retry — retry inflates reported latency
+    - Admin ops (flush, compact, load): no retry, one-shot
+    """
+
+    def __init__(self, host="localhost", port=19530, **client_options):
+        self.host = host
+        self.port = port
+        self.uri = f"http://{host}:{port}"
+        self.client_options = client_options
+        self.logger = logging.getLogger(__name__)
+
+        self._client = None
+        self._client_initialized = False
+        self._init_lock = threading.Lock()
+        self._collection_name = client_options.get(
+            "collection_name",
+            client_options.get("app_name", "target_index"),
+        )
+
+        max_workers = int(client_options.get("max_workers", 64))
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="milvus",
+        )
+
+        self._timeout_insert = int(client_options.get("timeout_insert", 60))
+        self._timeout_search = int(client_options.get("timeout_search", 30))
+        self._timeout_admin = int(client_options.get("timeout_admin", 300))
+
+        self._indices_ns = MilvusIndicesNamespace(self)
+        self._cluster_ns = MilvusClusterNamespace(self)
+        self._transport_ns = MilvusTransportNamespace(self)
+        self._nodes_ns = MilvusNodesNamespace(self)
+
+    def _ensure_client(self):
+        """Lazy-init pymilvus MilvusClient with double-checked locking.
+
+        pymilvus is imported HERE (not at module level) to avoid initializing
+        gRPC in the main process before Thespian forks. This method only runs
+        inside worker processes after all forks are complete.
+        """
+        if self._client_initialized:
+            return
+        with self._init_lock:
+            if self._client_initialized:
+                return
+
+            global PyMilvusClient, PYMILVUS_AVAILABLE  # pylint: disable=global-statement
+            if PYMILVUS_AVAILABLE is None:
+                # Set gRPC env vars right before first import — guaranteed to
+                # take effect since grpc hasn't been imported yet in this process.
+                os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "0")
+                os.environ.setdefault("GRPC_VERBOSITY", "ERROR")
+                try:
+                    from pymilvus import MilvusClient as _PyMilvusClient  # pylint: disable=import-outside-toplevel
+                    PyMilvusClient = _PyMilvusClient
+                    PYMILVUS_AVAILABLE = True
+                except ImportError:
+                    PYMILVUS_AVAILABLE = False
+
+            if not PYMILVUS_AVAILABLE:
+                raise exceptions.SystemSetupError(
+                    "pymilvus not installed. Run: pip install 'pymilvus>=2.5.0'"
+                )
+            try:
+                # Nuke any inherited ConnectionManager singleton from a parent
+                # process (Thespian fork). The inherited singleton may hold dead
+                # gRPC channels. Setting _instance = None forces a fresh singleton
+                # on next access. We do NOT call _reset_instance()/close_all()
+                # because calling close() on dead channels can hang.
+                from pymilvus.client.connection_manager import ConnectionManager  # pylint: disable=import-outside-toplevel
+                ConnectionManager._instance = None
+
+                self._client = PyMilvusClient(uri=self.uri, timeout=self._timeout_admin, dedicated=True)
+                self._client_initialized = True
+                self.logger.info("pymilvus connected to %s", self.uri)
+            except Exception as e:
+                self.logger.error("Failed to connect to Milvus at %s: %s", self.uri, e)
+                raise exceptions.SystemSetupError(
+                    f"Cannot connect to Milvus at {self.uri}: {e}"
+                )
+
+    async def _run(self, fn, *args, **kwargs):
+        """Run a synchronous pymilvus call in the dedicated thread pool."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            functools.partial(fn, *args, **kwargs),
+        )
+
+    async def _run_with_retry(self, fn, *args, max_retries=3, **kwargs):
+        """Run with retry for transient gRPC failures. Used for ingestion only."""
+        for attempt in range(max_retries + 1):
+            try:
+                return await self._run(fn, *args, **kwargs)
+            except Exception as e:
+                err_str = str(e).lower()
+                is_transient = any(t in err_str for t in (
+                    "unavailable", "deadline exceeded", "connection",
+                    "resource exhausted", "reset by peer", "broken pipe",
+                ))
+                if is_transient and attempt < max_retries:
+                    wait = 0.5 * (2 ** attempt)
+                    self.logger.warning(
+                        "Transient Milvus error (attempt %d/%d, retrying in %.1fs): %s",
+                        attempt + 1, max_retries, wait, e,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+
+    # --- Lifecycle ---
+
+    async def __aenter__(self):
+        self._ensure_client()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+        return False
+
+    async def close(self):  # pylint: disable=invalid-overridden-method
+        """Close pymilvus client and thread pool."""
+        with self._init_lock:
+            if self._client:
+                try:
+                    await asyncio.wait_for(self._run(self._client.close), timeout=10)
+                except (asyncio.TimeoutError, Exception) as e:
+                    self.logger.warning("Error closing pymilvus client: %s", e)
+                self._client = None
+                self._client_initialized = False
+        self._executor.shutdown(wait=False)
+
+    # --- Public pymilvus wrappers (runners never touch _client directly) ---
+
+    def create_schema(self):
+        """Expose pymilvus create_schema()."""
+        self._ensure_client()
+        return self._client.create_schema()
+
+    def prepare_index_params(self):
+        """Expose pymilvus prepare_index_params()."""
+        self._ensure_client()
+        return self._client.prepare_index_params()
+
+    async def load_collection(self, collection_name, timeout=None):
+        """Load collection into memory for search. Handles already-loaded state."""
+        self._ensure_client()
+        timeout = timeout or self._timeout_admin
+        try:
+            await self._run(
+                self._client.load_collection,
+                collection_name=collection_name,
+                timeout=timeout,
+            )
+        except Exception as e:
+            err_str = str(e).lower()
+            if "already loaded" in err_str or "load state: loaded" in err_str:
+                self.logger.info("Collection %s already loaded", collection_name)
+            else:
+                raise
+
+    # --- Namespace properties ---
+
+    @property
+    def indices(self):
+        return self._indices_ns
+
+    @property
+    def cluster(self):
+        return self._cluster_ns
+
+    @property
+    def transport(self):
+        return self._transport_ns
+
+    @property
+    def nodes(self):
+        return self._nodes_ns
+
+    # --- Core document operations ---
+
+    async def bulk(self, body, index=None, doc_type=None, params=None, **kwargs):
+        """Insert a batch of documents. Retries transient errors."""
+        self._ensure_client()
+        collection_name = index or self._collection_name
+
+        if not isinstance(body, (list, tuple)):
+            body = [body]
+
+        try:
+            result = await self._run_with_retry(
+                self._client.insert,
+                collection_name=collection_name,
+                data=body,
+                timeout=self._timeout_insert,
+            )
+            insert_count = result.get("insert_count", 0)
+            has_errors = insert_count < len(body)
+            if has_errors:
+                self.logger.warning(
+                    "Milvus partial insert: %d/%d docs succeeded (collection=%s)",
+                    insert_count, len(body), collection_name,
+                )
+            return {
+                "took": 0,
+                "errors": has_errors,
+                "items": [
+                    {"index": {"_id": str(i), "status": 200}}
+                    for i in range(insert_count)
+                ],
+            }
+        except Exception as e:
+            self.logger.warning("Milvus insert failed for %d docs: %s", len(body), e)
+            return {
+                "took": 0,
+                "errors": True,
+                "items": [
+                    {"index": {"_id": str(i), "status": 500, "error": str(e)}}
+                    for i in range(len(body))
+                ],
+            }
+
+    async def search(self, index=None, body=None, doc_type=None, **kwargs):
+        """Execute vector search. NO retry — retry inflates reported latency."""
+        self._ensure_client()
+        collection_name = index or self._collection_name
+
+        search_kwargs = dict(body) if body else {}
+        search_kwargs["collection_name"] = collection_name
+        search_kwargs.setdefault("timeout", self._timeout_search)
+
+        return await self._run(self._client.search, **search_kwargs)
+
+    async def index(self, index, body, id=None, doc_type=None, **kwargs):
+        """Index a single document."""
+        self._ensure_client()
+        collection_name = index or self._collection_name
+        if id is not None:
+            body["doc_id"] = int(id)
+        await self._run(
+            self._client.insert,
+            collection_name=collection_name,
+            data=[body],
+            timeout=self._timeout_insert,
+        )
+        return {"_id": str(id), "result": "created", "_version": 1}
+
+    def info(self, **kwargs):
+        """Get Milvus server version — synchronous, uses HTTP to avoid loading pymilvus.
+
+        This is called by the coordinator process during retrieve_cluster_info()
+        BEFORE workers are forked. Using pymilvus here would initialize gRPC in
+        the coordinator, poisoning all forked workers. HTTP avoids this.
+        """
+        import requests as req  # pylint: disable=import-outside-toplevel
+        try:
+            resp = req.get(f"{self.uri}/v2/vectordb/collections/list",
+                          json={}, timeout=10, headers={"Content-Type": "application/json"})
+            version = "unknown"
+            if resp.status_code == 200:
+                # Milvus REST API works — extract version from a separate call if needed
+                version = "2.x"  # REST API doesn't expose version; get it from health port
+                health_url = f"http://{self.host}:9091/api/v1/health"
+                try:
+                    health_resp = req.get(health_url, timeout=5)
+                    if health_resp.status_code == 200:
+                        version = health_resp.json().get("version", "2.x")
+                except Exception:
+                    pass
+            return {
+                "name": "milvus",
+                "cluster_name": self._collection_name,
+                "cluster_uuid": "milvus-cluster",
+                "version": {
+                    "number": version,
+                    "distribution": "milvus",
+                    "build_type": "standalone",
+                    "build_hash": "unknown",
+                    "build_date": "unknown",
+                    "build_snapshot": False,
+                    "build_flavor": "default",
+                    "lucene_version": "unknown",
+                    "minimum_wire_compatibility_version": version,
+                    "minimum_index_compatibility_version": version,
+                },
+                "tagline": "The Vector Database for AI",
+            }
+        except Exception:
+            return {
+                "name": "milvus",
+                "cluster_name": self._collection_name,
+                "version": {"number": "unknown", "distribution": "milvus", "build_hash": "unknown"},
+            }
+
+    def return_raw_response(self):
+        pass
+
+
+# =============================================================================
+# Namespace implementations
+# =============================================================================
+
+class MilvusIndicesNamespace(IndicesNamespace):
+    """Index operations mapped to Milvus collection operations."""
+
+    def __init__(self, client):
+        self._client = client
+
+    async def create(self, index, body=None, **kwargs):
+        """Create collection + index.
+
+        Body contains {"schema": CollectionSchema, "index_params": IndexParams}.
+        Handles drop/create race: Milvus drop_collection is async internally.
+
+        Note: create_collection(schema, index_params) auto-calls load_collection()
+        internally in pymilvus. The subsequent warmup runner will be a no-op.
+        """
+        self._client._ensure_client()
+        collection_name = index or self._client._collection_name
+        schema = body.get("schema") if body else None
+        index_params = body.get("index_params") if body else None
+
+        if schema and index_params:
+            if await self._client._run(
+                self._client._client.has_collection,
+                collection_name=collection_name,
+            ):
+                await self._client._run(
+                    self._client._client.drop_collection,
+                    collection_name=collection_name,
+                )
+                for _ in range(20):
+                    if not await self._client._run(
+                        self._client._client.has_collection,
+                        collection_name=collection_name,
+                    ):
+                        break
+                    await asyncio.sleep(0.5)
+
+            await self._client._run(
+                self._client._client.create_collection,
+                collection_name=collection_name,
+                schema=schema,
+                index_params=index_params,
+            )
+        return {"acknowledged": True, "shards_acknowledged": True, "index": collection_name}
+
+    async def delete(self, index, **kwargs):
+        self._client._ensure_client()
+        await self._client._run(
+            self._client._client.drop_collection,
+            collection_name=index or self._client._collection_name,
+        )
+        return {"acknowledged": True}
+
+    async def exists(self, index, **kwargs):
+        self._client._ensure_client()
+        return await self._client._run(
+            self._client._client.has_collection,
+            collection_name=index,
+        )
+
+    async def refresh(self, index=None, **kwargs):
+        """Map to Milvus flush() — seals growing segments, persists to storage.
+
+        Bypasses pymilvus's flush() to avoid its internal _wait_for_flushed()
+        polling loop. That loop can trigger a reconnect cascade that permanently
+        kills the gRPC channel (reconnect timeout → close channel → "Cannot
+        invoke RPC on closed channel!"). Instead we send the Flush RPC directly
+        and poll get_flush_state ourselves with reconnect resilience.
+        """
+        self._client._ensure_client()
+        if not index:
+            return {"acknowledged": True, "_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+        timeout = self._client._timeout_admin
+
+        # Step 1: Send the Flush RPC directly via the gRPC stub.
+        # Retry on rate limiting — Milvus throttles flush to 0.1/s.
+        for attempt in range(5):
+            try:
+                segment_ids, flush_ts = await self._client._run(
+                    self._send_flush_rpc, index, timeout
+                )
+                break
+            except Exception as e:
+                if "rate limit" in str(e).lower() and attempt < 4:
+                    self._client.logger.warning("Flush rate-limited, retrying in 10s...")
+                    await asyncio.sleep(10)
+                    continue
+                raise
+
+        if not segment_ids:
+            return {"acknowledged": True, "_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+        # Step 2: Poll get_flush_state ourselves
+        start = time.time()
+        while True:
+            try:
+                handler = self._client._client._get_connection()
+                flushed = await self._client._run(
+                    handler.get_flush_state,
+                    segment_ids, index, flush_ts, timeout=timeout,
+                )
+                if flushed:
+                    break
+            except Exception as e:
+                elapsed = time.time() - start
+                if elapsed > timeout:
+                    raise
+                err_str = str(e).lower()
+                if "closed channel" in err_str or "cannot invoke" in err_str:
+                    self._client.logger.warning(
+                        "Flush poll hit closed channel (%.0fs), reconnecting...", elapsed
+                    )
+                    self._client._client_initialized = False
+                    self._client._client = None
+                    self._client._ensure_client()
+                else:
+                    raise
+
+            if time.time() - start > timeout:
+                raise exceptions.SystemSetupError(
+                    f"Flush timed out after {timeout}s for collection {index}"
+                )
+            await asyncio.sleep(0.5)
+
+        return {"acknowledged": True, "_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+    def _send_flush_rpc(self, collection_name, timeout):
+        """Send Flush RPC directly, bypassing pymilvus's _wait_for_flushed()."""
+        from pymilvus.client.prepare import Prepare  # pylint: disable=import-outside-toplevel
+        from pymilvus.client.utils import check_status  # pylint: disable=import-outside-toplevel
+
+        handler = self._client._client._get_connection()
+        request = Prepare.flush_param([collection_name])
+        response = handler._stub.Flush(request, timeout=timeout)
+        check_status(response.status)
+
+        seg_id_array = response.coll_segIDs.get(collection_name)
+        segment_ids = list(seg_id_array.data) if seg_id_array else []
+        flush_ts = response.coll_flush_ts.get(collection_name, 0)
+        return segment_ids, flush_ts
+
+    async def stats(self, index=None, metric=None, **kwargs):  # pylint: disable=invalid-overridden-method
+        self._client._ensure_client()
+        if index:
+            result = await self._client._run(
+                self._client._client.get_collection_stats,
+                collection_name=index,
+            )
+            row_count = result.get("row_count", 0)
+            return {
+                "_all": {
+                    "primaries": {"docs": {"count": row_count}},
+                    "total": {"docs": {"count": row_count}},
+                }
+            }
+        return {"_all": {"primaries": {}, "total": {}}}
+
+    async def forcemerge(self, index=None, **kwargs):  # pylint: disable=invalid-overridden-method
+        """Map to Milvus compact(). Polls get_compaction_state() for completion.
+
+        get_compaction_state() returns a string: "Completed", "Executing",
+        or "UndefiedState" (note: Milvus typo in enum name).
+        """
+        self._client._ensure_client()
+        if not index:
+            return {"_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+        job_id = await self._client._run(
+            self._client._client.compact,
+            collection_name=index,
+            timeout=self._client._timeout_admin,
+        )
+
+        wait = kwargs.get("wait_for_completion", True)
+        if wait and wait != "false":
+            for i in range(120):
+                try:
+                    state = await self._client._run(
+                        self._client._client.get_compaction_state,
+                        job_id,
+                    )
+                    if state == "Completed":
+                        break
+                    if i > 0 and i % 15 == 0:
+                        self._client.logger.info(
+                            "Compaction in progress (%ds, state=%s)...", i, state
+                        )
+                except Exception:
+                    break
+                await asyncio.sleep(1)
+
+        return {"_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+
+class MilvusClusterNamespace(ClusterNamespace):
+
+    def __init__(self, client):
+        self._client = client
+
+    async def health(self, **kwargs):
+        self._client._ensure_client()
+        try:
+            await self._client._run(self._client._client.list_collections)
+            return {
+                "cluster_name": "milvus",
+                "status": "green",
+                "timed_out": False,
+                "number_of_nodes": 1,
+                "number_of_data_nodes": 1,
+                "active_primary_shards": 1,
+                "active_shards": 1,
+                "relocating_shards": 0,
+                "initializing_shards": 0,
+                "unassigned_shards": 0,
+            }
+        except Exception:
+            return {"cluster_name": "milvus", "status": "red", "timed_out": False}
+
+    async def put_settings(self, body, **kwargs):
+        return {"acknowledged": True}
+
+
+class MilvusTransportNamespace(TransportNamespace):
+    """Stub — Milvus uses gRPC, not HTTP."""
+
+    def __init__(self, client):
+        self._client = client
+
+    async def perform_request(self, method, url, params=None, body=None, headers=None):  # pylint: disable=too-many-positional-arguments
+        return {}
+
+    async def close(self):
+        # Intentionally a no-op. OSB calls transport.close() between every
+        # operation step (in AsyncIoAdapter.run's finally block). Closing the
+        # pymilvus client tears down the gRPC channel, and the gRPC C-core
+        # retains stale state that poisons the NEXT step's fresh client.
+        # Let process exit handle cleanup instead.
+        pass
+
+
+class MilvusNodesNamespace(NodesNamespace):
+    """Stub node stats/info for telemetry compatibility."""
+
+    def __init__(self, client):
+        self._client = client
+
+    def stats(self, node_id=None, metric=None, **kwargs):
+        return {
+            "nodes": {
+                "milvus-node-1": {
+                    "name": "milvus-node-1",
+                    "host": self._client.uri,
+                    "os": {"cpu": {"percent": 0}},
+                    "jvm": {
+                        "mem": {
+                            "heap_used_percent": 0,
+                            "pools": {
+                                "young": {"peak_used_in_bytes": 0},
+                                "old": {"peak_used_in_bytes": 0},
+                                "survivor": {"peak_used_in_bytes": 0},
+                            },
+                        },
+                        "gc": {
+                            "collectors": {
+                                "young": {"collection_time_in_millis": 0, "collection_count": 0},
+                                "old": {"collection_time_in_millis": 0, "collection_count": 0},
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+    def info(self, node_id=None, metric=None, **kwargs):
+        return {
+            "nodes": {
+                "milvus-node-1": {
+                    "name": "milvus-node-1",
+                    "host": self._client.uri,
+                    "version": "unknown",
+                    "os": {"name": "Linux"},
+                    "jvm": {
+                        "version": "N/A",
+                        "gc": {
+                            "collectors": {
+                                "young": "N/A",
+                                "old": "N/A",
+                            }
+                        },
+                    },
+                }
+            }
+        }

--- a/osbenchmark/database/clients/opensearch/opensearch.py
+++ b/osbenchmark/database/clients/opensearch/opensearch.py
@@ -30,10 +30,6 @@ import opensearchpy
 import urllib3
 from urllib3.util.ssl_ import is_ipaddress
 
-import grpc
-from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub
-from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub
-
 from osbenchmark.kafka_client import KafkaMessageProducer
 from osbenchmark import exceptions, doc_link, async_connection
 from osbenchmark.context import RequestContextHolder
@@ -303,6 +299,14 @@ class GrpcClientFactory:
         Create gRPC service stubs.
         Returns a dict of {cluster_name: {service_name: stub}} structure.
         """
+        # Import grpc and protobuf stubs lazily — loading the grpc C extension
+        # initializes background threads. If that happens in the main process
+        # before Thespian forks actor children, the forked processes inherit
+        # broken gRPC thread state and may deadlock.
+        import grpc  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub  # pylint: disable=import-outside-toplevel
+
         stubs = {}
 
         if len(self.grpc_hosts.all_hosts.items()) > 1:

--- a/osbenchmark/worker_coordinator/runners/milvus.py
+++ b/osbenchmark/worker_coordinator/runners/milvus.py
@@ -22,8 +22,518 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+Milvus-specific runner implementations for OpenSearch Benchmark.
+
+Timing boundaries:
+- BEFORE timing: parse bodies, build params, construct schemas, extract vectors
+- INSIDE timing: gRPC calls only (insert, search, create, flush, compact, load)
+- AFTER timing: convert responses, calculate recall, build result dicts
+
+All runners catch exceptions and return {"success": False} dicts. OSB framework
+catches opensearchpy.TransportError, not pymilvus.MilvusException — without
+this, uncaught exceptions terminate the task.
+"""
+
+import logging
+import time
+
+from osbenchmark.database.clients.milvus.helpers import (
+    build_collection_schema,
+    build_search_params,
+    calculate_topk_recall,
+    convert_milvus_search_response,
+    parse_vector_body,
+)
+from osbenchmark import workload
+from osbenchmark.worker_coordinator.runners.base import Runner, request_context_holder
+
+logger = logging.getLogger(__name__)
+
+
+class MilvusBulkVectorDataSet(Runner):
+    """Bulk inserts vector datasets into Milvus.
+
+    No periodic flush in the runner — Milvus 2.6 auto-flushes at segment
+    buffer threshold (~16MB). The workload schedules explicit refresh
+    operations between phases. Runner instances are singletons shared
+    across workers — mutable state would race.
+    """
+
+    async def __call__(self, milvus_client, params):
+        size = params.get("size", 0)
+        body = params["body"]
+        vector_field = params.get("target_field_name", "embedding")
+
+        prepared, index = parse_vector_body(body, vector_field)
+        if not prepared:
+            return {"weight": size, "unit": "docs", "success": True}
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            result = await milvus_client.bulk(body=prepared, index=index)
+            error_count = len(prepared) - len(result.get("items", []))
+            return {
+                "weight": size,
+                "unit": "docs",
+                "success": not result.get("errors", False),
+                "error-count": error_count,
+            }
+        except Exception as e:
+            self.logger.warning("MilvusBulkVectorDataSet failed: %s", e)
+            return {"weight": size, "unit": "docs", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-bulk-vector-data-set"
+
+
+class MilvusBulkIndex(Runner):
+    """Bulk indexes documents for generic bulk operations."""
+
+    async def __call__(self, milvus_client, params):
+        bulk_size = params.get("bulk-size", 0)
+        unit = params.get("unit", "docs")
+        body = params.get("body")
+        index = params.get("index")
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            result = await milvus_client.bulk(body=body, index=index)
+            return {
+                "weight": bulk_size,
+                "unit": unit,
+                "success": not result.get("errors", False),
+            }
+        except Exception as e:
+            self.logger.warning("MilvusBulkIndex failed: %s", e)
+            return {"weight": bulk_size, "unit": unit, "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-bulk-index"
+
+
+class MilvusVectorSearch(Runner):
+    """Vector similarity search against Milvus.
+
+    Timing: build params BEFORE, search() INSIDE, convert + recall AFTER.
+    """
+
+    @staticmethod
+    def _extract_doc_id(milvus_id):
+        return str(milvus_id)
+
+    async def __call__(self, milvus_client, params):
+        body = params.get("body", {})
+        index = params.get("index")
+        k = params.get("k", 100)
+        collection_name = index or getattr(milvus_client, "_collection_name", "target_index")
+        client_options = getattr(milvus_client, "client_options", {})
+        vector_field = params.get("target_field_name", "embedding")
+
+        # BEFORE timing: extract vector, build params
+        query = body.get("query", {})
+        knn = query.get("knn", body.get("knn", {}))
+        vector = None
+        anns_field = None
+        if knn:
+            for field_name, field_config in knn.items():
+                if isinstance(field_config, dict) and "vector" in field_config:
+                    vector = field_config["vector"]
+                    anns_field = field_name
+                    k = field_config.get("k", k)
+                    break
+            if vector is None:
+                vector = knn.get("vector")
+                anns_field = knn.get("field", vector_field)
+
+        if vector is None:
+            return {"weight": 1, "unit": "ops", "success": False, "hits": 0}
+
+        if hasattr(vector, 'tolist'):
+            vector = vector.tolist()
+
+        search_config = build_search_params(params, client_options)
+        search_body = {
+            "data": [vector],
+            "anns_field": anns_field,
+            "limit": k,
+            "output_fields": ["doc_id"],
+            "search_params": search_config["search_params"],
+        }
+
+        # INSIDE timing: gRPC search only
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            raw_result = await milvus_client.search(index=collection_name, body=search_body)
+        except Exception as e:
+            self.logger.warning("MilvusVectorSearch failed: %s", e)
+            return {"weight": 1, "unit": "ops", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+        # AFTER timing: convert response, calculate recall
+        response = convert_milvus_search_response(raw_result, collection_name)
+        hits = response.get("hits", {}).get("total", {}).get("value", 0)
+        result = {
+            "weight": 1,
+            "unit": "ops",
+            "hits": hits,
+            "hits_relation": "eq",
+            "timed_out": False,
+            "success": True,
+        }
+
+        if params.get("detailed-results", False):
+            result["hits_total"] = hits
+            result["took"] = response.get("took", 0)
+
+        if params.get("neighbors") is not None and "k" in params:
+            response_hits = response.get("hits", {}).get("hits", [])
+            candidates = [self._extract_doc_id(h.get("_id", "")) for h in response_hits]
+            neighbors = params["neighbors"]
+            result["recall@k"] = calculate_topk_recall(candidates, neighbors, k)
+            result["recall@1"] = calculate_topk_recall(candidates, neighbors, 1)
+
+        return result
+
+    def __repr__(self):
+        return "milvus-vector-search"
+
+
+class MilvusQuery(Runner):
+    """General search queries. For vectorsearch workload, all queries use KNN."""
+
+    async def __call__(self, milvus_client, params):
+        body = params.get("body", {})
+        index = params.get("index")
+        collection_name = index or getattr(milvus_client, "_collection_name", "target_index")
+        client_options = getattr(milvus_client, "client_options", {})
+        vector_field = params.get("target_field_name", "embedding")
+
+        query = body.get("query", {})
+        knn = query.get("knn", body.get("knn", {}))
+        vector = None
+        anns_field = None
+        if knn:
+            for field_name, field_config in knn.items():
+                if isinstance(field_config, dict) and "vector" in field_config:
+                    vector = field_config["vector"]
+                    anns_field = field_name
+                    break
+            if vector is None:
+                vector = knn.get("vector")
+                anns_field = knn.get("field", vector_field)
+
+        if vector is None:
+            return {"weight": 1, "unit": "ops", "success": True, "hits": 0}
+
+        if hasattr(vector, 'tolist'):
+            vector = vector.tolist()
+
+        k = params.get("k", body.get("size", 100))
+        search_config = build_search_params(params, client_options)
+        search_body = {
+            "data": [vector],
+            "anns_field": anns_field,
+            "limit": k,
+            "output_fields": ["doc_id"],
+            "search_params": search_config["search_params"],
+        }
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            raw_result = await milvus_client.search(index=collection_name, body=search_body)
+        except Exception as e:
+            self.logger.warning("MilvusQuery failed: %s", e)
+            return {"weight": 1, "unit": "ops", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+        response = convert_milvus_search_response(raw_result, collection_name)
+        hits = response.get("hits", {}).get("total", {}).get("value", 0)
+        return {"weight": 1, "unit": "ops", "hits": hits,
+                "hits_relation": "eq", "timed_out": False}
+
+    def __repr__(self):
+        return "milvus-query"
+
+
+class MilvusCreateIndex(Runner):
+    """Creates a Milvus collection with schema and index.
+
+    Schema derived from workload params, not OpenSearch index body JSON.
+    """
+
+    async def __call__(self, milvus_client, params):
+        indices = params.get("indices", [])
+        if not indices:
+            index = params.get("index")
+            body_param = params.get("body")
+            if index:
+                indices = [(index, body_param)]
+
+        client_options = getattr(milvus_client, "client_options", {})
+
+        # BEFORE timing: build schemas
+        schemas = []
+        for index_name, _ in indices:
+            schema, index_params, _ = build_collection_schema(
+                milvus_client, params, client_options
+            )
+            schemas.append((index_name, {"schema": schema, "index_params": index_params}))
+
+        # INSIDE timing: create collection
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            for index_name, create_body in schemas:
+                await milvus_client.indices.create(index=index_name, body=create_body)
+                self.logger.info("Created Milvus collection: %s", index_name)
+            return {"weight": len(schemas), "unit": "ops", "success": True}
+        except Exception as e:
+            self.logger.warning("MilvusCreateIndex failed: %s", e)
+            return {"weight": len(schemas), "unit": "ops", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-create-index"
+
+
+class MilvusDeleteIndex(Runner):
+
+    async def __call__(self, milvus_client, params):
+        indices = params.get("indices", [])
+        if not indices:
+            index = params.get("index")
+            if index:
+                indices = [index]
+
+        only_if_exists = params.get("only-if-exists", False)
+        ops = 0
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            for index_name in indices:
+                if not only_if_exists or await milvus_client.indices.exists(index=index_name):
+                    await milvus_client.indices.delete(index=index_name)
+                    ops += 1
+            return {"weight": ops, "unit": "ops", "success": True}
+        except Exception as e:
+            self.logger.warning("MilvusDeleteIndex failed: %s", e)
+            return {"weight": ops, "unit": "ops", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-delete-index"
+
+
+class MilvusRefresh(Runner):
+
+    async def __call__(self, milvus_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            await milvus_client.indices.refresh(index=params.get("index"))
+            return {"weight": 1, "unit": "ops", "success": True}
+        except Exception as e:
+            return {"weight": 1, "unit": "ops", "success": False,
+                    "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-refresh"
+
+
+class MilvusForceMerge(Runner):
+
+    async def __call__(self, milvus_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            await milvus_client.indices.forcemerge(index=params.get("index"))
+            return {"weight": 1, "unit": "ops", "success": True}
+        except Exception as e:
+            return {"weight": 1, "unit": "ops", "success": False,
+                    "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-force-merge"
+
+
+class MilvusClusterHealth(Runner):
+
+    async def __call__(self, milvus_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            response = await milvus_client.cluster.health()
+            cluster_status = response.get("status", "unknown")
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "success": cluster_status in ("green", "yellow"),
+                "cluster-status": cluster_status,
+                "relocating-shards": 0,
+            }
+        except Exception:
+            return {"weight": 1, "unit": "ops", "success": False, "cluster-status": "red"}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-cluster-health"
+
+
+class MilvusIndicesStats(Runner):
+
+    async def __call__(self, milvus_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            response = await milvus_client.indices.stats(index=params.get("index"))
+            return {"weight": 1, "unit": "ops", "stats": response}
+        except Exception:
+            return {"weight": 1, "unit": "ops", "success": False}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "milvus-indices-stats"
+
+
+class MilvusWarmupRunner(Runner):
+    """Load collection and warm up HNSW graph + gRPC channel.
+
+    1. load_collection() — ensures data is in memory (may be no-op if
+       create_collection already loaded it)
+    2. Warmup queries — issues random vector searches to exercise the HNSW
+       graph, warm page cache, and establish gRPC channel. This is critical
+       for consistent first-query latency.
+    """
+
+    DEFAULT_WARMUP_QUERIES = 100
+
+    async def __call__(self, milvus_client, params):
+        index = params.get("index", "target_index")
+        vector_field = params.get("target_field_name", "embedding")
+        dimension = int(params.get("target_index_dimension", 768))
+        k = int(params.get("query_k", params.get("k", 100)))
+        client_options = getattr(milvus_client, "client_options", {})
+        warmup_queries = self.DEFAULT_WARMUP_QUERIES
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            # Step 1: Ensure collection is loaded
+            start = time.perf_counter()
+            await milvus_client.load_collection(collection_name=index)
+            load_time = time.perf_counter() - start
+
+            # Step 2: Warmup queries with random vectors
+            import numpy as np  # pylint: disable=import-outside-toplevel
+            np.random.seed(0)
+            search_params = build_search_params(params, client_options)
+
+            for _ in range(warmup_queries):
+                warmup_vec = np.random.randn(dimension).astype(np.float32).tolist()
+                search_body = {
+                    "data": [warmup_vec],
+                    "anns_field": vector_field,
+                    "limit": k,
+                    "output_fields": ["doc_id"],
+                    "search_params": search_params["search_params"],
+                }
+                await milvus_client.search(index=index, body=search_body)
+
+            warmup_time = time.perf_counter() - start
+            self.logger.info(
+                "Warmup complete: load=%.1fs, %d queries in %.1fs total",
+                load_time, warmup_queries, warmup_time,
+            )
+            return {"weight": 1, "unit": "ops", "success": True}
+        except Exception as e:
+            self.logger.warning("MilvusWarmup failed: %s", e)
+            return {"weight": 1, "unit": "ops", "success": False,
+                    "error-type": "milvus", "error-description": str(e)}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return "warmup-knn-indices"
+
+
+class MilvusNoOp(Runner):
+
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+    async def __call__(self, milvus_client, params):
+        self.logger.info("Skipping unsupported operation [%s] for Milvus", self._name)
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            return {"weight": 1, "unit": "ops", "success": True}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+    def __repr__(self):
+        return self._name
+
+
 def register_milvus_runners():
-    """
-    Register all milvus-specific runners.
-    Implementation will be added in a future PR.
-    """
+    """Register all Milvus-specific runners with the runner registry."""
+    from osbenchmark.worker_coordinator.runners import register_runner  # pylint: disable=import-outside-toplevel
+
+    register_runner(workload.OperationType.Bulk, MilvusBulkIndex(), async_runner=True)
+    register_runner(workload.OperationType.Search, MilvusQuery(), async_runner=True)
+    register_runner(workload.OperationType.PaginatedSearch, MilvusQuery(), async_runner=True)
+    register_runner(workload.OperationType.VectorSearch, MilvusVectorSearch(), async_runner=True)
+    register_runner(workload.OperationType.BulkVectorDataSet, MilvusBulkVectorDataSet(), async_runner=True)
+    register_runner(workload.OperationType.CreateIndex, MilvusCreateIndex(), async_runner=True)
+    register_runner(workload.OperationType.DeleteIndex, MilvusDeleteIndex(), async_runner=True)
+    register_runner(workload.OperationType.IndexStats, MilvusIndicesStats(), async_runner=True)
+    register_runner(workload.OperationType.ClusterHealth, MilvusClusterHealth(), async_runner=True)
+    register_runner(workload.OperationType.Refresh, MilvusRefresh(), async_runner=True)
+    register_runner(workload.OperationType.ForceMerge, MilvusForceMerge(), async_runner=True)
+    register_runner("warmup-knn-indices", MilvusWarmupRunner(), async_runner=True)
+
+    for op_type in [
+        workload.OperationType.PutPipeline,
+        workload.OperationType.DeletePipeline,
+        workload.OperationType.CreateSearchPipeline,
+        workload.OperationType.PutSettings,
+    ]:
+        register_runner(op_type, MilvusNoOp(str(op_type)), async_runner=True)

--- a/osbenchmark/worker_coordinator/runners/vespa.py
+++ b/osbenchmark/worker_coordinator/runners/vespa.py
@@ -80,7 +80,8 @@ class VespaBulkIndex(Runner):
                 source = doc.get("_source", doc)
                 action = doc.get("_action", "index")
 
-                if "@timestamp" in source or "timestamp" in source or any(isinstance(v, (dict, list)) for v in source.values()):
+                has_nested = any(isinstance(v, (dict, list)) for v in source.values())
+                if "@timestamp" in source or "timestamp" in source or has_nested:
                     source = transform_document_for_vespa(source)
 
                 prepared.append({"_id": doc_id, "fields": source, "_action": action})
@@ -643,16 +644,17 @@ class VespaWarmupIndicesRunner(Runner):
     queries to warm OS page cache, attribute caches, and internal paths.
     """
 
-    WARMUP_QUERIES = 5
+    DEFAULT_WARMUP_QUERIES = 100
 
     async def __call__(self, vespa_client, params):
         index = params.get("index", "target_index")
         doc_type = index or getattr(vespa_client, "_app_name", "default")
+        warmup_queries = self.DEFAULT_WARMUP_QUERIES
 
         request_context_holder.on_client_request_start()
         request_context_holder.on_request_start()
         try:
-            for _ in range(self.WARMUP_QUERIES):
+            for _ in range(warmup_queries):
                 await vespa_client.search(
                     index=index,
                     body={"yql": f"select * from {doc_type} where true", "hits": 1}

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1712,6 +1712,10 @@ class Worker(actor.BenchmarkActor):
             from osbenchmark.worker_coordinator.runners.vespa import register_vespa_runners  # pylint: disable=import-outside-toplevel
             register_vespa_runners()
             self.logger.info("Registered Vespa runners (overriding OpenSearch and workload defaults for supported operations)")
+        elif database_type.lower() == "milvus":
+            from osbenchmark.worker_coordinator.runners.milvus import register_milvus_runners  # pylint: disable=import-outside-toplevel
+            register_milvus_runners()
+            self.logger.info("Registered Milvus runners (overriding OpenSearch and workload defaults for supported operations)")
         self.drive()
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter

--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,7 @@ setup(name="opensearch-benchmark",
       extras_require={
           "develop": tests_require + develop_require,
           "vespa": ["pyvespa>=0.62.0"],
+          "milvus": ["pymilvus>=2.5.0"],
       },
       entry_points={
           "console_scripts": [

--- a/tests/database/clients/milvus/helpers_test.py
+++ b/tests/database/clients/milvus/helpers_test.py
@@ -12,12 +12,10 @@ import numpy as np
 
 from osbenchmark.database.clients.milvus.helpers import (
     get_metric_type,
-    build_collection_schema,
     build_search_params,
     convert_milvus_search_response,
     parse_vector_body,
     calculate_topk_recall,
-    METRIC_TYPE_MAP,
 )
 
 
@@ -67,21 +65,14 @@ class BuildCollectionSchemaTests(TestCase):
     @patch("osbenchmark.database.clients.milvus.helpers.DataType", create=True)
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_defaults(self, _mock_dt):
-        # Patch pymilvus.DataType inside the function's lazy import
-        mock_datatype = MagicMock()
-        with patch("osbenchmark.database.clients.milvus.helpers.build_collection_schema") as _:
-            pass  # we'll call the real function instead
-
-        # Re-import so the lazy import of pymilvus.DataType resolves
-        import sys
-        mock_pymilvus = MagicMock()
-        sys.modules["pymilvus"] = mock_pymilvus
+        import sys  # pylint: disable=import-outside-toplevel
+        sys.modules["pymilvus"] = MagicMock()
 
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
-            schema, index_params, collection_name = bcs(client, {})
+            _, index_params, collection_name = bcs(client, {})
 
             self.assertEqual(collection_name, "target_index")
             client.create_schema.assert_called_once()
@@ -99,10 +90,10 @@ class BuildCollectionSchemaTests(TestCase):
 
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_custom_params(self):
-        import sys
+        import sys  # pylint: disable=import-outside-toplevel
         sys.modules["pymilvus"] = MagicMock()
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
             params = {
@@ -113,7 +104,7 @@ class BuildCollectionSchemaTests(TestCase):
                 "hnsw_m": 32,
                 "hnsw_ef_construction": 400,
             }
-            schema, index_params, collection_name = bcs(client, params)
+            _, index_params, collection_name = bcs(client, params)
 
             self.assertEqual(collection_name, "my_collection")
             call_kwargs = index_params.add_index.call_args[1]
@@ -126,10 +117,10 @@ class BuildCollectionSchemaTests(TestCase):
 
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_client_options_override_metric(self):
-        import sys
+        import sys  # pylint: disable=import-outside-toplevel
         sys.modules["pymilvus"] = MagicMock()
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
             params = {"target_index_space_type": "l2"}
@@ -143,10 +134,10 @@ class BuildCollectionSchemaTests(TestCase):
 
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_client_options_override_index_type(self):
-        import sys
+        import sys  # pylint: disable=import-outside-toplevel
         sys.modules["pymilvus"] = MagicMock()
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
             client_options = {"index_type": "IVF_FLAT"}
@@ -159,10 +150,10 @@ class BuildCollectionSchemaTests(TestCase):
 
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_schema_has_doc_id_and_vector_fields(self):
-        import sys
+        import sys  # pylint: disable=import-outside-toplevel
         sys.modules["pymilvus"] = MagicMock()
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
             schema_mock = client.create_schema.return_value
@@ -181,10 +172,10 @@ class BuildCollectionSchemaTests(TestCase):
 
     @patch.dict("sys.modules", {"pymilvus": MagicMock()})
     def test_hnsw_params_from_client_options(self):
-        import sys
+        import sys  # pylint: disable=import-outside-toplevel
         sys.modules["pymilvus"] = MagicMock()
         try:
-            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs  # pylint: disable=import-outside-toplevel
 
             client = self._make_mock_client()
             client_options = {"hnsw_m": 64, "hnsw_ef_construction": 500}
@@ -335,7 +326,7 @@ class ParseVectorBodyTests(TestCase):
             {"index": {"_index": "idx", "_id": 1}},
             {"embedding": [2.0]},
         ]
-        docs, index = parse_vector_body(body)
+        docs, _ = parse_vector_body(body)
         self.assertEqual(len(docs), 2)
         self.assertEqual(docs[0]["doc_id"], 0)
         self.assertEqual(docs[1]["doc_id"], 1)

--- a/tests/database/clients/milvus/helpers_test.py
+++ b/tests/database/clients/milvus/helpers_test.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from osbenchmark.database.clients.milvus.helpers import (
+    get_metric_type,
+    build_collection_schema,
+    build_search_params,
+    convert_milvus_search_response,
+    parse_vector_body,
+    calculate_topk_recall,
+    METRIC_TYPE_MAP,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_metric_type
+# ---------------------------------------------------------------------------
+class GetMetricTypeTests(TestCase):
+    def test_cosinesimil(self):
+        self.assertEqual(get_metric_type("cosinesimil"), "COSINE")
+
+    def test_l2(self):
+        self.assertEqual(get_metric_type("l2"), "L2")
+
+    def test_innerproduct(self):
+        self.assertEqual(get_metric_type("innerproduct"), "IP")
+
+    def test_ip_lowercase(self):
+        self.assertEqual(get_metric_type("ip"), "IP")
+
+    def test_cosine(self):
+        self.assertEqual(get_metric_type("cosine"), "COSINE")
+
+    def test_angular(self):
+        self.assertEqual(get_metric_type("angular"), "COSINE")
+
+    def test_uppercase_passthrough(self):
+        self.assertEqual(get_metric_type("COSINE"), "COSINE")
+        self.assertEqual(get_metric_type("L2"), "L2")
+        self.assertEqual(get_metric_type("IP"), "IP")
+
+    def test_unknown_defaults_to_cosine(self):
+        self.assertEqual(get_metric_type("hamming"), "COSINE")
+        self.assertEqual(get_metric_type(""), "COSINE")
+        self.assertEqual(get_metric_type("unknown_metric"), "COSINE")
+
+
+# ---------------------------------------------------------------------------
+# build_collection_schema
+# ---------------------------------------------------------------------------
+class BuildCollectionSchemaTests(TestCase):
+    def _make_mock_client(self):
+        client = MagicMock()
+        client.create_schema.return_value = MagicMock()
+        client.prepare_index_params.return_value = MagicMock()
+        return client
+
+    @patch("osbenchmark.database.clients.milvus.helpers.DataType", create=True)
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_defaults(self, _mock_dt):
+        # Patch pymilvus.DataType inside the function's lazy import
+        mock_datatype = MagicMock()
+        with patch("osbenchmark.database.clients.milvus.helpers.build_collection_schema") as _:
+            pass  # we'll call the real function instead
+
+        # Re-import so the lazy import of pymilvus.DataType resolves
+        import sys
+        mock_pymilvus = MagicMock()
+        sys.modules["pymilvus"] = mock_pymilvus
+
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            schema, index_params, collection_name = bcs(client, {})
+
+            self.assertEqual(collection_name, "target_index")
+            client.create_schema.assert_called_once()
+            client.prepare_index_params.assert_called_once()
+            # Vector field defaults to "embedding", index_type to HNSW
+            index_params.add_index.assert_called_once()
+            call_kwargs = index_params.add_index.call_args
+            self.assertEqual(call_kwargs[1]["field_name"], "embedding")
+            self.assertEqual(call_kwargs[1]["index_type"], "HNSW")
+            self.assertEqual(call_kwargs[1]["metric_type"], "COSINE")
+            self.assertEqual(call_kwargs[1]["params"]["M"], 16)
+            self.assertEqual(call_kwargs[1]["params"]["efConstruction"], 200)
+        finally:
+            del sys.modules["pymilvus"]
+
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_custom_params(self):
+        import sys
+        sys.modules["pymilvus"] = MagicMock()
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            params = {
+                "target_index_dimension": 128,
+                "target_index_space_type": "l2",
+                "target_field_name": "vec",
+                "target_index_name": "my_collection",
+                "hnsw_m": 32,
+                "hnsw_ef_construction": 400,
+            }
+            schema, index_params, collection_name = bcs(client, params)
+
+            self.assertEqual(collection_name, "my_collection")
+            call_kwargs = index_params.add_index.call_args[1]
+            self.assertEqual(call_kwargs["field_name"], "vec")
+            self.assertEqual(call_kwargs["metric_type"], "L2")
+            self.assertEqual(call_kwargs["params"]["M"], 32)
+            self.assertEqual(call_kwargs["params"]["efConstruction"], 400)
+        finally:
+            del sys.modules["pymilvus"]
+
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_client_options_override_metric(self):
+        import sys
+        sys.modules["pymilvus"] = MagicMock()
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            params = {"target_index_space_type": "l2"}
+            client_options = {"metric_type": "IP"}
+            _, index_params, _ = bcs(client, params, client_options)
+
+            call_kwargs = index_params.add_index.call_args[1]
+            self.assertEqual(call_kwargs["metric_type"], "IP")
+        finally:
+            del sys.modules["pymilvus"]
+
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_client_options_override_index_type(self):
+        import sys
+        sys.modules["pymilvus"] = MagicMock()
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            client_options = {"index_type": "IVF_FLAT"}
+            _, index_params, _ = bcs(client, {}, client_options)
+
+            call_kwargs = index_params.add_index.call_args[1]
+            self.assertEqual(call_kwargs["index_type"], "IVF_FLAT")
+        finally:
+            del sys.modules["pymilvus"]
+
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_schema_has_doc_id_and_vector_fields(self):
+        import sys
+        sys.modules["pymilvus"] = MagicMock()
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            schema_mock = client.create_schema.return_value
+            bcs(client, {"target_field_name": "my_vec"})
+
+            add_field_calls = schema_mock.add_field.call_args_list
+            self.assertEqual(len(add_field_calls), 2)
+            # First call: doc_id primary key
+            self.assertEqual(add_field_calls[0][1]["field_name"], "doc_id")
+            self.assertTrue(add_field_calls[0][1]["is_primary"])
+            self.assertFalse(add_field_calls[0][1]["auto_id"])
+            # Second call: vector field
+            self.assertEqual(add_field_calls[1][1]["field_name"], "my_vec")
+        finally:
+            del sys.modules["pymilvus"]
+
+    @patch.dict("sys.modules", {"pymilvus": MagicMock()})
+    def test_hnsw_params_from_client_options(self):
+        import sys
+        sys.modules["pymilvus"] = MagicMock()
+        try:
+            from osbenchmark.database.clients.milvus.helpers import build_collection_schema as bcs
+
+            client = self._make_mock_client()
+            client_options = {"hnsw_m": 64, "hnsw_ef_construction": 500}
+            _, index_params, _ = bcs(client, {}, client_options)
+
+            call_kwargs = index_params.add_index.call_args[1]
+            self.assertEqual(call_kwargs["params"]["M"], 64)
+            self.assertEqual(call_kwargs["params"]["efConstruction"], 500)
+        finally:
+            del sys.modules["pymilvus"]
+
+
+# ---------------------------------------------------------------------------
+# build_search_params
+# ---------------------------------------------------------------------------
+class BuildSearchParamsTests(TestCase):
+    def test_hnsw_defaults(self):
+        result = build_search_params({})
+        self.assertEqual(result["k"], 100)
+        self.assertEqual(result["ef_search"], 256)
+        self.assertEqual(result["search_params"]["params"]["ef"], 256)
+
+    def test_hnsw_k_larger_than_256(self):
+        result = build_search_params({"k": 500})
+        self.assertEqual(result["k"], 500)
+        self.assertEqual(result["ef_search"], 500)
+        self.assertEqual(result["search_params"]["params"]["ef"], 500)
+
+    def test_hnsw_ef_search_override_via_client_options(self):
+        result = build_search_params({}, client_options={"hnsw_ef_search": 512})
+        self.assertEqual(result["ef_search"], 512)
+        self.assertEqual(result["search_params"]["params"]["ef"], 512)
+
+    def test_hnsw_ef_search_override_via_params(self):
+        result = build_search_params({"hnsw_ef_search": 300})
+        self.assertEqual(result["ef_search"], 300)
+
+    def test_ivf_flat_branch(self):
+        result = build_search_params({}, client_options={"index_type": "IVF_FLAT"})
+        self.assertIn("nprobe", result["search_params"]["params"])
+        self.assertEqual(result["search_params"]["params"]["nprobe"], 128)
+
+    def test_ivf_custom_nprobe(self):
+        result = build_search_params(
+            {"nprobe": 64}, client_options={"index_type": "IVF_SQ8"}
+        )
+        self.assertEqual(result["search_params"]["params"]["nprobe"], 64)
+
+    def test_diskann_branch(self):
+        result = build_search_params({}, client_options={"index_type": "DISKANN"})
+        self.assertIn("search_list", result["search_params"]["params"])
+        self.assertEqual(result["search_params"]["params"]["search_list"], 256)
+
+    def test_unknown_index_type_empty_params(self):
+        result = build_search_params({}, client_options={"index_type": "EXOTIC"})
+        self.assertEqual(result["search_params"]["params"], {})
+
+    def test_query_k_fallback(self):
+        result = build_search_params({"query_k": 50})
+        self.assertEqual(result["k"], 50)
+
+    def test_k_takes_precedence_over_query_k(self):
+        result = build_search_params({"k": 200, "query_k": 50})
+        self.assertEqual(result["k"], 200)
+
+
+# ---------------------------------------------------------------------------
+# convert_milvus_search_response
+# ---------------------------------------------------------------------------
+class ConvertMilvusSearchResponseTests(TestCase):
+    def test_none_returns_empty(self):
+        result = convert_milvus_search_response(None)
+        self.assertEqual(result["hits"]["total"]["value"], 0)
+        self.assertEqual(result["hits"]["hits"], [])
+
+    def test_empty_list_returns_empty(self):
+        result = convert_milvus_search_response([])
+        self.assertEqual(result["hits"]["total"]["value"], 0)
+        self.assertEqual(result["hits"]["hits"], [])
+
+    def test_single_hit(self):
+        results = [[{"doc_id": 42, "distance": 0.95}]]
+        result = convert_milvus_search_response(results, "my_coll")
+        hits = result["hits"]["hits"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["_id"], "42")
+        self.assertEqual(hits[0]["_score"], 0.95)
+        self.assertEqual(hits[0]["_index"], "my_coll")
+
+    def test_multiple_hits(self):
+        results = [[
+            {"doc_id": 1, "distance": 0.9},
+            {"doc_id": 2, "distance": 0.8},
+            {"doc_id": 3, "distance": 0.7},
+        ]]
+        result = convert_milvus_search_response(results)
+        self.assertEqual(result["hits"]["total"]["value"], 3)
+        self.assertEqual(len(result["hits"]["hits"]), 3)
+
+    def test_doc_id_coerced_to_str(self):
+        results = [[{"doc_id": 12345, "distance": 0.5}]]
+        result = convert_milvus_search_response(results)
+        self.assertIsInstance(result["hits"]["hits"][0]["_id"], str)
+
+    def test_id_fallback_when_no_doc_id(self):
+        results = [[{"id": 99, "distance": 0.5}]]
+        result = convert_milvus_search_response(results)
+        self.assertEqual(result["hits"]["hits"][0]["_id"], "99")
+
+    def test_missing_id_fields_returns_empty_string(self):
+        results = [[{"distance": 0.5}]]
+        result = convert_milvus_search_response(results)
+        self.assertEqual(result["hits"]["hits"][0]["_id"], "")
+
+    def test_default_collection_name(self):
+        results = [[{"doc_id": 1, "distance": 0.5}]]
+        result = convert_milvus_search_response(results)
+        self.assertEqual(result["hits"]["hits"][0]["_index"], "default")
+
+    def test_response_structure(self):
+        results = [[{"doc_id": 1, "distance": 0.5}]]
+        result = convert_milvus_search_response(results)
+        self.assertIn("took", result)
+        self.assertIn("timed_out", result)
+        self.assertFalse(result["timed_out"])
+        self.assertEqual(result["hits"]["total"]["relation"], "eq")
+
+
+# ---------------------------------------------------------------------------
+# parse_vector_body
+# ---------------------------------------------------------------------------
+class ParseVectorBodyTests(TestCase):
+    def test_single_pair(self):
+        body = [
+            {"index": {"_index": "idx", "_id": 0}},
+            {"embedding": [1.0, 2.0, 3.0]},
+        ]
+        docs, index = parse_vector_body(body)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["doc_id"], 0)
+        self.assertEqual(docs[0]["embedding"], [1.0, 2.0, 3.0])
+        self.assertEqual(index, "idx")
+
+    def test_multiple_pairs(self):
+        body = [
+            {"index": {"_index": "idx", "_id": 0}},
+            {"embedding": [1.0]},
+            {"index": {"_index": "idx", "_id": 1}},
+            {"embedding": [2.0]},
+        ]
+        docs, index = parse_vector_body(body)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0]["doc_id"], 0)
+        self.assertEqual(docs[1]["doc_id"], 1)
+
+    def test_numpy_array_converted_to_list(self):
+        vec = np.array([1.0, 2.0, 3.0])
+        body = [
+            {"index": {"_index": "idx", "_id": 5}},
+            {"embedding": vec},
+        ]
+        docs, _ = parse_vector_body(body)
+        self.assertIsInstance(docs[0]["embedding"], list)
+        self.assertEqual(docs[0]["embedding"], [1.0, 2.0, 3.0])
+
+    def test_non_integer_id_raises(self):
+        body = [
+            {"index": {"_index": "idx", "_id": "abc"}},
+            {"embedding": [1.0]},
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            parse_vector_body(body)
+        self.assertIn("integer _id", str(ctx.exception))
+
+    def test_none_action_skipped(self):
+        body = [
+            None,
+            {"embedding": [1.0]},
+            {"index": {"_index": "idx", "_id": 0}},
+            {"embedding": [2.0]},
+        ]
+        docs, _ = parse_vector_body(body)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["doc_id"], 0)
+
+    def test_none_doc_skipped(self):
+        body = [
+            {"index": {"_index": "idx", "_id": 0}},
+            None,
+            {"index": {"_index": "idx", "_id": 1}},
+            {"embedding": [2.0]},
+        ]
+        docs, _ = parse_vector_body(body)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["doc_id"], 1)
+
+    def test_empty_body(self):
+        docs, index = parse_vector_body([])
+        self.assertEqual(docs, [])
+        self.assertIsNone(index)
+
+    def test_non_list_body(self):
+        docs, index = parse_vector_body("not a list")
+        self.assertEqual(docs, [])
+        self.assertIsNone(index)
+
+    def test_string_integer_id_accepted(self):
+        body = [
+            {"index": {"_index": "idx", "_id": "42"}},
+            {"embedding": [1.0]},
+        ]
+        docs, _ = parse_vector_body(body)
+        self.assertEqual(docs[0]["doc_id"], 42)
+
+    def test_missing_id_uses_positional_default(self):
+        body = [
+            {"index": {"_index": "idx"}},
+            {"embedding": [1.0]},
+        ]
+        docs, _ = parse_vector_body(body)
+        # _id defaults to i // 2, which is 0 for the first pair
+        self.assertEqual(docs[0]["doc_id"], 0)
+
+    def test_odd_length_body_ignores_trailing(self):
+        body = [
+            {"index": {"_index": "idx", "_id": 0}},
+            {"embedding": [1.0]},
+            {"index": {"_index": "idx", "_id": 1}},
+        ]
+        docs, _ = parse_vector_body(body)
+        self.assertEqual(len(docs), 1)
+
+
+# ---------------------------------------------------------------------------
+# calculate_topk_recall
+# ---------------------------------------------------------------------------
+class CalculateTopkRecallTests(TestCase):
+    def test_perfect_recall(self):
+        predictions = [1, 2, 3, 4, 5]
+        neighbors = [1, 2, 3, 4, 5]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 5), 1.0)
+
+    def test_zero_recall(self):
+        predictions = [10, 20, 30]
+        neighbors = [1, 2, 3]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 3), 0.0)
+
+    def test_partial_recall(self):
+        predictions = [1, 2, 99]
+        neighbors = [1, 2, 3]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 3), 2.0 / 3.0)
+
+    def test_none_neighbors_returns_zero(self):
+        self.assertAlmostEqual(calculate_topk_recall([1, 2, 3], None, 3), 0.0)
+
+    def test_str_coercion(self):
+        # Predictions as strings, neighbors as ints
+        predictions = ["1", "2", "3"]
+        neighbors = [1, 2, 3]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 3), 1.0)
+
+    def test_int_vs_numpy_int(self):
+        predictions = [np.int64(1), np.int64(2)]
+        neighbors = [1, 2]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 2), 1.0)
+
+    def test_minus_one_sentinels_excluded(self):
+        # -1 sentinels in neighbors should be excluded from truth set
+        predictions = [1, 2]
+        neighbors = [1, 2, -1, -1]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 4), 1.0)
+
+    def test_all_minus_one_neighbors_returns_one(self):
+        predictions = [1, 2, 3]
+        neighbors = [-1, -1, -1]
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 3), 1.0)
+
+    def test_topk_smaller_than_lists(self):
+        predictions = [1, 2, 3, 4, 5]
+        neighbors = [1, 2, 3, 4, 5]
+        # Only top-2 should be considered
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 2), 1.0)
+
+    def test_topk_larger_than_neighbors(self):
+        predictions = [1, 2, 3, 4, 5]
+        neighbors = [1, 2]
+        # min_results = min(5, 2) = 2; truth = {1, 2}; correct = 2
+        self.assertAlmostEqual(calculate_topk_recall(predictions, neighbors, 5), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/database/clients/milvus/milvus_test.py
+++ b/tests/database/clients/milvus/milvus_test.py
@@ -1,0 +1,613 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""
+Unit tests for osbenchmark.database.clients.milvus.milvus
+
+Tests MilvusClientFactory, MilvusDatabaseClient, and all namespace classes
+(MilvusIndicesNamespace, MilvusClusterNamespace, MilvusTransportNamespace,
+MilvusNodesNamespace).
+"""
+# pylint: disable=protected-access
+
+import asyncio
+from unittest import TestCase, mock
+
+from osbenchmark import exceptions
+from osbenchmark.database.clients.milvus.milvus import (
+    MilvusClientFactory,
+    MilvusDatabaseClient,
+    MilvusIndicesNamespace,
+    MilvusClusterNamespace,
+    MilvusTransportNamespace,
+    MilvusNodesNamespace,
+)
+from tests import run_async
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_client(host="localhost", port=19530, **opts):
+    """Create a MilvusDatabaseClient with a pre-injected MagicMock _client.
+
+    Bypasses _ensure_client() so tests never need pymilvus installed.
+    """
+    client = MilvusDatabaseClient(host=host, port=port, **opts)
+    client._client = mock.MagicMock()
+    client._client_initialized = True
+    return client
+
+
+async def _mock_run(fn, *args, **kwargs):
+    """Replace _run() to call the function directly (no executor)."""
+    return fn(*args, **kwargs)
+
+
+# =============================================================================
+# MilvusClientFactory Tests
+# =============================================================================
+
+class MilvusClientFactoryTests(TestCase):
+
+    def test_create_from_host_list(self):
+        factory = MilvusClientFactory(
+            hosts=[{"host": "myhost", "port": 19530}],
+            client_options={},
+        )
+        client = factory.create_async()
+        self.assertEqual("myhost", client.host)
+        self.assertEqual(19530, client.port)
+        self.assertEqual("http://myhost:19530", client.uri)
+
+    def test_create_from_hosts_with_default_key(self):
+        factory = MilvusClientFactory(
+            hosts={"default": [{"host": "myhost", "port": 9999}]},
+            client_options={},
+        )
+        client = factory.create_async()
+        self.assertEqual("myhost", client.host)
+        self.assertEqual(9999, client.port)
+
+    def test_empty_hosts_raises_error(self):
+        factory = MilvusClientFactory(hosts=[], client_options={})
+        with self.assertRaises(exceptions.SystemSetupError):
+            factory.create_async()
+
+    def test_create_delegates_to_create_async(self):
+        factory = MilvusClientFactory(
+            hosts=[{"host": "h", "port": 19530}],
+            client_options={},
+        )
+        sync_client = factory.create()
+        async_client = factory.create_async()
+        self.assertEqual(sync_client.uri, async_client.uri)
+
+    @mock.patch("requests.get")
+    def test_wait_for_rest_layer_success(self, mock_get):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        mock_get.return_value = resp
+
+        factory = MilvusClientFactory(
+            hosts=[{"host": "h", "health_port": 9091}],
+            client_options={},
+        )
+        result = factory.wait_for_rest_layer(max_attempts=1)
+        self.assertTrue(result)
+        mock_get.assert_called_once_with("http://h:9091/healthz", timeout=5)
+
+
+# =============================================================================
+# MilvusDatabaseClient Init Tests
+# =============================================================================
+
+class MilvusDatabaseClientInitTests(TestCase):
+
+    def test_init_stores_host_port_uri(self):
+        client = MilvusDatabaseClient(host="myhost", port=19530)
+        self.assertEqual("myhost", client.host)
+        self.assertEqual(19530, client.port)
+        self.assertEqual("http://myhost:19530", client.uri)
+
+    def test_init_defaults(self):
+        client = MilvusDatabaseClient()
+        self.assertEqual("localhost", client.host)
+        self.assertEqual(19530, client.port)
+        self.assertEqual("target_index", client._collection_name)
+
+    def test_init_custom_timeouts(self):
+        client = MilvusDatabaseClient(
+            timeout_insert=120, timeout_search=60, timeout_admin=600,
+        )
+        self.assertEqual(120, client._timeout_insert)
+        self.assertEqual(60, client._timeout_search)
+        self.assertEqual(600, client._timeout_admin)
+
+    def test_collection_name_from_collection_name_option(self):
+        client = MilvusDatabaseClient(collection_name="my_coll")
+        self.assertEqual("my_coll", client._collection_name)
+
+    def test_collection_name_falls_back_to_app_name(self):
+        client = MilvusDatabaseClient(app_name="my_app")
+        self.assertEqual("my_app", client._collection_name)
+
+    def test_init_creates_namespace_objects(self):
+        client = MilvusDatabaseClient()
+        self.assertIsInstance(client.indices, MilvusIndicesNamespace)
+        self.assertIsInstance(client.cluster, MilvusClusterNamespace)
+        self.assertIsInstance(client.transport, MilvusTransportNamespace)
+        self.assertIsInstance(client.nodes, MilvusNodesNamespace)
+
+
+# =============================================================================
+# Bulk / Insert Tests
+# =============================================================================
+
+class MilvusBulkTests(TestCase):
+
+    @run_async
+    async def test_bulk_success(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.insert.return_value = {"insert_count": 3}
+
+        result = await client.bulk(body=[{"a": 1}, {"a": 2}, {"a": 3}], index="coll")
+        self.assertFalse(result["errors"])
+        self.assertEqual(3, len(result["items"]))
+        client._client.insert.assert_called_once()
+
+    @run_async
+    async def test_bulk_partial_failure(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.insert.return_value = {"insert_count": 1}
+
+        result = await client.bulk(body=[{"a": 1}, {"a": 2}], index="coll")
+        self.assertTrue(result["errors"])
+        self.assertEqual(1, len(result["items"]))
+
+    @run_async
+    async def test_bulk_exception_returns_error_items(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.insert.side_effect = RuntimeError("network error")
+
+        result = await client.bulk(body=[{"a": 1}], index="coll")
+        self.assertTrue(result["errors"])
+        self.assertEqual(500, result["items"][0]["index"]["status"])
+        self.assertIn("network error", result["items"][0]["index"]["error"])
+
+    @run_async
+    async def test_bulk_single_dict_wrapped_in_list(self):
+        """A single dict body is auto-wrapped into [body]."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.insert.return_value = {"insert_count": 1}
+
+        result = await client.bulk(body={"a": 1}, index="coll")
+        self.assertFalse(result["errors"])
+        # Verify insert received a list
+        call_kwargs = client._client.insert.call_args[1]
+        self.assertIsInstance(call_kwargs["data"], list)
+
+    @run_async
+    async def test_bulk_retries_transient_error(self):
+        """Transient gRPC errors trigger retry via _run_with_retry."""
+        client = _make_client()
+
+        call_count = 0
+        original_insert = None
+
+        def flaky_insert(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("unavailable: server not ready")
+            return {"insert_count": 2}
+
+        client._client.insert.side_effect = flaky_insert
+
+        # Patch _run to call directly, and asyncio.sleep to not actually sleep
+        async def mock_run(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        client._run = mock_run
+
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            result = await client.bulk(body=[{"a": 1}, {"a": 2}], index="coll")
+
+        self.assertFalse(result["errors"])
+        self.assertEqual(2, call_count)
+
+    @run_async
+    async def test_bulk_no_retry_on_non_transient_error(self):
+        """Non-transient errors are NOT retried."""
+        client = _make_client()
+
+        call_count = 0
+
+        def bad_insert(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("schema mismatch: field not found")
+
+        client._client.insert.side_effect = bad_insert
+
+        async def mock_run(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        client._run = mock_run
+
+        # _run_with_retry should NOT retry non-transient errors,
+        # but the exception is caught by bulk() itself which returns error items
+        result = await client.bulk(body=[{"a": 1}], index="coll")
+        self.assertTrue(result["errors"])
+        # Should only have been called once (no retry for non-transient)
+        self.assertEqual(1, call_count)
+
+
+# =============================================================================
+# Search Tests
+# =============================================================================
+
+class MilvusSearchTests(TestCase):
+
+    @run_async
+    async def test_search_success_passthrough(self):
+        client = _make_client()
+        client._run = _mock_run
+        expected = [{"id": 1, "distance": 0.5}]
+        client._client.search.return_value = expected
+
+        result = await client.search(
+            index="coll",
+            body={"data": [[0.1, 0.2]], "limit": 10},
+        )
+        self.assertEqual(expected, result)
+        call_kwargs = client._client.search.call_args[1]
+        self.assertEqual("coll", call_kwargs["collection_name"])
+
+    @run_async
+    async def test_search_no_retry(self):
+        """Search should NOT retry — it inflates reported latency."""
+        client = _make_client()
+
+        call_count = 0
+
+        def fail_search(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("unavailable: server not ready")
+
+        client._client.search.side_effect = fail_search
+        client._run = _mock_run
+
+        with self.assertRaises(RuntimeError):
+            await client.search(index="coll", body={"data": [[0.1]]})
+        # Only called once, no retry
+        self.assertEqual(1, call_count)
+
+    @run_async
+    async def test_search_timeout_propagation(self):
+        client = _make_client(timeout_search=42)
+        client._run = _mock_run
+        client._client.search.return_value = []
+
+        await client.search(index="coll", body={"data": [[0.1]]})
+        call_kwargs = client._client.search.call_args[1]
+        self.assertEqual(42, call_kwargs["timeout"])
+
+    @run_async
+    async def test_search_uses_collection_name_fallback(self):
+        client = _make_client(collection_name="fallback_coll")
+        client._run = _mock_run
+        client._client.search.return_value = []
+
+        await client.search(body={"data": [[0.1]]})
+        call_kwargs = client._client.search.call_args[1]
+        self.assertEqual("fallback_coll", call_kwargs["collection_name"])
+
+
+# =============================================================================
+# Info Tests
+# =============================================================================
+
+class MilvusInfoTests(TestCase):
+
+    @mock.patch("requests.get")
+    def test_info_uses_http_not_pymilvus(self, mock_get):
+        """info() uses HTTP to avoid loading pymilvus in the coordinator process."""
+        rest_resp = mock.MagicMock()
+        rest_resp.status_code = 200
+
+        health_resp = mock.MagicMock()
+        health_resp.status_code = 200
+        health_resp.json.return_value = {"version": "2.5.1"}
+
+        mock_get.side_effect = [rest_resp, health_resp]
+
+        client = MilvusDatabaseClient(host="myhost", port=19530)
+        result = client.info()
+
+        self.assertEqual("milvus", result["name"])
+        self.assertEqual("2.5.1", result["version"]["number"])
+        self.assertEqual("milvus", result["version"]["distribution"])
+        # Should have called the REST endpoint, not pymilvus
+        self.assertEqual(2, mock_get.call_count)
+
+    @mock.patch("requests.get")
+    def test_info_fallback_on_error(self, mock_get):
+        mock_get.side_effect = ConnectionError("refused")
+
+        client = MilvusDatabaseClient(host="myhost")
+        result = client.info()
+
+        self.assertEqual("milvus", result["name"])
+        self.assertEqual("unknown", result["version"]["number"])
+
+    @mock.patch("requests.get")
+    def test_info_health_port_fallback(self, mock_get):
+        """When REST succeeds but health check fails, version falls back to '2.x'."""
+        rest_resp = mock.MagicMock()
+        rest_resp.status_code = 200
+
+        mock_get.side_effect = [rest_resp, ConnectionError("health check failed")]
+
+        client = MilvusDatabaseClient(host="myhost")
+        result = client.info()
+
+        self.assertEqual("2.x", result["version"]["number"])
+
+
+# =============================================================================
+# Indices Namespace Tests
+# =============================================================================
+
+class MilvusIndicesNamespaceTests(TestCase):
+
+    @run_async
+    async def test_create_with_schema_and_index_params(self):
+        client = _make_client()
+        client._run = _mock_run
+
+        schema = mock.MagicMock()
+        index_params = mock.MagicMock()
+        client._client.has_collection.return_value = False
+
+        result = await client.indices.create(
+            index="my_coll",
+            body={"schema": schema, "index_params": index_params},
+        )
+        self.assertTrue(result["acknowledged"])
+        self.assertEqual("my_coll", result["index"])
+        client._client.create_collection.assert_called_once_with(
+            collection_name="my_coll", schema=schema, index_params=index_params,
+        )
+
+    @run_async
+    async def test_create_drops_existing_and_waits(self):
+        """When collection already exists, drop it and wait for disappearance."""
+        client = _make_client()
+        client._run = _mock_run
+
+        schema = mock.MagicMock()
+        index_params = mock.MagicMock()
+        # Simulate: exists -> drop -> still exists once -> then gone
+        client._client.has_collection.side_effect = [True, True, False]
+
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            result = await client.indices.create(
+                index="my_coll",
+                body={"schema": schema, "index_params": index_params},
+            )
+
+        self.assertTrue(result["acknowledged"])
+        client._client.drop_collection.assert_called_once_with(collection_name="my_coll")
+        client._client.create_collection.assert_called_once()
+
+    @run_async
+    async def test_create_without_schema_skips_create(self):
+        """If no schema/index_params, just return acknowledged without creating."""
+        client = _make_client()
+        client._run = _mock_run
+
+        result = await client.indices.create(index="my_coll", body={})
+        self.assertTrue(result["acknowledged"])
+        client._client.create_collection.assert_not_called()
+
+    @run_async
+    async def test_delete(self):
+        client = _make_client()
+        client._run = _mock_run
+
+        result = await client.indices.delete(index="my_coll")
+        self.assertTrue(result["acknowledged"])
+        client._client.drop_collection.assert_called_once_with(collection_name="my_coll")
+
+    @run_async
+    async def test_exists_true(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.has_collection.return_value = True
+
+        result = await client.indices.exists(index="my_coll")
+        self.assertTrue(result)
+
+    @run_async
+    async def test_exists_false(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.has_collection.return_value = False
+
+        result = await client.indices.exists(index="my_coll")
+        self.assertFalse(result)
+
+    @run_async
+    async def test_refresh_no_index_returns_acknowledged(self):
+        """refresh(None) is a no-op shortcut."""
+        client = _make_client()
+        client._run = _mock_run
+
+        result = await client.indices.refresh(index=None)
+        self.assertTrue(result["acknowledged"])
+
+    @run_async
+    async def test_forcemerge_calls_compact(self):
+        """forcemerge maps to Milvus compact()."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.compact.return_value = 12345
+        client._client.get_compaction_state.return_value = "Completed"
+
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            result = await client.indices.forcemerge(index="my_coll")
+
+        self.assertEqual(1, result["_shards"]["successful"])
+        client._client.compact.assert_called_once_with(
+            collection_name="my_coll", timeout=client._timeout_admin,
+        )
+
+    @run_async
+    async def test_forcemerge_string_completed_check(self):
+        """get_compaction_state returns the string 'Completed', not a bool."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.compact.return_value = 42
+        # First call: "Executing", second: "Completed"
+        client._client.get_compaction_state.side_effect = ["Executing", "Completed"]
+
+        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+            result = await client.indices.forcemerge(index="my_coll")
+
+        self.assertEqual(1, result["_shards"]["successful"])
+        self.assertEqual(2, client._client.get_compaction_state.call_count)
+
+    @run_async
+    async def test_stats_returns_row_count(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.get_collection_stats.return_value = {"row_count": 1000}
+
+        result = await client.indices.stats(index="my_coll")
+        self.assertEqual(1000, result["_all"]["primaries"]["docs"]["count"])
+        self.assertEqual(1000, result["_all"]["total"]["docs"]["count"])
+
+    @run_async
+    async def test_stats_no_index_returns_empty(self):
+        client = _make_client()
+        client._run = _mock_run
+
+        result = await client.indices.stats(index=None)
+        self.assertEqual({}, result["_all"]["primaries"])
+
+
+# =============================================================================
+# Cluster Health Tests
+# =============================================================================
+
+class MilvusClusterHealthTests(TestCase):
+
+    @run_async
+    async def test_health_green_on_success(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.list_collections.return_value = ["coll1"]
+
+        result = await client.cluster.health()
+        self.assertEqual("green", result["status"])
+        self.assertFalse(result["timed_out"])
+
+    @run_async
+    async def test_health_red_on_failure(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.list_collections.side_effect = RuntimeError("connection refused")
+
+        result = await client.cluster.health()
+        self.assertEqual("red", result["status"])
+
+    @run_async
+    async def test_put_settings_acknowledged(self):
+        client = _make_client()
+        result = await client.cluster.put_settings(body={})
+        self.assertTrue(result["acknowledged"])
+
+
+# =============================================================================
+# Transport Close Tests
+# =============================================================================
+
+class MilvusTransportCloseTests(TestCase):
+
+    @run_async
+    async def test_close_is_noop(self):
+        """Transport.close() is intentionally a no-op to avoid killing gRPC channels."""
+        client = _make_client()
+        # Should not raise and should not close the pymilvus client
+        await client.transport.close()
+        # _client should still be set (not torn down)
+        self.assertIsNotNone(client._client)
+
+    @run_async
+    async def test_perform_request_returns_empty_dict(self):
+        client = _make_client()
+        result = await client.transport.perform_request("GET", "/")
+        self.assertEqual({}, result)
+
+
+# =============================================================================
+# Load Collection Tests
+# =============================================================================
+
+class MilvusLoadCollectionTests(TestCase):
+
+    @run_async
+    async def test_load_collection_success(self):
+        client = _make_client()
+        client._run = _mock_run
+        client._client.load_collection.return_value = None
+
+        # Should not raise
+        await client.load_collection("my_coll")
+        client._client.load_collection.assert_called_once_with(
+            collection_name="my_coll", timeout=client._timeout_admin,
+        )
+
+    @run_async
+    async def test_load_collection_already_loaded(self):
+        """'already loaded' exceptions are swallowed gracefully."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.load_collection.side_effect = RuntimeError(
+            "collection already loaded"
+        )
+
+        # Should not raise
+        await client.load_collection("my_coll")
+
+    @run_async
+    async def test_load_collection_load_state_loaded(self):
+        """'load state: loaded' exceptions are also swallowed."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.load_collection.side_effect = RuntimeError(
+            "load state: loaded"
+        )
+
+        # Should not raise
+        await client.load_collection("my_coll")
+
+    @run_async
+    async def test_load_collection_real_error_propagates(self):
+        """Non-already-loaded errors should propagate."""
+        client = _make_client()
+        client._run = _mock_run
+        client._client.load_collection.side_effect = RuntimeError("out of memory")
+
+        with self.assertRaises(RuntimeError):
+            await client.load_collection("my_coll")

--- a/tests/database/clients/milvus/milvus_test.py
+++ b/tests/database/clients/milvus/milvus_test.py
@@ -13,7 +13,6 @@ MilvusNodesNamespace).
 """
 # pylint: disable=protected-access
 
-import asyncio
 from unittest import TestCase, mock
 
 from osbenchmark import exceptions
@@ -201,7 +200,6 @@ class MilvusBulkTests(TestCase):
         client = _make_client()
 
         call_count = 0
-        original_insert = None
 
         def flaky_insert(**kwargs):
             nonlocal call_count

--- a/tests/worker_coordinator/milvus_runner_test.py
+++ b/tests/worker_coordinator/milvus_runner_test.py
@@ -548,7 +548,7 @@ class MilvusQueryTests(TestCase):
         }
 
         runner = MilvusQuery()
-        result = await runner(milvus_client, params)
+        await runner(milvus_client, params)
 
         call_kwargs = milvus_client.search.call_args[1]
         self.assertEqual(call_kwargs["body"]["limit"], 50)

--- a/tests/worker_coordinator/milvus_runner_test.py
+++ b/tests/worker_coordinator/milvus_runner_test.py
@@ -1,0 +1,1053 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=protected-access
+
+import unittest.mock as mock
+from unittest import TestCase
+
+from osbenchmark.worker_coordinator.runners.milvus import (
+    MilvusBulkVectorDataSet,
+    MilvusBulkIndex,
+    MilvusVectorSearch,
+    MilvusQuery,
+    MilvusCreateIndex,
+    MilvusDeleteIndex,
+    MilvusRefresh,
+    MilvusForceMerge,
+    MilvusClusterHealth,
+    MilvusIndicesStats,
+    MilvusWarmupRunner,
+    MilvusNoOp,
+    register_milvus_runners,
+)
+from tests import run_async
+
+
+def _make_milvus_client(**overrides):
+    """Create a standard mock milvus_client with common attributes."""
+    client = mock.AsyncMock()
+    client._collection_name = overrides.get("collection_name", "target_index")
+    client.client_options = overrides.get("client_options", {})
+    return client
+
+
+def _milvus_search_response(hits=None):
+    """Build a raw Milvus search response (List[List[Hit-like dicts]])."""
+    if hits is None:
+        hits = [{"doc_id": 1, "distance": 0.95}]
+    return [hits]
+
+
+def _converted_response(total_value=1, hits_list=None):
+    """Build a converted OpenSearch-style response (output of convert_milvus_search_response)."""
+    if hits_list is None:
+        hits_list = [{"_index": "target_index", "_id": "1", "_score": 0.95}]
+    return {
+        "took": 0,
+        "timed_out": False,
+        "hits": {
+            "total": {"value": total_value, "relation": "eq"},
+            "hits": hits_list,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# MilvusBulkVectorDataSet
+# ---------------------------------------------------------------------------
+class MilvusBulkVectorDataSetTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.parse_vector_body")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_success_with_parse_vector_body(self, mock_ctx, mock_parse):
+        milvus_client = _make_milvus_client()
+        mock_parse.return_value = (
+            [{"doc_id": 0, "embedding": [1.0, 2.0]}, {"doc_id": 1, "embedding": [3.0, 4.0]}],
+            "vectors",
+        )
+        milvus_client.bulk.return_value = {"items": [{"_id": 0}, {"_id": 1}], "errors": False}
+
+        body = [
+            {"index": {"_index": "vectors", "_id": 0}},
+            {"embedding": [1.0, 2.0]},
+            {"index": {"_index": "vectors", "_id": 1}},
+            {"embedding": [3.0, 4.0]},
+        ]
+        params = {"body": body, "size": 2}
+
+        runner = MilvusBulkVectorDataSet()
+        result = await runner(milvus_client, params)
+
+        self.assertEqual(result["weight"], 2)
+        self.assertEqual(result["unit"], "docs")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["error-count"], 0)
+        milvus_client.bulk.assert_called_once()
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+        mock_ctx.on_client_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.parse_vector_body")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_empty_body_returns_early(self, mock_ctx, mock_parse):
+        milvus_client = _make_milvus_client()
+        mock_parse.return_value = ([], None)
+
+        params = {"body": [], "size": 0}
+
+        runner = MilvusBulkVectorDataSet()
+        result = await runner(milvus_client, params)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 0)
+        milvus_client.bulk.assert_not_called()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.parse_vector_body")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_errors_in_bulk_response(self, mock_ctx, mock_parse):
+        milvus_client = _make_milvus_client()
+        mock_parse.return_value = (
+            [{"doc_id": 0, "embedding": [1.0]}, {"doc_id": 1, "embedding": [2.0]}],
+            "vectors",
+        )
+        # Only 1 item returned but 2 sent => error_count=1, and errors=True
+        milvus_client.bulk.return_value = {"items": [{"_id": 0}], "errors": True}
+
+        params = {"body": [], "size": 2}
+
+        runner = MilvusBulkVectorDataSet()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-count"], 1)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.parse_vector_body")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx, mock_parse):
+        milvus_client = _make_milvus_client()
+        mock_parse.return_value = (
+            [{"doc_id": 0, "embedding": [1.0]}],
+            "vectors",
+        )
+        milvus_client.bulk.side_effect = ConnectionError("connection lost")
+
+        params = {"body": [], "size": 1}
+
+        runner = MilvusBulkVectorDataSet()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        self.assertIn("connection lost", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+        mock_ctx.on_client_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.parse_vector_body")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_result_dict_format(self, mock_ctx, mock_parse):
+        milvus_client = _make_milvus_client()
+        mock_parse.return_value = (
+            [{"doc_id": 0, "embedding": [1.0]}],
+            "vectors",
+        )
+        milvus_client.bulk.return_value = {"items": [{"_id": 0}], "errors": False}
+
+        params = {"body": [], "size": 5}
+
+        runner = MilvusBulkVectorDataSet()
+        result = await runner(milvus_client, params)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("weight", result)
+        self.assertIn("unit", result)
+        self.assertIn("success", result)
+        self.assertIn("error-count", result)
+
+    def test_repr(self):
+        runner = MilvusBulkVectorDataSet()
+        self.assertEqual(repr(runner), "milvus-bulk-vector-data-set")
+
+
+# ---------------------------------------------------------------------------
+# MilvusBulkIndex
+# ---------------------------------------------------------------------------
+class MilvusBulkIndexTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_bulk_index_success(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.bulk.return_value = {"errors": False}
+
+        params = {"body": [{"doc_id": 1}], "bulk-size": 10, "unit": "docs", "index": "myindex"}
+
+        runner = MilvusBulkIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 10)
+        self.assertEqual(result["unit"], "docs")
+        milvus_client.bulk.assert_called_once_with(
+            body=[{"doc_id": 1}], index="myindex"
+        )
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_bulk_index_errors_flag(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.bulk.return_value = {"errors": True}
+
+        params = {"body": [], "bulk-size": 5, "index": "myindex"}
+
+        runner = MilvusBulkIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_bulk_index_exception(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.bulk.side_effect = RuntimeError("grpc error")
+
+        params = {"body": [], "bulk-size": 1, "index": "myindex"}
+
+        runner = MilvusBulkIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        self.assertIn("grpc error", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusBulkIndex()
+        self.assertEqual(repr(runner), "milvus-bulk-index")
+
+
+# ---------------------------------------------------------------------------
+# MilvusVectorSearch
+# ---------------------------------------------------------------------------
+class MilvusVectorSearchTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_nested_knn_extraction(self, mock_ctx, mock_build, mock_convert):
+        """KNN nested under body.query.knn with field_name -> {vector, k}."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=5, hits_list=[
+            {"_id": "1", "_score": 0.9}, {"_id": "2", "_score": 0.8},
+            {"_id": "3", "_score": 0.7}, {"_id": "4", "_score": 0.6},
+            {"_id": "5", "_score": 0.5},
+        ])
+
+        params = {
+            "body": {"query": {"knn": {"embedding": {"vector": [1.0, 2.0, 3.0], "k": 5}}}},
+            "index": "myindex",
+            "k": 100,
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["hits"], 5)
+        # Verify search body was built with correct field name and vector
+        call_kwargs = milvus_client.search.call_args[1]
+        self.assertEqual(call_kwargs["body"]["anns_field"], "embedding")
+        self.assertEqual(call_kwargs["body"]["data"], [[1.0, 2.0, 3.0]])
+        # k=5 from knn config should override the params k=100
+        self.assertEqual(call_kwargs["body"]["limit"], 5)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_flat_knn_extraction(self, mock_ctx, mock_build, mock_convert):
+        """KNN at body.knn with flat vector/field keys."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=2)
+
+        params = {
+            "body": {"knn": {"vector": [1.0, 2.0], "field": "my_vec"}},
+            "index": "myindex",
+            "k": 10,
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertTrue(result["success"])
+        call_kwargs = milvus_client.search.call_args[1]
+        self.assertEqual(call_kwargs["body"]["anns_field"], "my_vec")
+        self.assertEqual(call_kwargs["body"]["data"], [[1.0, 2.0]])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_no_vector_returns_failure(self, mock_ctx, mock_build):
+        """Missing vector in body returns failure immediately without searching."""
+        milvus_client = _make_milvus_client()
+
+        params = {"body": {"query": {"match_all": {}}}, "index": "myindex"}
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["hits"], 0)
+        milvus_client.search.assert_not_called()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_numpy_tolist_conversion(self, mock_ctx, mock_build, mock_convert):
+        """Numpy arrays are converted via .tolist() before sending to Milvus."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=1)
+
+        # Simulate numpy array with tolist method
+        numpy_like = mock.MagicMock()
+        numpy_like.tolist.return_value = [1.0, 2.0, 3.0]
+
+        params = {
+            "body": {"knn": {"vector": numpy_like, "field": "embedding"}},
+            "index": "myindex",
+            "k": 10,
+        }
+
+        runner = MilvusVectorSearch()
+        await runner(milvus_client, params)
+
+        numpy_like.tolist.assert_called_once()
+        call_kwargs = milvus_client.search.call_args[1]
+        self.assertEqual(call_kwargs["body"]["data"], [[1.0, 2.0, 3.0]])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.calculate_topk_recall")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_recall_calculation(self, mock_ctx, mock_build, mock_convert, mock_recall):
+        """Recall is calculated when neighbors and k are provided."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(
+            total_value=3,
+            hits_list=[
+                {"_id": "0", "_score": 1.0},
+                {"_id": "1", "_score": 0.9},
+                {"_id": "5", "_score": 0.8},
+            ],
+        )
+        # recall@k=2/3, recall@1=1.0
+        mock_recall.side_effect = [2.0 / 3.0, 1.0]
+
+        params = {
+            "body": {"knn": {"embedding": {"vector": [1.0, 2.0], "k": 3}}},
+            "index": "myindex",
+            "k": 3,
+            "neighbors": ["0", "1", "2"],
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertAlmostEqual(result["recall@k"], 2.0 / 3.0, places=5)
+        self.assertAlmostEqual(result["recall@1"], 1.0, places=5)
+        self.assertEqual(mock_recall.call_count, 2)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_recall_not_calculated_without_neighbors(self, mock_ctx, mock_build, mock_convert):
+        """Recall keys absent when neighbors param is missing."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=1)
+
+        params = {
+            "body": {"knn": {"embedding": {"vector": [1.0], "k": 10}}},
+            "index": "myindex",
+            "k": 10,
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertNotIn("recall@k", result)
+        self.assertNotIn("recall@1", result)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx, mock_build):
+        """Search exceptions are caught and return success=False."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        milvus_client.search.side_effect = RuntimeError("grpc timeout")
+
+        params = {
+            "body": {"knn": {"embedding": {"vector": [1.0], "k": 5}}},
+            "index": "myindex",
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        self.assertIn("grpc timeout", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_detailed_results(self, mock_ctx, mock_build, mock_convert):
+        """detailed-results flag adds hits_total and took to result."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=42)
+
+        params = {
+            "body": {"knn": {"embedding": {"vector": [1.0], "k": 10}}},
+            "index": "myindex",
+            "detailed-results": True,
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertEqual(result["hits_total"], 42)
+        self.assertIn("took", result)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_no_detailed_results_by_default(self, mock_ctx, mock_build, mock_convert):
+        """Without detailed-results, extra keys are absent."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=10)
+
+        params = {
+            "body": {"knn": {"embedding": {"vector": [1.0], "k": 10}}},
+            "index": "myindex",
+        }
+
+        runner = MilvusVectorSearch()
+        result = await runner(milvus_client, params)
+
+        self.assertNotIn("hits_total", result)
+
+    def test_extract_doc_id_returns_string(self):
+        self.assertEqual(MilvusVectorSearch._extract_doc_id(123), "123")
+        self.assertEqual(MilvusVectorSearch._extract_doc_id("abc"), "abc")
+        self.assertEqual(MilvusVectorSearch._extract_doc_id(0), "0")
+
+    def test_repr(self):
+        runner = MilvusVectorSearch()
+        self.assertEqual(repr(runner), "milvus-vector-search")
+
+
+# ---------------------------------------------------------------------------
+# MilvusQuery
+# ---------------------------------------------------------------------------
+class MilvusQueryTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_knn_extraction(self, mock_ctx, mock_build, mock_convert):
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=3)
+
+        params = {
+            "body": {"query": {"knn": {"embedding": {"vector": [1.0, 2.0], "k": 5}}}},
+            "index": "myindex",
+        }
+
+        runner = MilvusQuery()
+        result = await runner(milvus_client, params)
+
+        self.assertEqual(result["hits"], 3)
+        call_kwargs = milvus_client.search.call_args[1]
+        self.assertEqual(call_kwargs["body"]["anns_field"], "embedding")
+        self.assertEqual(call_kwargs["body"]["data"], [[1.0, 2.0]])
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_no_vector_returns_success_with_zero_hits(self, mock_ctx):
+        """MilvusQuery returns success=True with 0 hits when no vector is found."""
+        milvus_client = _make_milvus_client()
+
+        params = {"body": {"query": {"match_all": {}}}, "index": "myindex"}
+
+        runner = MilvusQuery()
+        result = await runner(milvus_client, params)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["hits"], 0)
+        milvus_client.search.assert_not_called()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.convert_milvus_search_response")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_k_from_body_size(self, mock_ctx, mock_build, mock_convert):
+        """k falls back to body.size when not in params."""
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        mock_convert.return_value = _converted_response(total_value=1)
+
+        params = {
+            "body": {"knn": {"vector": [1.0], "field": "embedding"}, "size": 50},
+            "index": "myindex",
+        }
+
+        runner = MilvusQuery()
+        result = await runner(milvus_client, params)
+
+        call_kwargs = milvus_client.search.call_args[1]
+        self.assertEqual(call_kwargs["body"]["limit"], 50)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx, mock_build):
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+        milvus_client.search.side_effect = RuntimeError("timeout")
+
+        params = {
+            "body": {"knn": {"vector": [1.0], "field": "embedding"}},
+            "index": "myindex",
+        }
+
+        runner = MilvusQuery()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusQuery()
+        self.assertEqual(repr(runner), "milvus-query")
+
+
+# ---------------------------------------------------------------------------
+# MilvusCreateIndex
+# ---------------------------------------------------------------------------
+class MilvusCreateIndexTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_collection_schema")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_create_from_indices_list(self, mock_ctx, mock_schema):
+        milvus_client = _make_milvus_client()
+        mock_schema.return_value = (mock.Mock(), mock.Mock(), "target_index")
+
+        indices = [("index1", {"mappings": {}}), ("index2", {"mappings": {}})]
+        params = {"indices": indices}
+
+        runner = MilvusCreateIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertEqual(milvus_client.indices.create.call_count, 2)
+        self.assertEqual(result["weight"], 2)
+        self.assertEqual(result["unit"], "ops")
+        self.assertTrue(result["success"])
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_collection_schema")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_create_from_single_index(self, mock_ctx, mock_schema):
+        milvus_client = _make_milvus_client()
+        mock_schema.return_value = (mock.Mock(), mock.Mock(), "target_index")
+
+        params = {"index": "myindex", "body": {"mappings": {}}}
+
+        runner = MilvusCreateIndex()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.create.assert_called_once()
+        call_kwargs = milvus_client.indices.create.call_args[1]
+        self.assertEqual(call_kwargs["index"], "myindex")
+        self.assertEqual(result["weight"], 1)
+        self.assertTrue(result["success"])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_collection_schema")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_schema_built_before_timing(self, mock_ctx, mock_schema):
+        """build_collection_schema is called before on_request_start."""
+        call_order = []
+        mock_schema.side_effect = lambda *a, **kw: (
+            call_order.append("schema"),
+            (mock.Mock(), mock.Mock(), "target_index"),
+        )[1]
+        mock_ctx.on_request_start.side_effect = lambda: call_order.append("timing_start")
+
+        milvus_client = _make_milvus_client()
+        params = {"indices": [("idx1", {})]}
+
+        runner = MilvusCreateIndex()
+        await runner(milvus_client, params)
+
+        self.assertEqual(call_order.index("schema"), 0)
+        self.assertGreater(call_order.index("timing_start"), call_order.index("schema"))
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_collection_schema")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_create_exception_returns_failure(self, mock_ctx, mock_schema):
+        milvus_client = _make_milvus_client()
+        mock_schema.return_value = (mock.Mock(), mock.Mock(), "target_index")
+        milvus_client.indices.create.side_effect = RuntimeError("already exists")
+
+        params = {"indices": [("idx1", {})]}
+
+        runner = MilvusCreateIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusCreateIndex()
+        self.assertEqual(repr(runner), "milvus-create-index")
+
+
+# ---------------------------------------------------------------------------
+# MilvusDeleteIndex
+# ---------------------------------------------------------------------------
+class MilvusDeleteIndexTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_delete_from_list(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+
+        params = {"indices": ["index1", "index2"]}
+
+        runner = MilvusDeleteIndex()
+        result = await runner(milvus_client, params)
+
+        self.assertEqual(milvus_client.indices.delete.call_count, 2)
+        self.assertEqual(result["weight"], 2)
+        self.assertTrue(result["success"])
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_delete_single(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+
+        params = {"index": "myindex"}
+
+        runner = MilvusDeleteIndex()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.delete.assert_called_once_with(index="myindex")
+        self.assertEqual(result["weight"], 1)
+        self.assertTrue(result["success"])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_only_if_exists_true_and_exists(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.indices.exists.return_value = True
+
+        params = {"indices": ["index1"], "only-if-exists": True}
+
+        runner = MilvusDeleteIndex()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.exists.assert_called_once_with(index="index1")
+        milvus_client.indices.delete.assert_called_once_with(index="index1")
+        self.assertEqual(result["weight"], 1)
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_only_if_exists_true_and_not_exists(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.indices.exists.return_value = False
+
+        params = {"indices": ["index1"], "only-if-exists": True}
+
+        runner = MilvusDeleteIndex()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.exists.assert_called_once_with(index="index1")
+        milvus_client.indices.delete.assert_not_called()
+        self.assertEqual(result["weight"], 0)
+        self.assertTrue(result["success"])
+
+    def test_repr(self):
+        runner = MilvusDeleteIndex()
+        self.assertEqual(repr(runner), "milvus-delete-index")
+
+
+# ---------------------------------------------------------------------------
+# MilvusWarmupRunner
+# ---------------------------------------------------------------------------
+class MilvusWarmupRunnerTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_calls_load_collection(self, mock_ctx, mock_build):
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+
+        params = {"index": "target_index", "target_index_dimension": 3}
+
+        runner = MilvusWarmupRunner()
+        result = await runner(milvus_client, params)
+
+        milvus_client.load_collection.assert_called_once_with(collection_name="target_index")
+        self.assertTrue(result["success"])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_issues_warmup_queries(self, mock_ctx, mock_build):
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+
+        params = {"index": "target_index", "target_index_dimension": 3}
+
+        runner = MilvusWarmupRunner()
+        await runner(milvus_client, params)
+
+        self.assertEqual(
+            milvus_client.search.call_count,
+            MilvusWarmupRunner.DEFAULT_WARMUP_QUERIES,
+        )
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx, mock_build):
+        milvus_client = _make_milvus_client()
+        milvus_client.load_collection.side_effect = RuntimeError("collection not found")
+
+        params = {"index": "target_index", "target_index_dimension": 3}
+
+        runner = MilvusWarmupRunner()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-type"], "milvus")
+        self.assertIn("collection not found", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.build_search_params")
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_timing_context_set_up(self, mock_ctx, mock_build):
+        milvus_client = _make_milvus_client()
+        mock_build.return_value = {"search_params": {"params": {"ef": 256}}}
+
+        params = {"index": "target_index", "target_index_dimension": 3}
+
+        runner = MilvusWarmupRunner()
+        await runner(milvus_client, params)
+
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+        mock_ctx.on_client_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusWarmupRunner()
+        self.assertEqual(repr(runner), "warmup-knn-indices")
+
+
+# ---------------------------------------------------------------------------
+# MilvusRefresh
+# ---------------------------------------------------------------------------
+class MilvusRefreshTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_calls_refresh(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+
+        params = {"index": "myindex"}
+
+        runner = MilvusRefresh()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.refresh.assert_called_once_with(index="myindex")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 1)
+        self.assertEqual(result["unit"], "ops")
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.indices.refresh.side_effect = RuntimeError("flush failed")
+
+        params = {"index": "myindex"}
+
+        runner = MilvusRefresh()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertIn("flush failed", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusRefresh()
+        self.assertEqual(repr(runner), "milvus-refresh")
+
+
+# ---------------------------------------------------------------------------
+# MilvusForceMerge
+# ---------------------------------------------------------------------------
+class MilvusForceMergeTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_calls_forcemerge(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+
+        params = {"index": "myindex"}
+
+        runner = MilvusForceMerge()
+        result = await runner(milvus_client, params)
+
+        milvus_client.indices.forcemerge.assert_called_once_with(index="myindex")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 1)
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_failure(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.indices.forcemerge.side_effect = RuntimeError("compact failed")
+
+        params = {"index": "myindex"}
+
+        runner = MilvusForceMerge()
+        result = await runner(milvus_client, params)
+
+        self.assertFalse(result["success"])
+        self.assertIn("compact failed", result["error-description"])
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusForceMerge()
+        self.assertEqual(repr(runner), "milvus-force-merge")
+
+
+# ---------------------------------------------------------------------------
+# MilvusClusterHealth
+# ---------------------------------------------------------------------------
+class MilvusClusterHealthTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_green_success(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.cluster.health.return_value = {"status": "green"}
+
+        runner = MilvusClusterHealth()
+        result = await runner(milvus_client, {})
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["cluster-status"], "green")
+        self.assertEqual(result["relocating-shards"], 0)
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_red_failure(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.cluster.health.return_value = {"status": "red"}
+
+        runner = MilvusClusterHealth()
+        result = await runner(milvus_client, {})
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["cluster-status"], "red")
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_exception_returns_red(self, mock_ctx):
+        milvus_client = _make_milvus_client()
+        milvus_client.cluster.health.side_effect = RuntimeError("connection refused")
+
+        runner = MilvusClusterHealth()
+        result = await runner(milvus_client, {})
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["cluster-status"], "red")
+        mock_ctx.on_request_end.assert_called_once()
+
+    def test_repr(self):
+        runner = MilvusClusterHealth()
+        self.assertEqual(repr(runner), "milvus-cluster-health")
+
+
+# ---------------------------------------------------------------------------
+# MilvusNoOp
+# ---------------------------------------------------------------------------
+class MilvusNoOpTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_returns_success(self, mock_ctx):
+        runner = MilvusNoOp("put-pipeline")
+        result = await runner(_make_milvus_client(), {})
+
+        self.assertEqual(result["weight"], 1)
+        self.assertEqual(result["unit"], "ops")
+        self.assertTrue(result["success"])
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.milvus.request_context_holder")
+    @run_async
+    async def test_timing_context_set_up(self, mock_ctx):
+        runner = MilvusNoOp("put-pipeline")
+        await runner(_make_milvus_client(), {})
+
+        mock_ctx.on_client_request_start.assert_called_once()
+        mock_ctx.on_request_start.assert_called_once()
+        mock_ctx.on_request_end.assert_called_once()
+        mock_ctx.on_client_request_end.assert_called_once()
+
+    def test_repr_returns_name(self):
+        runner = MilvusNoOp("put-pipeline")
+        self.assertEqual(repr(runner), "put-pipeline")
+
+    def test_repr_returns_different_name(self):
+        runner = MilvusNoOp("delete-pipeline")
+        self.assertEqual(repr(runner), "delete-pipeline")
+
+
+# ---------------------------------------------------------------------------
+# register_milvus_runners
+# ---------------------------------------------------------------------------
+class RegisterMilvusRunnersTests(TestCase):
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.register_runner")
+    def test_registers_all_named_operations(self, mock_register):
+        from osbenchmark import workload as wl  # pylint: disable=import-outside-toplevel
+
+        register_milvus_runners()
+
+        registered_ops = [call[0][0] for call in mock_register.call_args_list]
+
+        expected_ops = [
+            wl.OperationType.Bulk,
+            wl.OperationType.Search,
+            wl.OperationType.PaginatedSearch,
+            wl.OperationType.VectorSearch,
+            wl.OperationType.BulkVectorDataSet,
+            wl.OperationType.CreateIndex,
+            wl.OperationType.DeleteIndex,
+            wl.OperationType.IndexStats,
+            wl.OperationType.ClusterHealth,
+            wl.OperationType.Refresh,
+            wl.OperationType.ForceMerge,
+            "warmup-knn-indices",
+        ]
+
+        for op in expected_ops:
+            self.assertIn(op, registered_ops, f"{op} should be registered")
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.register_runner")
+    def test_all_registered_as_async(self, mock_register):
+        register_milvus_runners()
+
+        for call in mock_register.call_args_list:
+            kwargs = call[1]
+            self.assertTrue(
+                kwargs.get("async_runner", False),
+                f"Registration for {call[0][0]} should have async_runner=True",
+            )
+
+    @mock.patch("osbenchmark.worker_coordinator.runners.register_runner")
+    def test_correct_runner_types(self, mock_register):
+        from osbenchmark import workload as wl  # pylint: disable=import-outside-toplevel
+
+        register_milvus_runners()
+
+        type_map = {}
+        for call in mock_register.call_args_list:
+            op_type = call[0][0]
+            runner_instance = call[0][1]
+            type_map[op_type] = type(runner_instance)
+
+        self.assertEqual(type_map[wl.OperationType.Bulk], MilvusBulkIndex)
+        self.assertEqual(type_map[wl.OperationType.Search], MilvusQuery)
+        self.assertEqual(type_map[wl.OperationType.PaginatedSearch], MilvusQuery)
+        self.assertEqual(type_map[wl.OperationType.VectorSearch], MilvusVectorSearch)
+        self.assertEqual(type_map[wl.OperationType.BulkVectorDataSet], MilvusBulkVectorDataSet)
+        self.assertEqual(type_map[wl.OperationType.CreateIndex], MilvusCreateIndex)
+        self.assertEqual(type_map[wl.OperationType.DeleteIndex], MilvusDeleteIndex)
+        self.assertEqual(type_map[wl.OperationType.IndexStats], MilvusIndicesStats)
+        self.assertEqual(type_map[wl.OperationType.ClusterHealth], MilvusClusterHealth)
+        self.assertEqual(type_map[wl.OperationType.Refresh], MilvusRefresh)
+        self.assertEqual(type_map[wl.OperationType.ForceMerge], MilvusForceMerge)
+        self.assertEqual(type_map["warmup-knn-indices"], MilvusWarmupRunner)
+
+        # No-ops
+        self.assertEqual(type_map[wl.OperationType.PutPipeline], MilvusNoOp)
+        self.assertEqual(type_map[wl.OperationType.DeletePipeline], MilvusNoOp)
+        self.assertEqual(type_map[wl.OperationType.CreateSearchPipeline], MilvusNoOp)
+        self.assertEqual(type_map[wl.OperationType.PutSettings], MilvusNoOp)

--- a/tests/worker_coordinator/vespa_runner_test.py
+++ b/tests/worker_coordinator/vespa_runner_test.py
@@ -1503,7 +1503,7 @@ class VespaWarmupIndicesRunnerTests(TestCase):
         runner = VespaWarmupIndicesRunner()
         result = await runner(vespa_client, {"index": "target_index"})
 
-        self.assertEqual(vespa_client.search.call_count, VespaWarmupIndicesRunner.WARMUP_QUERIES)
+        self.assertEqual(vespa_client.search.call_count, VespaWarmupIndicesRunner.DEFAULT_WARMUP_QUERIES)
         self.assertTrue(result["success"])
 
     @mock.patch("osbenchmark.worker_coordinator.runners.vespa.request_context_holder")


### PR DESCRIPTION
## Description

Adds support for [[Milvus](https://milvus.io/)](https://milvus.io/) vector database to OpenSearch Benchmark, following the same database abstraction pattern established by the Vespa PR (#1029).

Implements a new async Milvus client under `database/clients/milvus/` with helper functions for collection schema building, metric type mapping (OpenSearch `space_type` → Milvus `metric_type`), and search parameter translation. Also includes runner implementations for indexing (gRPC batch insert), vector search with recall calculation, collection create/delete, flush, compact, warmup, and health checks.

Minor updates to the Vespa runner: moves recall calculation outside the request timing window for consistency with Milvus (and upstream OpenSearch's intended pattern), and increases warmup query count.

### Key Design Decisions

- **Sync SDK + ThreadPoolExecutor**: pymilvus is a synchronous gRPC client. Search requests are dispatched via `asyncio.run_in_executor()` to integrate with OSB's async runner framework — same pattern used by Vespa's pyvespa client.
- **Metric type from workload params**: `target_index_space_type` maps to Milvus metric types (`cosinesimil` → `COSINE`, `innerproduct` → `IP`, `l2` → `L2`). Can be overridden via `--client-options="metric_type:IP"`.
- **Schema auto-detection**: Collection schema (fields, index params, HNSW config) is built from workload parameters at runtime — no pre-deployed schema needed.
- **Flush resilience**: Bypasses pymilvus's internal `_wait_for_flushed()` which can trigger a reconnect cascade that kills the gRPC channel. Instead sends the Flush RPC directly and polls `get_flush_state` with reconnect resilience.

### Files Changed

| File | Description |
|------|-------------|
| `osbenchmark/database/clients/milvus/__init__.py` | Exports `MilvusClientFactory`, `MilvusDatabaseClient`, `PYMILVUS_AVAILABLE` |
| `osbenchmark/database/clients/milvus/helpers.py` | **New** — metric type mapping, collection schema builder, search param builder, response converter, recall helper |
| `osbenchmark/database/clients/milvus/milvus.py` | Milvus client with namespace implementations (indices, cluster, transport, nodes) |
| `osbenchmark/worker_coordinator/runners/milvus.py` | Runner implementations for all Milvus operations |
| `osbenchmark/worker_coordinator/runners/vespa.py` | Minor: recall moved outside timing, warmup queries increased, line length fix |
| `osbenchmark/database/__init__.py` | Register Milvus in the database factory |
| `osbenchmark/worker_coordinator/worker_coordinator.py` | Wire Milvus runners into the coordinator |
| `osbenchmark/benchmark.py` | Add `milvus` to CLI database type choices |
| `osbenchmark/client.py` | Add Milvus client factory registration |
| `setup.py` | Add `pymilvus` as optional dependency |

## Issues Resolved

#1026

## Testing

- [x] New functionality includes testing

Adds 156 unit tests covering:
- Collection schema building with configurable metric types, dimensions, HNSW params
- Metric type mapping (`cosinesimil` → `COSINE`, `innerproduct` → `IP`, `l2` → `L2`)
- Search parameter construction with ef_search from params and client_options
- Response conversion from Milvus format to OpenSearch-compatible format
- All runner operations (bulk index, vector search, create/delete index, flush, compact, warmup, health check)
- Client lifecycle (connect, close, namespace routing)

### Benchmark Results

Tested on a single-node Milvus standalone instance (Docker, m5d.8xlarge — 32 vCPU, 128GB) with the vectorsearch workload (Cohere 1M, 768-dim, HNSW):

**Ingestion**

| Metric | Value |
|--------|-------|
| Throughput (median) | 18,060 docs/s |
| p50 latency | 89ms |
| Error rate | 0% |
| Protocol | gRPC batch insert |

**Search — 1 Client (innerproduct / IP, ef_search=256, k=100)**

| Metric | Value |
|--------|-------|
| Throughput | 233 ops/s |
| p50 latency | 3.6ms |
| p90 latency | 4.0ms |
| p99 latency | 4.3ms |
| Recall@k | 0.970 |
| Recall@1 | 1.000 |
| Error rate | 0% |

**OSB Command**

```bash
opensearch-benchmark run --pipeline=benchmark-only \
    --workload-path=/home/ec2-user/opensearch-benchmark-workloads/vectorsearch \
    --workload-params=params_milvus_1m.json \
    --target-hosts=10.0.143.186:19530 \
    --database-type=milvus \
    --client-options="hnsw_ef_search:256,space_type:innerproduct" \
    --kill-running-processes
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).