### PR TITLE
fix vectorsearch retry doc counting

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -951,6 +951,8 @@ class BulkVectorDataSet(Runner):
         current_params = dict(params)
         retry_wait_period = params.get("retry-wait-period", 0.5)
         retry_max_wait_period = params.get("retry-max-wait-period", 60)
+        total_docs = self._doc_count(current_body, with_action_metadata)
+        cumulative_success_count = 0
 
         for attempt in range(retries):
             docs_in_request = self._doc_count(current_body, with_action_metadata)
@@ -964,14 +966,16 @@ class BulkVectorDataSet(Runner):
                 stats = self.detailed_stats(current_params, response) if detailed_results else self.simple_stats(
                     docs_in_request, unit, response
                 )
+                cumulative_success_count += stats.get("success-count", 0)
 
                 meta_data = {
-                    "size": docs_in_request,
+                    "size": total_docs,
                     "index": current_params.get("index"),
-                    "weight": docs_in_request,
+                    "weight": total_docs,
                     "unit": unit,
                 }
                 meta_data.update(stats)
+                meta_data["success-count"] = cumulative_success_count
 
                 if not stats["success"]:
                     meta_data["error-type"] = "bulk"

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -7823,3 +7823,96 @@ class ProduceStreamMessageTests(TestCase):
             await self.runner_instance(mock_opensearch, params)
 
         self.assertIn("Failed to produce message", str(context.exception))
+
+
+class BulkVectorDataSetRetryTests(TestCase):
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_retry_reports_total_docs_not_just_retried(self, opensearch, on_client_request_start, on_client_request_end):
+        """When 90 of 500 docs fail then succeed on retry, weight/size should be 500, not 90."""
+        # First call: 5 docs, 2 fail (indices 1 and 3)
+        first_response = {
+            "took": 10,
+            "errors": True,
+            "items": [
+                {"index": {"_index": "test", "_id": "0", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"_index": "test", "_id": "1", "status": 429, "result": "noop",
+                           "_shards": {"total": 2, "successful": 0, "failed": 2},
+                           "error": {"type": "rejected_execution_exception"}}},
+                {"index": {"_index": "test", "_id": "2", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"_index": "test", "_id": "3", "status": 429, "result": "noop",
+                           "_shards": {"total": 2, "successful": 0, "failed": 2},
+                           "error": {"type": "rejected_execution_exception"}}},
+                {"index": {"_index": "test", "_id": "4", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+            ]
+        }
+        # Second call: the 2 retried docs succeed
+        retry_response = {
+            "took": 5,
+            "errors": False,
+            "items": [
+                {"index": {"_index": "test", "_id": "1", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"_index": "test", "_id": "3", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+            ]
+        }
+        opensearch.bulk.side_effect = [as_future(first_response), as_future(retry_response)]
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action\n", "doc0\n", "action\n", "doc1\n", "action\n", "doc2\n",
+                     "action\n", "doc3\n", "action\n", "doc4\n"],
+            "action-metadata-present": True,
+            "index": "test",
+            "retries": 2,
+            "retry-wait-period": 0,
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(5, result["weight"])
+        self.assertEqual(5, result["size"])
+        self.assertEqual(5, result["success-count"])
+        self.assertTrue(result["success"])
+        self.assertEqual(0, result["error-count"])
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_no_retry_reports_correct_counts(self, opensearch, on_client_request_start, on_client_request_end):
+        """When all docs succeed on first attempt, weight/size/success-count should all match."""
+        response = {
+            "took": 10,
+            "errors": False,
+            "items": [
+                {"index": {"_index": "test", "_id": "0", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"_index": "test", "_id": "1", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"_index": "test", "_id": "2", "status": 201, "result": "created",
+                           "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+            ]
+        }
+        opensearch.bulk.return_value = as_future(response)
+
+        bulk = runner.BulkVectorDataSet()
+        params = {
+            "body": ["action\n", "doc0\n", "action\n", "doc1\n", "action\n", "doc2\n"],
+            "action-metadata-present": True,
+            "index": "test",
+        }
+
+        result = await bulk(opensearch, params)
+
+        self.assertEqual(3, result["weight"])
+        self.assertEqual(3, result["size"])
+        self.assertEqual(3, result["success-count"])
+        self.assertTrue(result["success"])
+        self.assertEqual(0, result["error-count"])


### PR DESCRIPTION
### Description
VectorSearch Bulk retry logic was miscounting how many docs were being ingested by the host. So if OSB sent 500 docs -> 410 succeed but 90 fail -> retry the 90 docs -> all 90 succeed, this would only count as 90 total docs ingested.

This was throwing off the number of successful docs which in turn throws off throughput calculations. This PR captures the total docs number from the original body *before* any retry loop, and uses that for weight and size. We also accumulate the number of successful docs across attempts which overwrites the per-attempt `success-count`

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [x] New functionality includes testing

Adds 2 new unit tests specific to these changes

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
