### PR TITLE
Add rescore support 

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1097,6 +1097,8 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_REQUEST_PARAMS = "request-params"
     PARAMS_NAME_SOURCE = "_source"
     PARAMS_NAME_ALLOW_PARTIAL_RESULTS = "allow_partial_search_results"
+    PARAMS_NAME_OVERSAMPLE_FACTOR = "oversample_factor"
+    PARAMS_NAME_RESCORE = "rescore"
 
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
@@ -1112,6 +1114,11 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.neighbors_data_set = None
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
+        self.oversample_factor = params.get(self.PARAMS_NAME_OVERSAMPLE_FACTOR)
+        if self.oversample_factor and ("max_distance" in query_params or "min_score" in query_params):
+            raise exceptions.InvalidSyntax(
+                "'oversample_factor' cannot be used with 'max_distance' or 'min_score'. "
+                "Rescoring is only supported with top-k search.")
         self.query_params = query_params
         self.query_params.update({
             self.PARAMS_NAME_K: self.k,
@@ -1230,6 +1237,11 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             query.update({
                 "filter": efficient_filter,
             })
+
+        if self.oversample_factor:
+            query[self.PARAMS_NAME_RESCORE] = {
+                self.PARAMS_NAME_OVERSAMPLE_FACTOR: self.oversample_factor
+            }
 
         knn_search_query = {
             "knn": {

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3187,6 +3187,117 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         with self.assertRaises(StopIteration):
             query_param_source_partition.params()
 
+    def test_build_vector_search_query_body_with_oversample_factor(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k,
+            "oversample_factor": 5.0
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertIn("rescore", query)
+        self.assertEqual(query["rescore"]["oversample_factor"], 5.0)
+
+    def test_build_vector_search_query_body_without_oversample_factor(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertNotIn("rescore", query)
+
+    def test_oversample_factor_with_max_distance_raises_error(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k,
+            "oversample_factor": 5.0
+        }
+        with self.assertRaises(exceptions.InvalidSyntax):
+            VectorSearchPartitionParamSource(
+                workload.Workload(name="unit-test"),
+                test_param_source_params, {
+                    "index": self.DEFAULT_INDEX_NAME,
+                    "request-params": {},
+                    "max_distance": -160.0,
+                }
+            )
+
     def _check_params(
             self,
             actual_params: dict,


### PR DESCRIPTION
### Description
Add rescore parameter support to VectorSearchPartitionParamSource

When oversample_factor is specified in workload params, injects a rescore block into the k-NN query body. This allows benchmarking the latency/recall tradeoff of disk-based vector search with different oversample factor values.
                                                                                                                                                                             
Includes unit tests.  

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
