### PR TITLE
worker_coordinator: fix 'occured' -> 'occurred' in error description

### DIFF
--- a/osbenchmark/worker_coordinator/errors.py
+++ b/osbenchmark/worker_coordinator/errors.py
@@ -3,7 +3,7 @@ import re
 def parse_error(error_metadata):
     error = error_metadata['error']
     status_code = None
-    description = "error occured, check logs for details"
+    description = "error occurred, check logs for details"
     operation = UnknownOperationError(description, None)
 
     if 'status' in error_metadata:


### PR DESCRIPTION
### Description
Error description in `osbenchmark/worker_coordinator/errors.py` line 6 reads `error occured`. Fixed to `occurred`. String-literal-only change.

### Issues Resolved
N/A — typo fix only.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented above
- [x] Commits are signed per the DCO using `--signoff`