### PR TITLE
Accept space_type as configurable parameter in script score filter queries

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1099,6 +1099,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_ALLOW_PARTIAL_RESULTS = "allow_partial_search_results"
     PARAMS_NAME_OVERSAMPLE_FACTOR = "oversample_factor"
     PARAMS_NAME_RESCORE = "rescore"
+    PARAMS_NAME_SPACE_TYPE = "space_type"
 
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
@@ -1128,6 +1129,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
+        self.space_type = params.get(self.PARAMS_NAME_SPACE_TYPE, "l2")
 
 
         if self.PARAMS_NAME_FILTER in params:
@@ -1272,7 +1274,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
                         "params": {
                             "field": self.field_name,
                             "query_value": vector,
-                            "space_type": "l2"
+                            "space_type": self.space_type
                         }
                     }
                 }

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3298,6 +3298,70 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
                 }
             )
 
+    def test_script_score_filter_custom_space_type(self):
+        k = 12
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir,
+        )
+        neighbors_data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+        )
+
+        SCRIPT_SCORE_FILTER_BODY = {
+            "bool": {
+                "must": [
+                    {"range": {"rating": {"gte": 8, "lte": 10}}},
+                    {"term": {"parking": "true"}},
+                ]
+            }
+        }
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "neighbors_data_set_path": neighbors_data_set_path,
+            "k": k,
+            "filter_type": "script",
+            "filter_body": SCRIPT_SCORE_FILTER_BODY,
+            "space_type": "cosinesimil",
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params,
+            {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+                "body": {
+                    "size": 100,
+                },
+            },
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+
+        for _ in range(DEFAULT_NUM_VECTORS):
+            params = query_param_source_partition.params()
+            self._check_params_script_score(
+                params,
+                self.DEFAULT_FIELD_NAME,
+                self.DEFAULT_DIMENSION,
+                k,
+                100,
+                SCRIPT_SCORE_FILTER_BODY,
+                "cosinesimil",
+            )
+
+        with self.assertRaises(StopIteration):
+            query_param_source_partition.params()
+
+
     def _check_params(
             self,
             actual_params: dict,
@@ -3366,7 +3430,8 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             expected_dimension: int,
             expected_k: int,
             expected_size=None,
-            expected_script_query=None
+            expected_script_query=None,
+            expected_space_type="l2"
             ):
         body = actual_params.get("body")
         self.assertIsInstance(body, dict)
@@ -3397,8 +3462,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertIsInstance(vector, np.ndarray)
         self.assertEqual(len(list(vector)), expected_dimension)
 
-        space_type = params.get("space_type")
-        self.assertEqual(space_type, "l2") # TODO change this once it's all modifiable.
+        self.assertEqual(params.get("space_type"), expected_space_type)
 
     def test_update_request_params_with_request_params(self):
         k = 12


### PR DESCRIPTION
### Description
Make `space_type` a configurable workload parameter in `VectorSearchPartitionParamSource` instead of hardcoding `"l2"` in script score filter queries. This allows users to benchmark script score queries with any supported distance metric (e.g., `cosinesimil`, `innerproduct`, `l1`, `linf`). Defaults to `"l2"` for backward compatibility.

### Issues Resolved
Resolves #1069

### Testing
- [x] New functionality includes testing

Added `test_script_score_filter_custom_space_type` to verify that a custom space type (`cosinesimil`) is correctly passed through to the generated script score query. Existing `test_script_score_filter` continues to pass, confirming backward compatibility with the default `"l2"`.

Tested on a local cluster (OpenSearch 3.7.0-SNAPSHOT): omitting space_type from a script score query returns Missing parameter [space_type]. It does not fall back to the index mapping, so defaulting to "l2" is necessary.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
