### PR TITLE
Add explicit permissions to CI workflow files

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, reopened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,9 @@ on:
           - warning
           - debug
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'docker/**'
 
+permissions:
+  contents: read
+
 jobs:
   test_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -1,5 +1,7 @@
 name: Run Integration Tests
 on: [workflow_dispatch, pull_request]
+permissions:
+  contents: read
 jobs:
   Integration-Tests:
     strategy:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,7 @@
 name: Run Unit Tests
 on: [workflow_dispatch, pull_request]
+permissions:
+  contents: read
 jobs:
   Unit-Tests:
     strategy:


### PR DESCRIPTION
## Summary
- Add explicit `permissions:` blocks to workflow files that were missing them
- `unit-test.yml`, `integ-test.yml`, `dockerfile-lint.yml`, `docker-build.yml` → `contents: read`
- `add-untriaged.yml` → `issues: write`

Follows least-privilege principle for GitHub Actions tokens.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).