### PR TITLE
bug-fix: the total run duration should also include ramp down time period

### DIFF
--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -3001,7 +3001,7 @@ class TimePeriodBased:
         self.logger = logging.getLogger(__name__)
 
         if warmup_time_period is not None and time_period is not None:
-            self._base_duration = self._warmup_time_period + self._time_period
+            self._base_duration = self._warmup_time_period + self._time_period + self._ramp_down_time_period
 
             # Calculate how early this client should stop during ramp-down
             # Clients stop in REVERSE order: Client 0 stops first, Client (N-1) stops last

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -2345,8 +2345,8 @@ class TimePeriodBasedTests(TestCase):
 
         # Client 0: reverse_index = 3, early_stop = 20 * (3/4) = 15
         # duration = 110 - 15 = 95
-        self.assertEqual(110, loop_control._base_duration)
-        self.assertEqual(95, loop_control._duration)
+        self.assertEqual(130, loop_control._base_duration)
+        self.assertEqual(115, loop_control._duration)
         self.assertEqual(20, loop_control._ramp_down_time_period)
 
     def test_time_period_based_with_ramp_down_client_3(self):
@@ -2361,8 +2361,8 @@ class TimePeriodBasedTests(TestCase):
 
         # Client 3: reverse_index = 0, early_stop = 20 * (0/4) = 0
         # duration = 110 - 0 = 110
-        self.assertEqual(110, loop_control._base_duration)
-        self.assertEqual(110, loop_control._duration)
+        self.assertEqual(130, loop_control._base_duration)
+        self.assertEqual(130, loop_control._duration)
 
     def test_time_period_based_with_ramp_down_all_clients(self):
         # Test that clients stop in reverse order with correct spacing
@@ -2383,7 +2383,7 @@ class TimePeriodBasedTests(TestCase):
             durations.append(loop_control._duration)
 
         # Expected: [95, 100, 105, 110] - clients stop 5s apart
-        self.assertEqual([95, 100, 105, 110], durations)
+        self.assertEqual([115, 120, 125, 130], durations)
 
         # Verify spacing is correct
         for i in range(1, len(durations)):


### PR DESCRIPTION
### Description
bug-fix: the total run duration should also include ramp down time period. 

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
