### PR TITLE
Removes _source default from search request params for Vectors

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1151,8 +1151,6 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
     def _update_request_params(self):
         request_params = self.query_params.get(self.PARAMS_NAME_REQUEST_PARAMS, {})
-        request_params[self.PARAMS_NAME_SOURCE] = request_params.get(
-            self.PARAMS_NAME_SOURCE, "false")
         request_params[self.PARAMS_NAME_ALLOW_PARTIAL_RESULTS] = request_params.get(
             self.PARAMS_NAME_ALLOW_PARTIAL_RESULTS, "false")
         self.query_params.update({self.PARAMS_NAME_REQUEST_PARAMS: request_params})

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3289,6 +3289,79 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         space_type = params.get("space_type")
         self.assertEqual(space_type, "l2") # TODO change this once it's all modifiable.
 
+    def test_update_request_params_with_request_params(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {"_source": "false"},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+        request_params = params.get("request-params")
+        self.assertEqual(request_params["_source"], "false")
+        self.assertEqual(request_params["allow_partial_search_results"], "false")
+
+    def test_update_request_params_without_request_params(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+        request_params = params.get("request-params")
+        self.assertEqual(request_params, {"allow_partial_search_results": "false"})
+
+
 class BulkVectorsFromDataSetParamSourceTestCase(TestCase):
 
     DEFAULT_INDEX_NAME = "test-partition-index"


### PR DESCRIPTION
This overrides query body defaults making it difficult to override for various runs

https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/782 for disabling source as an alternative

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
