### PR TITLE
Add GitHub environment to release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Publish Release to GitHub
+name: Release Workflow
 
 on:
   push:
@@ -6,43 +6,29 @@ on:
       - "*"
 
 jobs:
-  publish-release:
+  release-to-pypi:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
-      issues: write
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-      - id: get_approvers
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_approvers.outputs.approvers }}
-          minimum-approvals: 1
-          issue-title: 'Release opensearch-benchmark'
-          issue-body: "Please approve or deny the release of opensearch-benchmark. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Build project for distribution
-        run: |
-          make build
-          tar zcvf artifacts.tar.gz dist
+        run: make build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Publish release
-        uses: softprops/action-gh-release@v1
+      - name: Release on Github
+        uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: false
           generate_release_notes: true
-          files: artifacts.tar.gz

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -57,15 +57,14 @@ Add backport labels to PRs and commits so that changes can be added to `main` br
     git tag 1.4.0 1.4
 ```
 
-5. Push the tag.  This starts a workflow in Jenkins and creates an automated issue in the OSB repository. The issue needs to be commented on by a maintainer of the repository for the release process to proceed.  The workflow uploads OSB to PyPI and OSB Docker Hub Staging account. Once the workflows are finished publishing OSB to PyPI and OSB Docker Hub staging account, the maintainer who pushed the tag should visit both PyPI and Docker Hub staging to perform the following steps to verify that the artifacts have been properly uploaded.
+5. Push the tag. This triggers the [publish-release.yml](.github/workflows/publish-release.yml) workflow which requires approval from reviewers configured in the `release-approval` GitHub environment before it proceeds. Once approved, the workflow builds and publishes OSB to PyPI using trusted publishers (OIDC authentication) and creates a GitHub release with auto-generated release notes.
 
 ```
     git push origin 1.4.0
 ```
 
-6. Check the progress of release here in the Jenkins console:: https://build.ci.opensearch.org/job/opensearch-benchmark-release/
-    1. For a more detailed look at what's happening, you can take the Build ID (which is the number highlighted in blue beneath "Stage View") and substitute it into this URL: https://build.ci.opensearch.org/blue/organizations/jenkins/opensearch-benchmark-release/detail/opensearch-benchmark-release/<Build ID>/pipeline/
-     2. If failed, inspect the logs.
+6. Check the progress of the release in the GitHub Actions tab of the repository.
+    1. If failed, inspect the workflow logs.
 
 7. Verify PyPI:
     1. Download the OSB distribution build from PyPI: https://pypi.org/project/opensearch-benchmark/#files.  This is a `wheel` file with the extension `.whl`.


### PR DESCRIPTION
### Description
Add GitHub environment to release workflow

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
