### PR TITLE
bug-fix:fix wrong doc count when retries enabled

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -952,6 +952,9 @@ class BulkVectorDataSet(Runner):
         retry_wait_period = params.get("retry-wait-period", 0.5)
         retry_max_wait_period = params.get("retry-max-wait-period", 60)
 
+        total_docs = self._doc_count(current_body, with_action_metadata)
+        cumulative_success = 0
+
         for attempt in range(retries):
             docs_in_request = self._doc_count(current_body, with_action_metadata)
             current_params["body"] = current_body
@@ -965,16 +968,9 @@ class BulkVectorDataSet(Runner):
                     docs_in_request, unit, response
                 )
 
-                meta_data = {
-                    "size": docs_in_request,
-                    "index": current_params.get("index"),
-                    "weight": docs_in_request,
-                    "unit": unit,
-                }
-                meta_data.update(stats)
+                cumulative_success += stats.get("success-count", 0)
 
                 if not stats["success"]:
-                    meta_data["error-type"] = "bulk"
                     if detailed_results:
                         failed_indices = stats.get("failed-indices", [])
                         if failed_indices and attempt < retries - 1:
@@ -986,6 +982,20 @@ class BulkVectorDataSet(Runner):
                             current_body = self._build_retry_body(current_body, failed_indices, with_action_metadata)
                             await asyncio.sleep(backoff)
                             continue
+
+                total_error_count = total_docs - cumulative_success
+                meta_data = {
+                    "size": total_docs,
+                    "index": current_params.get("index"),
+                    "weight": total_docs,
+                    "unit": unit,
+                }
+                meta_data.update(stats)
+                meta_data["success-count"] = cumulative_success
+                meta_data["error-count"] = total_error_count
+                meta_data["success"] = total_error_count == 0
+                if total_error_count > 0:
+                    meta_data["error-type"] = "bulk"
                 return meta_data
             except ConnectionTimeout:
                 backoff = min(retry_wait_period * (2 ** attempt), retry_max_wait_period)

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -7823,3 +7823,133 @@ class ProduceStreamMessageTests(TestCase):
             await self.runner_instance(mock_opensearch, params)
 
         self.assertIn("Failed to produce message", str(context.exception))
+
+
+class BulkVectorDataSetTests(TestCase):
+    def _bulk_response(self, items):
+        return {
+            "errors": any(item[next(iter(item))]["status"] > 299 for item in items),
+            "took": 5,
+            "items": items,
+        }
+
+    def _ok_item(self, idx=0):
+        return {"index": {"_id": str(idx), "status": 201, "result": "created",
+                          "_shards": {"total": 2, "successful": 1, "failed": 0}}}
+
+    def _err_item(self, idx=0):
+        return {"index": {"_id": str(idx), "status": 429, "result": "rejected",
+                          "_shards": {"total": 2, "successful": 0, "failed": 1},
+                          "error": {"reason": "rejected"}}}
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_all_docs_succeed_no_retry(self, opensearch, on_client_request_start, on_client_request_end):
+        response = self._bulk_response([self._ok_item(0), self._ok_item(1), self._ok_item(2)])
+        opensearch.bulk.return_value = as_future(response)
+        opensearch.return_raw_response.return_value = None
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action0", "doc0", "action1", "doc1", "action2", "doc2"],
+            "action-metadata-present": True,
+            "retries": 2,
+            "index": "test",
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(3, result["weight"])
+        self.assertEqual(3, result["size"])
+        self.assertEqual(3, result["success-count"])
+        self.assertEqual(0, result["error-count"])
+        self.assertTrue(result["success"])
+        self.assertNotIn("error-type", result)
+        opensearch.bulk.assert_called_once()
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_retry_counts_all_successful_docs(self, opensearch, on_client_request_start, on_client_request_end):
+        first_response = self._bulk_response([self._ok_item(0), self._err_item(1), self._ok_item(2)])
+        retry_response = self._bulk_response([self._ok_item(1)])
+
+        opensearch.bulk.side_effect = [as_future(first_response), as_future(retry_response)]
+        opensearch.return_raw_response.return_value = None
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action0", "doc0", "action1", "doc1", "action2", "doc2"],
+            "action-metadata-present": True,
+            "retries": 2,
+            "index": "test",
+            "retry-wait-period": 0,
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(3, result["weight"])
+        self.assertEqual(3, result["size"])
+        self.assertEqual(3, result["success-count"])
+        self.assertEqual(0, result["error-count"])
+        self.assertTrue(result["success"])
+        self.assertEqual(2, opensearch.bulk.call_count)
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_retry_partial_failure_still_reports_total(self, opensearch, on_client_request_start, on_client_request_end):
+        first_response = self._bulk_response([self._ok_item(0), self._err_item(1), self._err_item(2)])
+        retry_response = self._bulk_response([self._ok_item(1), self._err_item(2)])
+
+        opensearch.bulk.side_effect = [as_future(first_response), as_future(retry_response)]
+        opensearch.return_raw_response.return_value = None
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action0", "doc0", "action1", "doc1", "action2", "doc2"],
+            "action-metadata-present": True,
+            "retries": 1,
+            "index": "test",
+            "retry-wait-period": 0,
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(3, result["weight"])
+        self.assertEqual(3, result["size"])
+        self.assertEqual(2, result["success-count"])
+        self.assertEqual(1, result["error-count"])
+        self.assertFalse(result["success"])
+        self.assertEqual("bulk", result["error-type"])
+        self.assertEqual(2, opensearch.bulk.call_count)
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_no_retry_configured_reports_original_counts(self, opensearch, on_client_request_start, on_client_request_end):
+        response = self._bulk_response([self._ok_item(0), self._err_item(1), self._ok_item(2)])
+        opensearch.bulk.return_value = as_future(response)
+        opensearch.return_raw_response.return_value = None
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action0", "doc0", "action1", "doc1", "action2", "doc2"],
+            "action-metadata-present": True,
+            "retries": 0,
+            "index": "test",
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(3, result["weight"])
+        self.assertEqual(3, result["size"])
+        self.assertEqual(2, result["success-count"])
+        self.assertEqual(1, result["error-count"])
+        self.assertFalse(result["success"])
+        opensearch.bulk.assert_called_once()


### PR DESCRIPTION
### Description
Fix BulkVectorDataSet reporting wrong success count after doc-level retries. 

Summary

  - Fix a bug where BulkVectorDataSet runner only reported the success count from the final retry attempt, silently dropping docs that succeeded on earlier attempts
  - For example, a 500-doc bulk with 90 failures retried successfully would report success-count: 90 and weight: 90 instead of 500
  - Track cumulative successes across retry iterations and use the original total doc count for size and weight
  - Add tests covering: all-success (no retry), full recovery after retry, partial recovery, and no-retry-configured paths
### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
