### PR TITLE
feat(grpc): Add gRPC vector bulk ingestion with extra_field_values

### DIFF
--- a/osbenchmark/worker_coordinator/proto_helpers/ProtoBulkHelper.py
+++ b/osbenchmark/worker_coordinator/proto_helpers/ProtoBulkHelper.py
@@ -1,3 +1,4 @@
+import numpy as np
 from opensearch.protobufs.schemas import common_pb2
 
 def _parse_docs_from_body(body):
@@ -6,6 +7,13 @@ def _parse_docs_from_body(body):
     for doc in index_op_lines[1::2]:
         doc_list.append(doc)
     return doc_list
+
+def _build_float_binary_le(vector):
+    """Convert a numpy float32 vector to a FloatBinaryLE protobuf message."""
+    arr = np.asarray(vector, dtype=np.float32)
+    if not arr.dtype.byteorder == '=' or not np.little_endian:
+        arr = arr.astype('<f4')
+    return common_pb2.FloatBinaryLE(bytes_le=arr.tobytes(), dimension=len(arr))
 
 class ProtoBulkHelper:
     # Build protobuf SearchRequest.
@@ -26,6 +34,31 @@ class ProtoBulkHelper:
             request_body = common_pb2.BulkRequestBody()
             request_body.object = doc.encode('utf-8')
             request_body.operation_container.CopyFrom(op_container)
+            request.bulk_request_body.append(request_body)
+        return request
+
+    # Build protobuf BulkRequest with extra_field_values for vector data.
+    # Consumed from params dictionary:
+    # * ``vectors``: list of numpy float32 arrays (one per document)
+    # * ``index``: index name
+    # * ``field``: vector field name (used as key in extra_field_values map)
+    @staticmethod
+    def build_proto_vector_request(params):
+        index = params.get("index")
+        vectors = params.get("vectors")
+        field = params.get("field")
+        request = common_pb2.BulkRequest()
+        request.index = index
+        op_container = common_pb2.OperationContainer()
+        op_container.index.CopyFrom(common_pb2.IndexOperation())
+        for vec in vectors:
+            request_body = common_pb2.BulkRequestBody()
+            request_body.object = b'{}'
+            request_body.operation_container.CopyFrom(op_container)
+            float_binary_le = _build_float_binary_le(vec)
+            float_array_value = common_pb2.FloatArrayValue(binary_le=float_binary_le)
+            binary_field_value = common_pb2.BinaryFieldValue(float_array_value=float_array_value)
+            request_body.extra_field_values[field].CopyFrom(binary_field_value)
             request.bulk_request_body.append(request_body)
         return request
 

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -433,6 +433,7 @@ def register_default_runners():
     register_runner(workload.OperationType.ListAllPointInTime, ListAllPointInTime(), async_runner=True)
     register_runner(workload.OperationType.ProduceStreamMessage, ProduceStreamMessage(), async_runner=True)
     register_runner(workload.OperationType.ProtoBulk, ProtoBulkIndex(), async_runner=True)
+    register_runner(workload.OperationType.ProtoBulkVectorDataSet, ProtoBulkVectorDataSet(), async_runner=True)
     register_runner(workload.OperationType.ProtoSearch, ProtoQuery(), async_runner=True)
     register_runner(workload.OperationType.ProtoVectorSearch, ProtoKNNQuery(), async_runner=True)
 
@@ -3066,6 +3067,20 @@ class ProtoBulkIndex(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "proto-bulk-index"
+
+class ProtoBulkVectorDataSet(Runner):
+    async def __call__(self, opensearch, params):
+        request_context_holder.on_client_request_start()
+        proto_req = ProtoBulkHelper.build_proto_vector_request(params)
+        stub = opensearch.document_service()
+        request_context_holder.on_request_start()
+        bulk_resp = await stub.Bulk(proto_req)
+        request_context_holder.on_request_end()
+        request_context_holder.on_client_request_end()
+        return ProtoBulkHelper.build_stats(bulk_resp, params)
+
+    def __repr__(self, *args, **kwargs):
+        return "proto-bulk-vector-data-set"
 
 class ProtoQuery(Runner):
     async def __call__(self, opensearch, params):

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -2002,6 +2002,45 @@ class SourceOnlyIndexDataReader(IndexDataReader):
 register_param_source_for_operation(workload.OperationType.Bulk, BulkIndexParamSource)
 register_param_source_for_operation(workload.OperationType.ProtoBulk, BulkIndexParamSource)
 register_param_source_for_operation(workload.OperationType.BulkVectorDataSet, BulkVectorsFromDataSetParamSource)
+
+
+class ProtoBulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
+    """Create gRPC bulk index requests from a data set of vectors.
+
+    Unlike BulkVectorsFromDataSetParamSource, this keeps vectors as numpy arrays
+    for binary encoding via extra_field_values (FloatBinaryLE) instead of
+    converting to JSON lists.
+    """
+
+    def __init__(self, workload, params, **kwargs):
+        super().__init__(workload, params, Context.INDEX, **kwargs)
+        self.bulk_size: int = parse_int_parameter("bulk_size", params)
+        self.index_name: str = parse_string_parameter("index", params)
+
+    def partition(self, partition_index, total_partitions):
+        return super().partition(partition_index, total_partitions)
+
+    def params(self):
+        if self.current >= self.num_vectors + self.offset:
+            raise StopIteration
+
+        remaining = self.num_vectors + self.offset - self.current
+        bulk_size = min(self.bulk_size, remaining)
+        partition = self.data_set.read(bulk_size)
+        size = len(partition)
+        self.current += size
+        self.task_progress = (self.current / self.total, '%')
+
+        return {
+            "index": self.index_name,
+            "field": self.field_name,
+            "vectors": list(partition),
+            "bulk-size": size,
+            "unit": "docs",
+        }
+
+
+register_param_source_for_operation(workload.OperationType.ProtoBulkVectorDataSet, ProtoBulkVectorsFromDataSetParamSource)
 register_param_source_for_operation(workload.OperationType.Search, SearchParamSource)
 register_param_source_for_operation(workload.OperationType.VectorSearch, VectorSearchParamSource)
 register_param_source_for_operation(workload.OperationType.ProtoVectorSearch, VectorSearchParamSource)

--- a/osbenchmark/workload/workload.py
+++ b/osbenchmark/workload/workload.py
@@ -624,6 +624,7 @@ class OperationType(Enum):
     ProtoBulk = (201, AdminStatus.No, ServerlessStatus.Blocked)
     ProtoSearch = (202, AdminStatus.No, ServerlessStatus.Blocked)
     ProtoVectorSearch = (203, AdminStatus.No, ServerlessStatus.Blocked)
+    ProtoBulkVectorDataSet = (204, AdminStatus.No, ServerlessStatus.Blocked)
 
     # administrative actions
     ForceMerge = (22, AdminStatus.Yes, ServerlessStatus.Blocked)
@@ -708,6 +709,8 @@ class OperationType(Enum):
             return OperationType.Bulk
         elif v == "proto-bulk":
             return OperationType.ProtoBulk
+        elif v == "proto-bulk-vector-data-set":
+            return OperationType.ProtoBulkVectorDataSet
         elif v == "raw-request":
             return OperationType.RawRequest
         elif v == "put-pipeline":

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ install_requires = [
     "pydantic_core>=2.27.2",
     # License: Apache 2.0
     # gRPC & proto deps
-    "opensearch-protobufs==1.2.0"
+    "opensearch-protobufs>=1.4.0"
 ]
 
 tests_require = [

--- a/tests/worker_coordinator/proto_bulk_helper_test.py
+++ b/tests/worker_coordinator/proto_bulk_helper_test.py
@@ -24,8 +24,9 @@
 
 from unittest import TestCase
 
+import numpy as np
 from opensearch.protobufs.schemas import common_pb2
-from osbenchmark.worker_coordinator.proto_helpers.ProtoBulkHelper import ProtoBulkHelper
+from osbenchmark.worker_coordinator.proto_helpers.ProtoBulkHelper import ProtoBulkHelper, _build_float_binary_le
 
 class ProtoBulkHelperTests(TestCase):
     def test_build_proto_request_single_document(self):
@@ -122,3 +123,87 @@ class ProtoBulkHelperTests(TestCase):
             ProtoBulkHelper.build_stats(mock_bulk_response, params)
 
         self.assertIn("Detailed results not supported for gRPC bulk requests", str(ctx.exception))
+
+    # --- extra_field_values / vector bulk tests ---
+
+    def test_build_float_binary_le_basic(self):
+        vec = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = _build_float_binary_le(vec)
+        self.assertEqual(result.dimension, 3)
+        self.assertEqual(len(result.bytes_le), 12)  # 3 * 4 bytes
+        # Verify round-trip: decode the LE bytes back to floats
+        decoded = np.frombuffer(result.bytes_le, dtype='<f4')
+        np.testing.assert_array_equal(decoded, vec)
+
+    def test_build_float_binary_le_from_float64(self):
+        """float64 input should be converted to float32."""
+        vec = np.array([1.5, 2.5], dtype=np.float64)
+        result = _build_float_binary_le(vec)
+        self.assertEqual(result.dimension, 2)
+        decoded = np.frombuffer(result.bytes_le, dtype='<f4')
+        np.testing.assert_array_almost_equal(decoded, [1.5, 2.5])
+
+    def test_build_proto_vector_request_single_vector(self):
+        vec = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        params = {
+            "index": "test-index",
+            "field": "my_vector",
+            "vectors": [vec],
+        }
+
+        result = ProtoBulkHelper.build_proto_vector_request(params)
+
+        self.assertIsInstance(result, common_pb2.BulkRequest)
+        self.assertEqual(result.index, "test-index")
+        self.assertEqual(len(result.bulk_request_body), 1)
+
+        body = result.bulk_request_body[0]
+        self.assertEqual(body.object, b'{}')
+        self.assertTrue(body.operation_container.HasField("index"))
+        self.assertIn("my_vector", body.extra_field_values)
+
+        bfv = body.extra_field_values["my_vector"]
+        self.assertTrue(bfv.HasField("float_array_value"))
+        fav = bfv.float_array_value
+        self.assertTrue(fav.HasField("binary_le"))
+        self.assertEqual(fav.binary_le.dimension, 3)
+        decoded = np.frombuffer(fav.binary_le.bytes_le, dtype='<f4')
+        np.testing.assert_array_equal(decoded, vec)
+
+    def test_build_proto_vector_request_multiple_vectors(self):
+        vecs = [
+            np.array([1.0, 0.0], dtype=np.float32),
+            np.array([0.0, 1.0], dtype=np.float32),
+            np.array([0.5, 0.5], dtype=np.float32),
+        ]
+        params = {
+            "index": "vec-index",
+            "field": "embedding",
+            "vectors": vecs,
+        }
+
+        result = ProtoBulkHelper.build_proto_vector_request(params)
+
+        self.assertEqual(len(result.bulk_request_body), 3)
+        for i, body in enumerate(result.bulk_request_body):
+            self.assertEqual(body.object, b'{}')
+            bfv = body.extra_field_values["embedding"]
+            decoded = np.frombuffer(bfv.float_array_value.binary_le.bytes_le, dtype='<f4')
+            np.testing.assert_array_equal(decoded, vecs[i])
+
+    def test_build_proto_vector_request_high_dimensional(self):
+        vec = np.random.rand(768).astype(np.float32)
+        params = {
+            "index": "test-index",
+            "field": "vec",
+            "vectors": [vec],
+        }
+
+        result = ProtoBulkHelper.build_proto_vector_request(params)
+
+        body = result.bulk_request_body[0]
+        fav = body.extra_field_values["vec"].float_array_value
+        self.assertEqual(fav.binary_le.dimension, 768)
+        self.assertEqual(len(fav.binary_le.bytes_le), 768 * 4)
+        decoded = np.frombuffer(fav.binary_le.bytes_le, dtype='<f4')
+        np.testing.assert_array_equal(decoded, vec)

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -36,7 +36,7 @@ from osbenchmark.utils.dataset import Context, HDF5DataSet
 from osbenchmark.utils.parse import ConfigurationError
 from osbenchmark.workload import params, workload, loader
 from osbenchmark.workload.params import VectorDataSetPartitionParamSource, VectorSearchPartitionParamSource, \
-    BulkVectorsFromDataSetParamSource
+    BulkVectorsFromDataSetParamSource, ProtoBulkVectorsFromDataSetParamSource
 from tests.utils.dataset_helper import create_data_set, create_attributes_data_set, create_parent_data_set
 from tests.utils.dataset_test import DEFAULT_NUM_VECTORS
 
@@ -3421,6 +3421,74 @@ class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
                 self.assertFalse(expected_id_field in req_body)
                 continue
             self.assertTrue(expected_id_field in req_body)
+
+
+class ProtoBulkVectorsFromDataSetParamSourceTestCase(TestCase):
+    DEFAULT_INDEX_NAME = "test-index"
+    DEFAULT_VECTOR_FIELD_NAME = "test-vector-field"
+    DEFAULT_TYPE = HDF5DataSet.FORMAT_NAME
+    DEFAULT_DIMENSION = 10
+
+    def setUp(self):
+        self.data_set_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.data_set_dir)
+
+    def test_params_returns_vectors_as_numpy(self):
+        num_vectors = 5
+        bulk_size = 3
+        data_set_path = create_data_set(
+            num_vectors, self.DEFAULT_DIMENSION, self.DEFAULT_TYPE,
+            Context.INDEX, self.data_set_dir)
+
+        source = ProtoBulkVectorsFromDataSetParamSource(
+            workload.Workload(name="unit-test"), {
+                "index": self.DEFAULT_INDEX_NAME,
+                "field": self.DEFAULT_VECTOR_FIELD_NAME,
+                "data_set_format": self.DEFAULT_TYPE,
+                "data_set_path": data_set_path,
+                "bulk_size": bulk_size,
+            })
+        partition = source.partition(0, 1)
+
+        result = partition.params()
+        self.assertEqual(result["index"], self.DEFAULT_INDEX_NAME)
+        self.assertEqual(result["field"], self.DEFAULT_VECTOR_FIELD_NAME)
+        self.assertEqual(result["bulk-size"], bulk_size)
+        self.assertEqual(result["unit"], "docs")
+        vectors = result["vectors"]
+        self.assertEqual(len(vectors), bulk_size)
+        for vec in vectors:
+            self.assertIsInstance(vec, np.ndarray)
+            self.assertEqual(len(vec), self.DEFAULT_DIMENSION)
+
+    def test_params_exhausts_dataset(self):
+        num_vectors = 5
+        bulk_size = 3
+        data_set_path = create_data_set(
+            num_vectors, self.DEFAULT_DIMENSION, self.DEFAULT_TYPE,
+            Context.INDEX, self.data_set_dir)
+
+        source = ProtoBulkVectorsFromDataSetParamSource(
+            workload.Workload(name="unit-test"), {
+                "index": self.DEFAULT_INDEX_NAME,
+                "field": self.DEFAULT_VECTOR_FIELD_NAME,
+                "data_set_format": self.DEFAULT_TYPE,
+                "data_set_path": data_set_path,
+                "bulk_size": bulk_size,
+            })
+        partition = source.partition(0, 1)
+
+        # First batch: 3 vectors
+        r1 = partition.params()
+        self.assertEqual(r1["bulk-size"], 3)
+        # Second batch: remaining 2
+        r2 = partition.params()
+        self.assertEqual(r2["bulk-size"], 2)
+        # Exhausted
+        with self.assertRaises(StopIteration):
+            partition.params()
 
 
 class BulkVectorsAttributeCase(TestCase):


### PR DESCRIPTION
### Description

Add support for bulk indexing vectors over gRPC using the extra_field_values optimization from OpenSearch PR #20635. Vectors are sent as packed little-endian binary (FloatBinaryLE) via the protobuf extra_field_values side-channel, bypassing JSON serialization entirely.

- Add build_proto_vector_request() to ProtoBulkHelper for building BulkRequest with FloatBinaryLE encoding in extra_field_values map
- Add ProtoBulkVectorsFromDataSetParamSource that reads HDF5 vectors as numpy arrays and passes them as binary (no .tolist() conversion)
- Add ProtoBulkVectorDataSet runner and OperationType (204)
- Bump opensearch-protobufs dependency from ==1.2.0 to >=1.4.0
- Add 7 unit tests covering protobuf message construction and param source behavior


### Issues Resolved
N/A

### Testing
- [x] New functionality includes testing


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
