### PR TITLE
Pin aiohttp<3.14 to keep CI green

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,10 @@ install_requires = [
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
     "opensearch-py[async]>=2.5.0,<3.0.0",
+    # Pin aiohttp below 3.14: 3.14 made `stream_writer` mandatory on
+    # ClientResponse.__init__, which breaks osbenchmark/async_connection.py
+    # static-response path. opensearch-py only constrains aiohttp to <4.
+    "aiohttp>=3.9.4,<3.14",
     # License: BSD
     "psutil>=5.8.0",
     # License: MIT


### PR DESCRIPTION
### Description
aiohttp 3.14 (released Nov 2026) made `stream_writer` a mandatory keyword argument on `ClientResponse.__init__`, which breaks `osbenchmark/async_connection.py`'s static-response path. OSB pulls aiohttp transitively through `opensearch-py[async]`, whose only constraint is `<4`, so fresh installs now grab 3.14.x.

CI surfaced this as:
```
osbenchmark/async_connection.py:69:8: E1125: Missing mandatory keyword argument 'stream_writer' in method call (missing-kwoa)
```

Pinning `aiohttp>=3.9.4,<3.14` matches the last known-good range and unblocks `make lint`. A code-side fix can land later if/when we want to track aiohttp's main line.

### Testing
- `pip install -e .` resolves to `aiohttp==3.13.x` after the pin.
- `pylint osbenchmark/async_connection.py` — `E1125` no longer fires (the path simply isn't reachable on <3.14).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.