### PR TITLE
Fix: radial recall empty results

### DIFF
--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1778,8 +1778,9 @@ class Query(Runner):
             add_profile_to_results(response_json, params, result)
 
             if _is_empty_search_results(response_json):
-                self.logger.info("Vector search query returned no results.")
-                return result
+                if "max_distance" not in params and "min_score" not in params:
+                    self.logger.info("Vector search query returned no results.")
+                    return result
 
             if not should_calculate_recall:
                 return result

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1695,7 +1695,7 @@ class Query(Runner):
                 min_num_of_results = len(truth_set)
                 if min_num_of_results == 0:
                     self.logger.info("No neighbors are provided for recall calculation")
-                    return 1
+                    return 1.0
 
                 if enable_top_1_recall:
                     return 1.0 if predictions and predictions[0] in truth_set else 0.0
@@ -1779,7 +1779,7 @@ class Query(Runner):
 
             id_field = parse_string_parameter("id-field-name", params, "_id")
             candidates = []
-            for hit in response_json['hits']['hits']:
+            for hit in response_json.get('hits', {}).get('hits', []):
                 field_value = _get_field_value(hit, id_field)
                 if field_value is None:  # Will add to candidates if field value is present
                     self.logger.warning("No value found for field %s", id_field)

--- a/osbenchmark/worker_coordinator/runner.py
+++ b/osbenchmark/worker_coordinator/runner.py
@@ -1698,18 +1698,10 @@ class Query(Runner):
                     return 1
 
                 if enable_top_1_recall:
-                    min_num_of_results = 1
+                    return 1.0 if predictions and predictions[0] in truth_set else 0.0
 
-                for j in range(min_num_of_results):
-                    if j >= len(predictions):
-                        self.logger.info("No more neighbors in prediction to compare against ground truth.\n"
-                                         "Total neighbors in prediction: [%d].\n"
-                                         "Total neighbors in ground truth: [%d]", len(predictions), min_num_of_results)
-                        break
-                    if predictions[j] in truth_set:
-                        correct += 1.0
-
-                return correct / min_num_of_results
+                correct = len(set(predictions) & set(truth_set))
+                return correct / len(truth_set)
 
             def _set_initial_recall_values(params: dict, result: dict) -> None:
                 # Add recall@k and recall@1 to the initial result only if k is present in the params and calculate_recall is true

--- a/tests/worker_coordinator/runner_test.py
+++ b/tests/worker_coordinator/runner_test.py
@@ -3029,6 +3029,95 @@ class VectorSearchQueryRunnerTests(TestCase):
     @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
     @mock.patch("opensearchpy.OpenSearch")
     @run_async
+    async def test_query_radial_search_empty_results_empty_neighbors(self, opensearch, on_client_request_start, on_client_request_end):
+        search_response = {
+            "timed_out": False,
+            "took": 1,
+            "hits": {
+                "total": {
+                    "value": 0,
+                    "relation": "eq"
+                },
+                "hits": []
+            }
+        }
+        opensearch.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
+
+        query_runner = runner.Query()
+
+        params = {
+            "index": "unittest",
+            "operation-type": "vector-search",
+            "detailed-results": True,
+            "response-compression-enabled": False,
+            "max_distance": 159.29,
+            "neighbors": ["-1", "-1", "-1"],
+            "body": {
+                "query": {
+                    "knn": {
+                        "location": {
+                            "vector": [5, 4],
+                            "max_distance": 159.29
+                        }
+                    }}
+            }
+        }
+
+        async with query_runner:
+            result = await query_runner(opensearch, params)
+
+        self.assertIn("recall@max_distance", result.keys())
+        self.assertEqual(result["recall@max_distance"], 1.0)
+        self.assertIn("recall@max_distance_1", result.keys())
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
+    async def test_query_radial_search_empty_results_with_neighbors(self, opensearch, on_client_request_start, on_client_request_end):
+        search_response = {
+            "timed_out": False,
+            "took": 1,
+            "hits": {
+                "total": {
+                    "value": 0,
+                    "relation": "eq"
+                },
+                "hits": []
+            }
+        }
+        opensearch.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
+
+        query_runner = runner.Query()
+
+        params = {
+            "index": "unittest",
+            "operation-type": "vector-search",
+            "detailed-results": True,
+            "response-compression-enabled": False,
+            "max_distance": 159.29,
+            "neighbors": ["101", "102", "103", "-1"],
+            "body": {
+                "query": {
+                    "knn": {
+                        "location": {
+                            "vector": [5, 4],
+                            "max_distance": 159.29
+                        }
+                    }}
+            }
+        }
+
+        async with query_runner:
+            result = await query_runner(opensearch, params)
+
+        self.assertIn("recall@max_distance", result.keys())
+        self.assertEqual(result["recall@max_distance"], 0.0)
+
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_end')
+    @mock.patch('osbenchmark.client.RequestContextHolder.on_client_request_start')
+    @mock.patch("opensearchpy.OpenSearch")
+    @run_async
     async def test_query_vector_search_with_custom_id_field(self, opensearch, on_client_request_start, on_client_request_end):
         search_response = {
             "timed_out": False,


### PR DESCRIPTION
### Description
- Use set intersection for radial recall calculation instead of positional iteration
- Fix `_is_empty_search_results` early-returning with recall=0 before `calculate_radial_search_recall` could handle the case where both predictions and ground truth are empty (should be recall=1)

### Issues Resolved

### Testing
- Ran radial search benchmark on 10M Cohere dataset (10,000 queries) on both Faiss and Lucene clusters. Verified OSB recall matches manual recall calculation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
