### PR TITLE
Add radial search (max_distance/min_score) recall metrics support

### DIFF
--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1844,6 +1844,15 @@ class GlobalStatsCalculator:
                         duration
                     )
 
+                    result.add_radial_correctness_metrics(
+                        task_name,
+                        task.operation.name,
+                        self.single_latency(task_name, op_type, metric_name="recall@max_distance"),
+                        self.single_latency(task_name, op_type, metric_name="recall@max_distance_1"),
+                        self.single_latency(task_name, op_type, metric_name="recall@min_score"),
+                        self.single_latency(task_name, op_type, metric_name="recall@min_score_1"),
+                    )
+
                     profile_metrics = task.operation.params.get("profile-metrics", None)
                     if profile_metrics:
                         profile_metrics.append("query_time")
@@ -2138,7 +2147,9 @@ class GlobalStats:
                     })
             elif metric == "correctness_metrics":
                 for item in value:
-                    for knn_metric in ["recall@k", "recall@1"]:
+                    for knn_metric in ["recall@k", "recall@1",
+                                       "recall@max_distance", "recall@max_distance_1",
+                                       "recall@min_score", "recall@min_score_1"]:
                         if knn_metric in item:
                             all_results.append({
                                 "task": item["task"],
@@ -2208,6 +2219,20 @@ class GlobalStats:
             "error_rate": error_rate,
             "duration": duration,
             })
+
+    def add_radial_correctness_metrics(self, task, operation, recall_max_dist_stats, recall_max_dist_1_stats,
+                                       recall_min_score_stats, recall_min_score_1_stats):
+        entry = {"task": task, "operation": operation}
+        if recall_max_dist_stats:
+            entry["recall@max_distance"] = recall_max_dist_stats
+        if recall_max_dist_1_stats:
+            entry["recall@max_distance_1"] = recall_max_dist_1_stats
+        if recall_min_score_stats:
+            entry["recall@min_score"] = recall_min_score_stats
+        if recall_min_score_1_stats:
+            entry["recall@min_score_1"] = recall_min_score_1_stats
+        if len(entry) > 2:
+            self.correctness_metrics.append(entry)
 
     def add_profile_metrics(self, task, operation, profile_metrics):
         self.profile_metrics.append({

--- a/osbenchmark/publisher.py
+++ b/osbenchmark/publisher.py
@@ -199,6 +199,12 @@ class SummaryResultsPublisher:
             recall_keys_in_task_dict = "recall@1" in keys and "recall@k" in keys
             if recall_keys_in_task_dict and "mean" in record["recall@1"] and "mean" in record["recall@k"]:
                 metrics_table.extend(self._publish_recall(record, task))
+            radial_max_dist_keys = "recall@max_distance" in keys and "recall@max_distance_1" in keys
+            if radial_max_dist_keys and "mean" in record["recall@max_distance"] and "mean" in record["recall@max_distance_1"]:
+                metrics_table.extend(self._publish_radial_recall(record, task, "max_distance"))
+            radial_min_score_keys = "recall@min_score" in keys and "recall@min_score_1" in keys
+            if radial_min_score_keys and "mean" in record["recall@min_score"] and "mean" in record["recall@min_score_1"]:
+                metrics_table.extend(self._publish_radial_recall(record, task, "min_score"))
 
         for record in stats.profile_metrics:
             task = record["task"]
@@ -255,6 +261,15 @@ class SummaryResultsPublisher:
         return self._join(
             self._line("Mean recall@k", task, recall_k_mean, "", lambda v: "%.2f" % v),
             self._line("Mean recall@1", task, recall_1_mean, "", lambda v: "%.2f" % v)
+        )
+
+    def _publish_radial_recall(self, values, task, query_type):
+        recall_mean = values[f"recall@{query_type}"]["mean"]
+        recall_1_mean = values[f"recall@{query_type}_1"]["mean"]
+
+        return self._join(
+            self._line(f"Mean recall@{query_type}", task, recall_mean, "", lambda v: "%.2f" % v),
+            self._line(f"Mean recall@{query_type}_1", task, recall_1_mean, "", lambda v: "%.2f" % v)
         )
 
     def _publish_profile_metrics(self, metrics, task):

--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -24,8 +24,7 @@ class Context(Enum):
     INDEX = 1
     QUERY = 2
     NEIGHBORS = 3
-    MAX_DISTANCE_NEIGHBORS = 4
-    MIN_SCORE_NEIGHBORS = 5
+    RADIAL_NEIGHBORS = 4
     PARENTS = 6
     ATTRIBUTES = 7
 
@@ -148,11 +147,8 @@ class HDF5DataSet(DataSet):
 
         if context == Context.PARENTS:
             return "parents" # used in nested benchmarks to get the parent document id associated with each vector.
-        if context == Context.MAX_DISTANCE_NEIGHBORS:
-            return "max_distance_neighbors"
-
-        if context == Context.MIN_SCORE_NEIGHBORS:
-            return "min_score_neighbors"
+        if context == Context.RADIAL_NEIGHBORS:
+            return "radial_neighbors"
 
         if context == Context.ATTRIBUTES:
             return "attributes"

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1440,7 +1440,11 @@ class DefaultSamplePostprocessor(SamplePostprocessor):
             if sample.request_meta_data and len(sample.request_meta_data) > 1:
                 self.logger.debug("Found: %s", sample.request_meta_data)
 
-                recall_metric_names = ["recall@k", "recall@1"]
+                recall_metric_names = [
+                    "recall@k", "recall@1",
+                    "recall@max_distance", "recall@max_distance_1",
+                    "recall@min_score", "recall@min_score_1",
+                ]
 
                 for recall_metric_name in recall_metric_names:
                     if recall_metric_name in sample.request_meta_data:

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1100,6 +1100,8 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_OVERSAMPLE_FACTOR = "oversample_factor"
     PARAMS_NAME_RESCORE = "rescore"
     PARAMS_NAME_SPACE_TYPE = "space_type"
+    PARAMS_NAME_MAX_DISTANCE = "max_distance"
+    PARAMS_NAME_MIN_SCORE = "min_score"
 
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
@@ -1116,15 +1118,12 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
         self.oversample_factor = params.get(self.PARAMS_NAME_OVERSAMPLE_FACTOR)
-        has_radial = ("max_distance" in params or "min_score" in params
-                      or "max_distance" in query_params or "min_score" in query_params)
+        has_radial = (self.PARAMS_NAME_MAX_DISTANCE in params or self.PARAMS_NAME_MIN_SCORE in params
+                      or self.PARAMS_NAME_MAX_DISTANCE in query_params or self.PARAMS_NAME_MIN_SCORE in query_params)
         if self.oversample_factor and has_radial:
             raise exceptions.InvalidSyntax(
                 "'oversample_factor' cannot be used with 'max_distance' or 'min_score'. "
                 "Rescoring is only supported with top-k search.")
-        if "max_distance" in params and "min_score" in params:
-            raise exceptions.InvalidSyntax(
-                "'max_distance' and 'min_score' cannot be used together.")
         self.query_params = query_params
         self.query_params.update({
             self.PARAMS_NAME_OPERATION_TYPE: operation_type,
@@ -1132,13 +1131,10 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         })
         if self.k is not None:
             self.query_params[self.PARAMS_NAME_K] = self.k
-        if "max_distance" in params:
-            self.query_params["max_distance"] = params["max_distance"]
-        if "min_score" in params:
-            self.query_params["min_score"] = params["min_score"]
-        if self.k is None and "max_distance" not in self.query_params and "min_score" not in self.query_params:
-            raise exceptions.InvalidSyntax(
-                "Must specify at least one of 'k', 'max_distance', or 'min_score'.")
+        if self.PARAMS_NAME_MAX_DISTANCE in params:
+            self.query_params[self.PARAMS_NAME_MAX_DISTANCE] = params[self.PARAMS_NAME_MAX_DISTANCE]
+        if self.PARAMS_NAME_MIN_SCORE in params:
+            self.query_params[self.PARAMS_NAME_MIN_SCORE] = params[self.PARAMS_NAME_MIN_SCORE]
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
@@ -1180,11 +1176,8 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     def _update_body_params(self, vector):
         # accept body params if passed from workload, else, create empty dictionary
         body_params = self.query_params.get(self.PARAMS_NAME_BODY) or dict()
-        if self.PARAMS_NAME_SIZE not in body_params:
-            if self.k is not None:
-                body_params[self.PARAMS_NAME_SIZE] = self.k
-            elif "max_distance" in self.query_params or "min_score" in self.query_params:
-                body_params[self.PARAMS_NAME_SIZE] = 10000
+        if self.PARAMS_NAME_SIZE not in body_params and self.k is not None:
+            body_params[self.PARAMS_NAME_SIZE] = self.k
         filter_type=self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         filter_body=self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
         efficient_filter = filter_body if filter_type == "efficient" else None
@@ -1207,9 +1200,9 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         if not self.neighbors_data_set_path:
             self.neighbors_data_set_path = self.data_set_path
         # add neighbor instance to partition
-        if "max_distance" in self.query_params:
+        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params:
             neighbors_context = Context.MAX_DISTANCE_NEIGHBORS
-        elif "min_score" in self.query_params:
+        elif self.PARAMS_NAME_MIN_SCORE in self.query_params:
             neighbors_context = Context.MIN_SCORE_NEIGHBORS
         else:
             neighbors_context = Context.NEIGHBORS
@@ -1247,6 +1240,14 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.task_progress = (self.current / self.total, '%')
         return self.query_params
 
+    def _add_search_threshold(self, query):
+        if self.k is not None:
+            query["k"] = self.k
+        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params:
+            query[self.PARAMS_NAME_MAX_DISTANCE] = self.query_params[self.PARAMS_NAME_MAX_DISTANCE]
+        if self.PARAMS_NAME_MIN_SCORE in self.query_params:
+            query[self.PARAMS_NAME_MIN_SCORE] = self.query_params[self.PARAMS_NAME_MIN_SCORE]
+
     def _build_vector_search_query_body(self, vector, efficient_filter=None, filter_type=None, filter_body=None) -> dict:
         """Builds a k-NN request that can be used to execute an approximate nearest
         neighbor search against a k-NN plugin index
@@ -1258,12 +1259,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         query = {
             "vector": vector,
         }
-        if self.k is not None:
-            query["k"] = self.k
-        if "max_distance" in self.query_params:
-            query["max_distance"] = self.query_params["max_distance"]
-        if "min_score" in self.query_params:
-            query["min_score"] = self.query_params["min_score"]
+        self._add_search_threshold(query)
         if efficient_filter:
             query.update({
                 "filter": efficient_filter,

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1200,10 +1200,8 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         if not self.neighbors_data_set_path:
             self.neighbors_data_set_path = self.data_set_path
         # add neighbor instance to partition
-        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params:
-            neighbors_context = Context.MAX_DISTANCE_NEIGHBORS
-        elif self.PARAMS_NAME_MIN_SCORE in self.query_params:
-            neighbors_context = Context.MIN_SCORE_NEIGHBORS
+        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params or self.PARAMS_NAME_MIN_SCORE in self.query_params:
+            neighbors_context = Context.RADIAL_NEIGHBORS
         else:
             neighbors_context = Context.NEIGHBORS
 

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1104,7 +1104,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
         self.logger = logging.getLogger(__name__)
-        self.k = parse_int_parameter(self.PARAMS_NAME_K, params)
+        self.k = parse_int_parameter(self.PARAMS_NAME_K, params) if self.PARAMS_NAME_K in params else None
         self.repetitions = parse_int_parameter(self.PARAMS_NAME_REPETITIONS, params, 1)
         self.current_rep = 1
         self.neighbors_data_set_format = parse_string_parameter(
@@ -1116,16 +1116,29 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
         self.oversample_factor = params.get(self.PARAMS_NAME_OVERSAMPLE_FACTOR)
-        if self.oversample_factor and ("max_distance" in query_params or "min_score" in query_params):
+        has_radial = ("max_distance" in params or "min_score" in params
+                      or "max_distance" in query_params or "min_score" in query_params)
+        if self.oversample_factor and has_radial:
             raise exceptions.InvalidSyntax(
                 "'oversample_factor' cannot be used with 'max_distance' or 'min_score'. "
                 "Rescoring is only supported with top-k search.")
+        if "max_distance" in params and "min_score" in params:
+            raise exceptions.InvalidSyntax(
+                "'max_distance' and 'min_score' cannot be used together.")
         self.query_params = query_params
         self.query_params.update({
-            self.PARAMS_NAME_K: self.k,
             self.PARAMS_NAME_OPERATION_TYPE: operation_type,
             self.PARAMS_NAME_ID_FIELD_NAME: params.get(self.PARAMS_NAME_ID_FIELD_NAME),
         })
+        if self.k is not None:
+            self.query_params[self.PARAMS_NAME_K] = self.k
+        if "max_distance" in params:
+            self.query_params["max_distance"] = params["max_distance"]
+        if "min_score" in params:
+            self.query_params["min_score"] = params["min_score"]
+        if self.k is None and "max_distance" not in self.query_params and "min_score" not in self.query_params:
+            raise exceptions.InvalidSyntax(
+                "Must specify at least one of 'k', 'max_distance', or 'min_score'.")
 
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
@@ -1168,7 +1181,10 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         # accept body params if passed from workload, else, create empty dictionary
         body_params = self.query_params.get(self.PARAMS_NAME_BODY) or dict()
         if self.PARAMS_NAME_SIZE not in body_params:
-            body_params[self.PARAMS_NAME_SIZE] = self.k
+            if self.k is not None:
+                body_params[self.PARAMS_NAME_SIZE] = self.k
+            elif "max_distance" in self.query_params or "min_score" in self.query_params:
+                body_params[self.PARAMS_NAME_SIZE] = 10000
         filter_type=self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         filter_body=self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
         efficient_filter = filter_body if filter_type == "efficient" else None
@@ -1191,8 +1207,15 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         if not self.neighbors_data_set_path:
             self.neighbors_data_set_path = self.data_set_path
         # add neighbor instance to partition
+        if "max_distance" in self.query_params:
+            neighbors_context = Context.MAX_DISTANCE_NEIGHBORS
+        elif "min_score" in self.query_params:
+            neighbors_context = Context.MIN_SCORE_NEIGHBORS
+        else:
+            neighbors_context = Context.NEIGHBORS
+
         partition.neighbors_data_set = get_data_set(
-            self.neighbors_data_set_format, self.neighbors_data_set_path, Context.NEIGHBORS)
+            self.neighbors_data_set_format, self.neighbors_data_set_path, neighbors_context)
         partition.neighbors_data_set.seek(partition.offset)
         return partition
 
@@ -1211,7 +1234,10 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             raise StopIteration
         vector = self.data_set.read(1)[0]
         neighbor = self.neighbors_data_set.read(1)[0]
-        true_neighbors = list(map(str, neighbor[:self.k]))
+        if self.k is not None:
+            true_neighbors = list(map(str, neighbor[:self.k].astype(int)))
+        else:
+            true_neighbors = list(map(str, neighbor[neighbor >= 0].astype(int)))
         self.query_params.update({
             "neighbors": true_neighbors,
         })
@@ -1231,8 +1257,13 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         """
         query = {
             "vector": vector,
-            "k": self.k,
         }
+        if self.k is not None:
+            query["k"] = self.k
+        if "max_distance" in self.query_params:
+            query["max_distance"] = self.query_params["max_distance"]
+        if "min_score" in self.query_params:
+            query["min_score"] = self.query_params["min_score"]
         if efficient_filter:
             query.update({
                 "filter": efficient_filter,

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3400,7 +3400,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertNotIn("k", query)
         self.assertEqual(query["max_distance"], -160.0)
         self.assertNotIn("min_score", query)
-        self.assertEqual(body["size"], 10000)
+        self.assertNotIn("size", body)
         neighbors = params.get("neighbors")
         self.assertIsInstance(neighbors, list)
 
@@ -3442,7 +3442,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertNotIn("k", query)
         self.assertNotIn("max_distance", query)
         self.assertEqual(query["min_score"], 161.0)
-        self.assertEqual(body["size"], 10000)
+        self.assertNotIn("size", body)
         neighbors = params.get("neighbors")
         self.assertIsInstance(neighbors, list)
 
@@ -3455,7 +3455,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             self.data_set_dir
         )
         # Create neighbors with -1 padding (simulating radial ground truth)
-        padded_neighbors = np.full((self.DEFAULT_NUM_VECTORS, 100), -1, dtype=np.float32)
+        padded_neighbors = np.full((self.DEFAULT_NUM_VECTORS, 100), -1, dtype=np.int32)
         for i in range(self.DEFAULT_NUM_VECTORS):
             num_real = 5
             padded_neighbors[i, :num_real] = np.arange(num_real)
@@ -3483,37 +3483,6 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertNotIn("-1", neighbors)
         self.assertNotIn("-1.0", neighbors)
         self.assertEqual(neighbors, ["0", "1", "2", "3", "4"])
-
-    def test_no_k_no_radial_raises_error(self):
-        data_set_path = create_data_set(
-            self.DEFAULT_NUM_VECTORS,
-            self.DEFAULT_DIMENSION,
-            self.DEFAULT_TYPE,
-            Context.QUERY,
-            self.data_set_dir
-        )
-        create_data_set(
-            self.DEFAULT_NUM_VECTORS,
-            self.DEFAULT_DIMENSION,
-            self.DEFAULT_TYPE,
-            Context.NEIGHBORS,
-            self.data_set_dir,
-            data_set_path
-        )
-
-        test_param_source_params = {
-            "field": self.DEFAULT_FIELD_NAME,
-            "data_set_format": self.DEFAULT_TYPE,
-            "data_set_path": data_set_path,
-        }
-        with self.assertRaises(exceptions.InvalidSyntax):
-            VectorSearchPartitionParamSource(
-                workload.Workload(name="unit-test"),
-                test_param_source_params, {
-                    "index": self.DEFAULT_INDEX_NAME,
-                    "request-params": {},
-                }
-            )
 
     def _check_params(
             self,

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3374,7 +3374,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             self.DEFAULT_NUM_VECTORS,
             self.DEFAULT_DIMENSION,
             self.DEFAULT_TYPE,
-            Context.MAX_DISTANCE_NEIGHBORS,
+            Context.RADIAL_NEIGHBORS,
             self.data_set_dir,
             data_set_path
         )
@@ -3416,7 +3416,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             self.DEFAULT_NUM_VECTORS,
             self.DEFAULT_DIMENSION,
             self.DEFAULT_TYPE,
-            Context.MIN_SCORE_NEIGHBORS,
+            Context.RADIAL_NEIGHBORS,
             self.data_set_dir,
             data_set_path
         )
@@ -3460,7 +3460,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             num_real = 5
             padded_neighbors[i, :num_real] = np.arange(num_real)
         with h5py.File(data_set_path, 'a') as hf:
-            hf.create_dataset("max_distance_neighbors", data=padded_neighbors)
+            hf.create_dataset("radial_neighbors", data=padded_neighbors)
 
         test_param_source_params = {
             "field": self.DEFAULT_FIELD_NAME,

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -28,6 +28,7 @@ import shutil
 import tempfile
 from unittest import TestCase
 
+import h5py
 import numpy as np
 
 from osbenchmark import exceptions
@@ -3361,6 +3362,158 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         with self.assertRaises(StopIteration):
             query_param_source_partition.params()
 
+    def test_radial_search_max_distance(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.MAX_DISTANCE_NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "max_distance": -160.0,
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertNotIn("k", query)
+        self.assertEqual(query["max_distance"], -160.0)
+        self.assertNotIn("min_score", query)
+        self.assertEqual(body["size"], 10000)
+        neighbors = params.get("neighbors")
+        self.assertIsInstance(neighbors, list)
+
+    def test_radial_search_min_score(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.MIN_SCORE_NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "min_score": 161.0,
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertNotIn("k", query)
+        self.assertNotIn("max_distance", query)
+        self.assertEqual(query["min_score"], 161.0)
+        self.assertEqual(body["size"], 10000)
+        neighbors = params.get("neighbors")
+        self.assertIsInstance(neighbors, list)
+
+    def test_radial_search_neighbors_filter_padding(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        # Create neighbors with -1 padding (simulating radial ground truth)
+        padded_neighbors = np.full((self.DEFAULT_NUM_VECTORS, 100), -1, dtype=np.float32)
+        for i in range(self.DEFAULT_NUM_VECTORS):
+            num_real = 5
+            padded_neighbors[i, :num_real] = np.arange(num_real)
+        with h5py.File(data_set_path, 'a') as hf:
+            hf.create_dataset("max_distance_neighbors", data=padded_neighbors)
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "max_distance": -160.0,
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+
+        neighbors = params.get("neighbors")
+        self.assertEqual(len(neighbors), 5)
+        self.assertNotIn("-1", neighbors)
+        self.assertNotIn("-1.0", neighbors)
+        self.assertEqual(neighbors, ["0", "1", "2", "3", "4"])
+
+    def test_no_k_no_radial_raises_error(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+        }
+        with self.assertRaises(exceptions.InvalidSyntax):
+            VectorSearchPartitionParamSource(
+                workload.Workload(name="unit-test"),
+                test_param_source_params, {
+                    "index": self.DEFAULT_INDEX_NAME,
+                    "request-params": {},
+                }
+            )
 
     def _check_params(
             self,


### PR DESCRIPTION
- Make k optional for radial search queries (max_distance/min_score)
- Route to correct ground truth context (MAX_DISTANCE_NEIGHBORS/MIN_SCORE_NEIGHBORS)
- Add validation that at least one of k/max_distance/min_score is specified
- Handle variable-length neighbor lists (filter -1 padding) for radial recall
- Wire up radial recall metrics through worker coordinator, metrics, and publisher
- Set size=10000 for radial queries to capture all results within threshold
- Add unit tests for radial search query construction and neighbor filtering

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
