### PR TITLE
backport fire and forget changes to 1.x

### DIFF
--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -709,6 +709,12 @@ def create_arg_parser():
         help="How many seconds between CPU checks there should be during CPU-based redline testing. (Default: 30)",
         default=None
     )
+    test_execution_parser.add_argument(
+        "--no-await",
+        help="Enable unhinged mode for maximum throughput without response handling or metrics collection (search queries only).",
+        action="store_true",
+        default=False
+    )
 
     ###############################################################################
     #
@@ -1024,6 +1030,7 @@ def configure_test(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.repeat_frequency", args.randomization_repeat_frequency)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.n", args.randomization_n)
     cfg.add(config.Scope.applicationOverride, "workload", "randomization.alpha", args.randomization_alpha)
+    cfg.add(config.Scope.applicationOverride, "worker_coordinator", "no_await", args.no_await)
     configure_workload_params(arg_parser, args, cfg)
     configure_connection_params(arg_parser, args, cfg)
     configure_telemetry_params(args, cfg)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1572,6 +1572,42 @@ class Query(Runner):
             result["recall_time_ms"] = recall_processing_time
             return result
 
+        async def _fire_and_forget_query(opensearch, params):
+            """
+            Fire-and-forget search execution.
+
+            The caller (AsyncNoAwaitExecutor) has already wrapped this call in an
+            asyncio.Task so the dispatch loop returns immediately. We do the HTTP
+            call inline here (NOT as another nested task) so the executor's drain
+            at end-of-run waits for the actual HTTP request to finish — otherwise
+            the aiohttp session is torn down before the request completes and we
+            get "Session is closed" errors for every request.
+            """
+            doc_type = params.get("type")
+
+            # Modify request_params to disable timeouts for fire-and-forget mode
+            ff_request_params = request_params.copy()
+            ff_request_params.pop("timeout", None)
+            ff_request_params.pop("request_timeout", None)
+
+            try:
+                await self._raw_search(opensearch, doc_type, index, body, ff_request_params, headers=headers)
+            except Exception:
+                # Silently swallow errors in fire-and-forget mode
+                pass
+
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "fire_and_forget": True
+            }
+
+        # Check if fire-and-forget mode is enabled
+        fire_and_forget = params.get("fire_and_forget", False)
+        if fire_and_forget:
+            return await _fire_and_forget_query(opensearch, params)
+
         search_method = params.get("operation-type")
         if search_method == "paginated-search":
             return await _search_after_query(opensearch, params)

--- a/osbenchmark/worker_coordinator/scheduler.py
+++ b/osbenchmark/worker_coordinator/scheduler.py
@@ -86,18 +86,21 @@ task's parameter source into this property.
 """
 
 
-def scheduler_for(task: osbenchmark.workload.Task):
+def scheduler_for(task: osbenchmark.workload.Task, schedule_override: str = None):
     """
     Creates a scheduler instance
 
     :param task: The current task for which a scheduler is needed.
+    :param schedule_override: Optional scheduler name to use instead of task.schedule.
+        Used by fire-and-forget mode to force deterministic scheduling without
+        mutating the shared task object.
     :return: An initialized scheduler instance.
     """
     logger = logging.getLogger(__name__)
     if run_unthrottled(task):
         return Unthrottled()
 
-    schedule = task.schedule or DeterministicScheduler.name
+    schedule = schedule_override or task.schedule or DeterministicScheduler.name
     try:
         scheduler_class = __SCHEDULERS[schedule]
     except KeyError:

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -46,6 +46,7 @@ from enum import Enum
 import thespian.actors
 
 from osbenchmark import actor, config, exceptions, metrics, workload, client, paths, PROGRAM_NAME, telemetry
+from osbenchmark.context import RequestContextHolder
 from osbenchmark.worker_coordinator import runner, scheduler
 from osbenchmark.workload import WorkloadProcessorRegistry, load_workload, load_workload_plugins
 from osbenchmark.utils import convert, console, net
@@ -2172,10 +2173,21 @@ class AsyncIoAdapter:
             #
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
-            schedule = schedule_for(task_allocation, params_per_task[task])
-            async_executor = AsyncExecutor(
-                client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
-                task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+            # Check if fire-and-forget mode is enabled and use appropriate schedule
+            fire_and_forget = self.cfg.opts("worker_coordinator", "no_await", mandatory=False, default_value=False)
+            schedule = schedule_for(task_allocation, params_per_task[task], fire_and_forget)
+
+            if fire_and_forget:
+                # Use AsyncNoAwaitExecutor for fire-and-forget mode
+                async_executor = AsyncNoAwaitExecutor(
+                    client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
+                    task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+            else:
+                # Use regular AsyncExecutor
+                async_executor = AsyncExecutor(
+                    client_id, task, schedule, opensearch, self.sampler, self.profile_sampler, self.cancel, self.complete,
+                    task.error_behavior(self.abort_on_error), self.cfg, self.shared_states, self.feedback_actor, self.error_queue, self.queue_lock)
+
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
             aws.append(final_executor())
         run_start = time.perf_counter()
@@ -2508,6 +2520,157 @@ class AsyncExecutor:
                 self.complete.set()
             await self._cleanup()
 
+class AsyncNoAwaitExecutor:
+    def __init__(self, client_id, task, schedule, opensearch, sampler, profile_sampler, cancel, complete, on_error,
+                 config=None, shared_states=None, feedback_actor=None, error_queue=None, queue_lock=None):
+        """
+        Fire-and-forget executor for maximum throughput without response handling or metrics collection.
+        Only supports search queries.
+        """
+        self.client_id = client_id
+        self.task = task
+        self.op = task.operation
+        self.schedule_handle = schedule
+        self.opensearch = opensearch
+        self.cancel = cancel
+        self.complete = complete
+        self.logger = logging.getLogger(__name__)
+        self.cfg = config
+        self.shared_states = shared_states
+        self.is_0 = int(self.client_id) == 0
+
+        # Variables to keep track of during execution
+        self.expected_scheduled_time = 0
+        self.sample_type = None
+        self.runner = None
+        self.task_completes_parent = False
+        # Strong refs to in-flight fire-and-forget tasks. asyncio only keeps weak
+        # refs to tasks, so without this set the GC can collect tasks mid-flight.
+        self._inflight_tasks: set = set()
+
+    async def _wait_for_rampup(self, rampup_wait_time: float) -> None:
+        """Wait for the ramp-up phase if needed."""
+        if rampup_wait_time:
+            self.logger.info("client id [%s] waiting [%.2f]s for ramp-up.", self.client_id, rampup_wait_time)
+            await asyncio.sleep(rampup_wait_time)
+            self.logger.info("Client id [%s] is running now.", self.client_id)
+
+
+    async def _async_no_await_request(self, params: dict, expected_scheduled_time: float, total_start: float) -> None:
+        """Execute a request in fire-and-forget mode - no response handling or metrics collection."""
+        absolute_expected_schedule_time = total_start + expected_scheduled_time
+        throughput_throttled = expected_scheduled_time > 0
+
+        if throughput_throttled:
+            rest = absolute_expected_schedule_time - time.perf_counter()
+            if rest > 0:
+                await asyncio.sleep(rest)
+
+        processing_start = time.perf_counter()
+        self.logger.debug("Client [%s] executing request at processing_start [%s]", self.client_id, processing_start)
+        self.schedule_handle.before_request(processing_start)
+
+        # Fire and forget - create async task to execute request without waiting
+        try:
+            # Add fire_and_forget flag to params for the runner
+            if params is None:
+                params = {}
+            params["fire_and_forget"] = True
+            # Remove any timeout settings to prevent timeout errors
+            params.pop("request-timeout", None)
+
+            # Snapshot self.runner since the main loop will reassign it before the
+            # background task runs. Skip the runner's async context manager — it's
+            # not safe to enter the same shared runner concurrently from multiple
+            # in-flight fire-and-forget tasks, and the base runner's __aenter__ /
+            # __aexit__ are no-ops anyway.
+            runner = self.runner
+            self.logger.debug("Client [%s] creating direct fire-and-forget task", self.client_id)
+            async def fire_and_forget_runner():
+                try:
+                    # Initialize request context for the fire-and-forget task
+                    _, token = RequestContextHolder.init_request_context()
+                    try:
+                        await runner(self.opensearch, params)
+                    finally:
+                        # Clean up the context
+                        RequestContextHolder.restore_context(token)
+                except Exception:
+                    # Silently swallow errors in fire-and-forget mode
+                    pass
+
+            # Create task but don't await - true fire and forget. Hold a strong
+            # reference in self._inflight_tasks until the task completes —
+            # asyncio only keeps weak refs and may GC the task mid-flight otherwise.
+            task = asyncio.create_task(fire_and_forget_runner())
+            self._inflight_tasks.add(task)
+            def handle_task_completion(t):
+                self._inflight_tasks.discard(t)
+                if not t.cancelled():
+                    t.exception()  # Consume exception to prevent logging
+            task.add_done_callback(handle_task_completion)
+
+        except Exception:
+            # Silently ignore all errors in fire-and-forget mode
+            pass
+
+        processing_end = time.perf_counter()
+        # Minimal metrics - just mark the request as sent
+        self.schedule_handle.after_request(processing_end, 1, "ops", {"success": True, "fire_and_forget": True})
+
+    async def __call__(self, *args, **kwargs):
+        self.task_completes_parent = self.task.completes_parent
+        total_start = time.perf_counter()
+
+        self.logger.debug("Initializing unhinged schedule for client id [%s].", self.client_id)
+        schedule = self.schedule_handle()
+        self.schedule_handle.start()
+        rampup_wait_time = self.schedule_handle.ramp_up_wait_time
+
+        await self._wait_for_rampup(rampup_wait_time)
+
+        self.logger.debug("Entering unhinged main loop for client id [%s].", self.client_id)
+        try:
+            async for expected_scheduled_time, sample_type, _, runner, params in schedule:
+                self.expected_scheduled_time = expected_scheduled_time
+                self.sample_type = sample_type
+                self.runner = runner
+
+                if self.cancel.is_set():
+                    self.logger.info("User cancelled execution.")
+                    break
+
+                # Fire and forget mode - don't wait for responses
+                await self._async_no_await_request(params, expected_scheduled_time, total_start)
+
+                # Check completion status
+                if self.complete.is_set():
+                    self.logger.info("Task [%s] is considered completed due to external event.", self.task)
+                    break
+        except BaseException as e:
+            self.logger.exception("Could not execute unhinged schedule")
+            raise exceptions.BenchmarkError(f"Cannot run task [{self.task}]: {e}") from None
+        finally:
+            # Drain any in-flight fire-and-forget tasks before exiting. The dispatch
+            # loop completes very quickly (it just creates background tasks), so without
+            # this drain the event loop would be torn down and pending HTTP requests
+            # would be destroyed mid-flight. This also keeps metric samples flowing
+            # while the requests complete.
+            if self._inflight_tasks:
+                self.logger.info(
+                    "Client [%s] draining [%d] in-flight fire-and-forget tasks before exit...",
+                    self.client_id, len(self._inflight_tasks)
+                )
+                await asyncio.gather(*self._inflight_tasks, return_exceptions=True)
+
+            if self.task_completes_parent:
+                self.logger.info(
+                    "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion.",
+                    self.task, self.client_id
+                )
+                self.complete.set()
+
+
 request_context_holder = client.RequestContextHolder()
 
 
@@ -2785,25 +2948,35 @@ class Allocator:
 
 # Runs a concrete schedule on one worker client
 # Needs to determine the runners and concrete iterations per client.
-def schedule_for(task_allocation, parameter_source):
+def schedule_for(task_allocation, parameter_source, fire_and_forget=False):
     """
     Calculates a client's schedule for a given task.
 
     :param task: The task that should be executed.
     :param client_index: The current client index.  Must be in the range [0, `task.clients').
     :param parameter_source: The parameter source that should be used for this task.
+    :param fire_and_forget: If True, forces deterministic scheduling for fire-and-forget mode.
     :return: A generator for the operations the given client needs to perform for this task.
     """
     logger = logging.getLogger(__name__)
     task = task_allocation.task
     op = task.operation
-    sched = scheduler.scheduler_for(task)
+
+    # Force deterministic scheduler for fire-and-forget mode without mutating
+    # the shared task object (workload Task instances are shared across clients).
+    if fire_and_forget and not task.schedule:
+        sched = scheduler.scheduler_for(task, schedule_override="deterministic")
+    else:
+        sched = scheduler.scheduler_for(task)
 
     client_index = task_allocation.client_index_in_task
     # guard all logging statements with the client index and only emit them for the first client. This information is
     # repetitive and may cause issues in thespian with many clients (an excessive number of actor messages is sent).
     if client_index == 0:
-        logger.info("Choosing [%s] for [%s].", sched, task)
+        if fire_and_forget:
+            logger.info("Choosing [%s] for [%s] (fire-and-forget mode).", sched, task)
+        else:
+            logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = parameter_source.partition(client_index, task.clients)
     if hasattr(sched, "parameter_source"):

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -2474,3 +2474,147 @@ class TaskRampDownTests(TestCase):
 
         # Different ramp_down should produce different hashes
         self.assertNotEqual(hash(task1), hash(task2))
+
+
+class AsyncNoAwaitExecutorTests(TestCase):
+    def setUp(self):
+        params.register_param_source_for_name("worker-coordinator-test-param-source", WorkerCoordinatorTestParamSource)
+
+        self.cfg = config.Config()
+        self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
+        self.cfg.add(config.Scope.application, "system", "available.cores", 8)
+        self.cfg.add(config.Scope.application, "workload", "test.mode.enabled", True)
+
+        all_client_options = {"default": {"base_timeout": 10}}
+        self.cfg.add(config.Scope.application, "client", "options",
+                     WorkerCoordinatorTests.Holder(all_client_options=all_client_options))
+
+        self.task = workload.Task("test-task",
+                                  workload.Operation("test-op", workload.OperationType.Bulk),
+                                  clients=2)
+        self.sampler = mock.Mock()
+        self.profile_sampler = mock.Mock()
+        self.cancel = threading.Event()
+        self.complete = threading.Event()
+        self.schedule_handle = mock.Mock()
+
+        opensearch_mock = mock.Mock()
+        opensearch_mock.new_request_context.return_value = mock.Mock()
+        self.opensearch = {"default": opensearch_mock}
+
+    def test_unhinged_executor_initialization(self):
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        self.assertEqual(0, executor.client_id)
+        self.assertEqual(self.task, executor.task)
+        self.assertEqual(self.schedule_handle, executor.schedule_handle)
+        self.assertEqual(self.opensearch, executor.opensearch)
+        self.assertTrue(executor.is_0)
+
+    def test_unhinged_executor_client_id_not_zero(self):
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
+            client_id=1,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        self.assertEqual(1, executor.client_id)
+        self.assertFalse(executor.is_0)
+
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_async_no_await_request_creates_task(self, mock_create_task, mock_context_holder):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access
+
+        mock_create_task.assert_called_once()
+
+    @mock.patch('time.perf_counter')
+    @mock.patch('asyncio.sleep')
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_async_no_await_request_with_throttling(self, mock_create_task, mock_context_holder,
+                                                          mock_sleep, mock_perf_counter):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+        mock_perf_counter.return_value = 0.5  # Current time less than expected schedule time
+
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
+
+        mock_sleep.assert_called_once_with(0.5)  # Should sleep for the difference
+        mock_create_task.assert_called_once()
+
+    @mock.patch('time.perf_counter')
+    @mock.patch('asyncio.sleep')
+    @mock.patch('osbenchmark.worker_coordinator.worker_coordinator.RequestContextHolder')
+    @mock.patch('asyncio.create_task')
+    @run_async
+    async def test_async_no_await_request_no_throttling_needed(self, mock_create_task, mock_context_holder,
+                                                               mock_sleep, mock_perf_counter):
+        mock_context_holder.init_request_context.return_value = ({}, mock.Mock())
+        mock_perf_counter.return_value = 1.5  # Current time exceeds expected schedule time
+
+        executor = worker_coordinator.AsyncNoAwaitExecutor(
+            client_id=0,
+            task=self.task,
+            schedule=self.schedule_handle,
+            opensearch=self.opensearch,
+            sampler=self.sampler,
+            profile_sampler=self.profile_sampler,
+            cancel=self.cancel,
+            complete=self.complete,
+            on_error="continue"
+        )
+
+        executor.runner = mock.AsyncMock()
+
+        await executor._async_no_await_request({}, 1.0, 0.0)  # pylint: disable=protected-access  # expected_scheduled_time = 1.0
+
+        mock_sleep.assert_not_called()  # No sleep needed
+        mock_create_task.assert_called_once()


### PR DESCRIPTION
### Description
Backport of #964 `--no-await` flag for 1.x release

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
