### PR TITLE
Add AGENTS.md and agent playbooks for AI coding assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md
+
+This file is for AI coding assistants (Claude, Codex, Cursor, Aider, etc.) working in this repository. It contains facts an agent needs every session: paths, commands, conventions. Human-oriented context lives in [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Concepts
+
+Terms used throughout the codebase and these docs:
+
+- **Workload**: a benchmarking scenario (e.g., `geonames`, `big5`). Defines indexes, corpora, and test procedures. Workloads live in the separate [opensearch-benchmark-workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) repo.
+- **Test procedure**: a named sequence of operations within a workload (e.g., `append-no-conflicts`, `query-only`). One workload can ship multiple procedures.
+- **Operation**: one logical action (bulk-index, search, refresh, etc.). Each operation has a type defined in `OperationType` (`osbenchmark/workload/workload.py`).
+- **Runner**: the Python class that executes one operation. Subclass of `Runner` in `osbenchmark/worker_coordinator/runner.py`.
+- **Param source**: produces the parameter dict each runner invocation receives. Subclass of `ParamSource` in `osbenchmark/workload/params.py`.
+- **Corpora**: the document datasets a workload ingests, declared in the workload's `corpora` section.
+- **Pipeline**: top-level mode controlling whether OSB provisions a cluster (`from-sources`, `from-distribution`) or only drives an existing one (`benchmark-only`).
+- **Telemetry**: optional pluggable cluster-side data collectors (`node-stats`, `recovery-stats`, `jfr`, etc.). See `osbenchmark/telemetry.py`.
+- **Test run**: one end-to-end invocation of `opensearch-benchmark run`. Results land in `~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json` (also reachable via the `~/.osb` symlink).
+
+## Repository structure
+
+OpenSearch Benchmark (OSB) is a Python macrobenchmarking framework. Key directories:
+
+- `osbenchmark/`: the package. Major subsystems:
+  - `worker_coordinator/`: orchestrates benchmark workers. `runner.py` contains the runner class for every operation type.
+  - `workload/`: workload loading and parameter generation. `workload.py` defines the `OperationType` enum; `params.py` is the parameter source registry.
+  - `builder/`: cluster provisioning logic. Used by `from-sources` and `from-distribution` pipelines; skipped by `benchmark-only`.
+  - `client.py`: async OpenSearch client wrapper and request context manager. Read this before adding a new runner: it defines the `on_client_request_start/end` and `on_request_start/end` hooks every runner uses.
+  - `test_run_orchestrator.py`: top-level orchestration entry point.
+- `tests/`: unit tests. Run with `make test` or `python -m pytest tests/`.
+- `it/`: integration tests. Long-running; require Docker + JDK 17/21. Run with `make it310`.
+- `benchmarks/`: micro-benchmarks for OSB internals (not user-facing benchmarks).
+- `scripts/`: release and CI helpers.
+- `docs/agents/`: agent playbooks (running benchmarks, comparing runs, provisioning targets).
+
+## Build and test
+
+Python 3.10–3.13 supported, minimum 3.10.6 (see `.ci/variables.json`). `pyenv` is required.
+
+```
+make develop           # pyenv install + pip install -e .[develop]
+make test              # unit tests
+make lint              # pylint
+make it310             # full integration suite on Python 3.10 (slow: ~20–30 min, needs Docker + JDK)
+```
+
+`make develop` installs OSB and its dev dependencies into the active Python environment via `pip install -e .`. It does not create a virtualenv. If you want isolation, create one yourself before running `make develop`:
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+make develop
+```
+
+To run a single test file:
+
+```
+python -m pytest tests/worker_coordinator/runner_test.py -q
+python -m pytest tests/worker_coordinator/runner_test.py::TestQuery -q
+```
+
+Use `python -m pytest`, not the bare `pytest` from `pyenv` shims. The shim version often points at a Python without `cbor2` installed and produces misleading `ModuleNotFoundError`.
+
+## Coding conventions
+
+- Match existing style. Don't reformat unrelated code.
+- 4-space indent. snake_case for functions/variables, CapCase for classes.
+- Type hints: add them to new public functions and class attributes you create. When modifying inside an existing untyped function, match the surrounding style: don't leave a function half-typed. Don't sweep through unrelated modules adding hints.
+- Async I/O uses `asyncio`. Runners are `async def __call__(self, opensearch, params)` on a subclass of `Runner`.
+- Logging: `self.logger = logging.getLogger(__name__)`. Don't `print()`.
+- Tests: `unittest.TestCase` subclasses with `async def test_*` methods using `IsolatedAsyncioTestCase` where needed. Test file naming: `<module>_test.py`. Test methods start with `test_`.
+
+## Operation types and runners
+
+Adding a new operation type is a 3-file change:
+
+1. `osbenchmark/workload/workload.py`: add an `OperationType` enum entry (numeric ID must be unique). Update `from_hyphenated_string()`.
+2. `osbenchmark/workload/params.py`: add a `ParamSource` subclass and register it with `register_param_source_for_operation(OperationType.YourOp, YourParamSource)` near the bottom of the file.
+3. `osbenchmark/worker_coordinator/runner.py`: add a `Runner` subclass and register it inside `register_default_runners()`.
+
+Canonical examples to copy from:
+
+- Runner: `Query` in `runner.py` (search-style) or `BulkIndex` (bulk-style).
+- ParamSource: `SearchParamSource` or `BulkIndexParamSource` in `params.py`.
+- Tests: `tests/worker_coordinator/runner_test.py::TestQuery` shows the `AsyncMock` + transport-mock pattern.
+
+Each operation must have:
+- A unique hyphenated name (`OperationType.to_hyphenated_string()` derives it from the enum name)
+- A 1:1 mapping in `register_default_runners()`
+- Documentation in the documentation-website repo at `_benchmark/reference/workloads/operations.md`
+
+### Runner contract
+
+A `Runner` subclass implements `async def __call__(self, opensearch, params)`. Return shape options:
+
+- `None` (or no return statement): framework defaults `weight=1`, `unit="ops"`, `success=True`. Most simple runners do this.
+- A `dict`: must include `weight: int` and `unit: str`. Bulk-style runners also return `success: bool`, `success-count`, `error-count`, and other metadata that flows into the metrics store. See `BulkIndex` for the canonical shape.
+- A `(weight, unit)` tuple is also accepted but is legacy; prefer returning a dict or `None`.
+
+Timing hooks (from `osbenchmark/client.py`): for any runner that issues network requests outside the `opensearch` client (raw `transport.perform_request`, gRPC, custom HTTP), call `request_context_holder.on_client_request_start()` / `on_client_request_end()` around the call so OSB can measure client-observed latency. For most runners that just call `opensearch.search()` / `opensearch.bulk()` etc., the wrapper in `client.py` already handles this.
+
+Exceptions raised from `__call__` are treated as operation failures; OSB records them and continues with the next operation. Don't catch and swallow.
+
+## Database backends
+
+`osbenchmark/database/` defines the pluggable-backend registry. The `DatabaseType` enum (`database/registry.py`) currently includes `OPENSEARCH`, `MILVUS`, and `VESPA`. To add a new backend:
+
+1. Add an entry to `DatabaseType`.
+2. Implement a client factory under `osbenchmark/database/clients/<name>/` following the OpenSearch factory's shape.
+3. Call `register_database(DatabaseType.YOUR_BACKEND, YourClientFactory)` at module-import time.
+
+Per-backend Python deps go in `setup.py` `extras_require`, not the base install: keep the core lean.
+
+## Pull request conventions
+
+- Sign-off required (DCO): `git commit -s`.
+- Reference the issue in the PR body: `Closes #1234`.
+- Title format: short imperative, no period. Match recent commits in `git log --oneline`.
+- One commit per logical change. Squash before opening if you have noise.
+- Tests required for behavior changes. Doc updates required for user-visible changes (link to the matching `documentation-website` PR).
+
+## Common gotchas
+
+- `~/.osb` is a symlink to `~/.benchmark` (set up the first time OSB runs). Either path resolves to the same files. Tools and docs use them interchangeably. Stale config from a previous OSB version produces confusing errors like `No value for mandatory configuration: section='reporting'`. `rm -rf ~/.osb ~/.benchmark` is safe.
+- Forks: `origin` should be your fork, `upstream` should be `opensearch-project/opensearch-benchmark`. Always `git fetch upstream` before checking branch status; `git log upstream/main..HEAD` shows what's actually unmerged.
+- Tests using a real cluster must use the integration test harness (`it/`). Mock OpenSearch with `unittest.mock.AsyncMock`; don't ship tests that hit real network endpoints from `tests/`.
+- The `min-os-version.txt` file gates which OpenSearch versions OSB supports. Update it together with version-specific code paths.
+- Workload changes don't live here: they're in `opensearch-project/opensearch-benchmark-workloads`.
+
+## For benchmark workflows
+
+To actually run benchmarks (locally or against AWS), see `docs/agents/`:
+
+- [`docs/agents/skills/run-benchmark.md`](docs/agents/skills/run-benchmark.md)
+- [`docs/agents/skills/compare-runs.md`](docs/agents/skills/compare-runs.md)
+- [`docs/agents/skills/provision-target.md`](docs/agents/skills/provision-target.md)
+- [`docs/agents/reference/aws-access.md`](docs/agents/reference/aws-access.md)
+- [`docs/agents/reference/troubleshooting.md`](docs/agents/reference/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ How to Contribute
 
 See all details in the [contributor guidelines](<https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/CONTRIBUTING.md>).
 
+For AI coding assistants
+------------------------
+
+If you're using an AI coding assistant (Claude, Codex, Cursor, Aider, etc.) to contribute to this repo, point it at [`AGENTS.md`](AGENTS.md) — it covers repository layout, build commands, conventions, and common gotchas. Playbooks for actually running benchmarks against real clusters live under [`docs/agents/`](docs/agents/).
+
 License
 -------
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,36 @@
+# Agent playbooks
+
+This directory contains playbooks for AI coding assistants (Claude, Codex, Cursor, Aider, local models, etc.) that need to run OpenSearch Benchmark workflows end-to-end: not just edit the OSB codebase.
+
+For repository conventions (build, test, code style, PR guidelines), see [AGENTS.md](../../AGENTS.md) at the repo root.
+
+## When to use what
+
+- **Editing OSB source code:** read [AGENTS.md](../../AGENTS.md). You usually don't need anything here.
+- **Running a benchmark against a cluster:** start with [`skills/run-benchmark.md`](skills/run-benchmark.md).
+- **Comparing two test runs:** [`skills/compare-runs.md`](skills/compare-runs.md).
+- **Spinning up a target cluster on AWS:** [`skills/provision-target.md`](skills/provision-target.md).
+- **Connecting to EC2 instances or refreshing AWS credentials:** [`reference/aws-access.md`](reference/aws-access.md).
+- **Diagnosing a benchmark that failed or produced weird results:** [`reference/troubleshooting.md`](reference/troubleshooting.md).
+
+## Structure
+
+```
+docs/agents/
+├── README.md              # this file
+├── skills/                # task-oriented playbooks ("how do I do X end-to-end")
+│   ├── run-benchmark.md
+│   ├── compare-runs.md
+│   └── provision-target.md
+└── reference/             # cross-cutting context for multiple skills
+    ├── aws-access.md
+    └── troubleshooting.md
+```
+
+Each skill is a self-contained markdown file. It states the goal, lists prerequisites, gives the exact commands to run, and explains what success looks like. Anything account-specific (instance IDs, profile names, IP addresses) is left as a placeholder: the user invoking the agent supplies their own values.
+
+## Contributing
+
+These playbooks are most useful when they reflect what actually works today. If a skill is wrong or stale, fix it in the same PR as the code change. If you discover a new pattern worth keeping, add a skill rather than burying it in a commit message.
+
+Keep skills short. If a playbook grows past ~150 lines, it's probably trying to do two things: split it.

--- a/docs/agents/reference/aws-access.md
+++ b/docs/agents/reference/aws-access.md
@@ -1,0 +1,144 @@
+# Reference: AWS access patterns
+
+Generic patterns for working with AWS resources from an agent session. Specifics (account IDs, instance IDs, profile names, IP ranges) belong in the user's local notes, not here.
+
+## Production safety
+
+Before doing **anything** in AWS:
+
+1. **Confirm which account you're operating in.**
+   ```
+   aws sts get-caller-identity --profile <profile>
+   ```
+   The output includes the account ID. Verify against the account the user specified.
+
+2. **Prefer read-only over write.** `describe`, `list`, `get` first. Only mutate with explicit user direction.
+
+3. **Never tear down infrastructure you didn't create** without explicit user permission. EC2 instances, security groups, IAM roles, CloudFormation stacks: if you didn't make it, it's likely someone else's work in progress.
+
+4. **Assume production when uncertain.** If you can't tell whether a resource is prod or test, treat it as prod and don't touch it.
+
+5. **Destructive operations** (`terminate-instances`, `delete-stack`, `iam delete-role`, `cloudformation destroy`) require explicit user confirmation in the current session. A user permitting them once does not authorize them in future sessions.
+
+## Refreshing credentials
+
+Before assuming credentials are missing, diagnose:
+
+```
+aws sts get-caller-identity                        # account + role currently in use
+echo "${AWS_PROFILE:-default}"                     # which profile is active
+cat ~/.aws/config 2>/dev/null | head              # what profiles are configured
+```
+
+Then use whatever credential mechanism the environment provides: `aws configure sso`, `aws-vault`, IAM Identity Center, named profiles in `~/.aws/credentials`, environment variables, or an organization-specific helper. The skill files in this directory assume the caller has already obtained valid credentials.
+
+If `aws sts get-caller-identity` returns `ExpiredToken` mid-session, refresh and retry the failed command. Never hard-code access keys or session tokens in scripts.
+
+## Accessing EC2 hosts
+
+Two common patterns. SSM is preferred for ephemeral access; SSH is preferred for long-running interactive sessions.
+
+### SSM (preferred for one-shots)
+
+The host must have the SSM agent running and an instance profile with `AmazonSSMManagedInstanceCore`. Most modern AMIs satisfy this.
+
+**Interactive shell:**
+```
+aws ssm start-session --target <instance-id> --region <region> --profile <profile>
+```
+
+**One-shot command:**
+```
+aws ssm send-command \
+  --profile <profile> --region <region> \
+  --instance-ids <instance-id> \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["<command-here>"]' \
+  --query 'Command.CommandId' --output text
+```
+
+This returns a command ID. Poll for the result:
+
+```
+aws ssm get-command-invocation \
+  --profile <profile> --region <region> \
+  --command-id <command-id> --instance-id <instance-id> \
+  --query '[Status,StandardOutputContent,StandardErrorContent]' --output text
+```
+
+Status progresses `Pending → InProgress → Success` (or `Failed`/`TimedOut`). Output truncates around 24 KB: for longer output, redirect to a file on the host and read it back.
+
+### SSM gotchas
+
+- **Quoting:** `send-command` parses the `commands` array as JSON, then the host shell parses it again. Complex commands with nested quotes, parens, ampersands, or heredocs break in opaque ways.
+- **Escape hatch for scripts that resist JSON escaping:** base64-encode the script and decode on the host. Use this only when the script is one-shot. For anything reused, upload it to S3 (or bake it into the AMI/user-data) and invoke by path instead.
+  ```
+  SCRIPT='<your multi-line shell script>'
+  B64=$(echo "$SCRIPT" | base64 | tr -d '\n')
+  aws ssm send-command \
+    --instance-ids <instance-id> \
+    --document-name AWS-RunShellScript \
+    --parameters "{\"commands\":[\"echo $B64 | base64 -d > /tmp/script.sh && bash /tmp/script.sh\"]}" \
+    ...
+  ```
+- **Timeout:** default is 600 seconds. For long jobs (benchmark runs), set `executionTimeout`:
+  ```
+  --parameters '{"commands":["..."],"executionTimeout":["7200"]}'
+  ```
+- **Process groups:** background processes (`&`, `nohup`) started inside `send-command` are killed when the command returns. Use `screen`, `tmux`, or `systemd-run` to detach properly.
+
+### SSH
+
+If the host has an SSH key configured and the security group allows your IP:
+
+```
+ssh -i ~/.ssh/<key>.pem ec2-user@<public-ip-or-private-ip>
+```
+
+SSH preserves the connection through long commands and supports `scp`/`rsync` for file transfer. Prefer SSH when you'll be iterating interactively for more than a few commands.
+
+## Security groups and reachability
+
+A common failure mode is "OSB host can't connect to OS cluster": usually a security group issue.
+
+Diagnose:
+```
+# From the OSB host:
+nc -zv <target-host> <target-port>
+# or
+curl -v <target-host>:<target-port>
+```
+
+If unreachable, check:
+1. Is the target's security group inbound rule allowing the OSB host's security group or CIDR on the right port?
+2. Are both hosts in the same VPC, or connected via peering / transit gateway?
+3. Is the target listening on the right interface (`network.host: 0.0.0.0` vs `127.0.0.1`)?
+
+Don't open security groups to `0.0.0.0/0` to "make it work." Always narrow to the specific source.
+
+## Credential and PII hygiene
+
+- Never commit AWS access keys, session tokens, or `.aws/credentials` files.
+- Strip them from logs before sharing.
+- If a script needs credentials, read them from environment variables or named profiles, not hard-coded.
+
+## Useful commands
+
+```
+# Which account am I in?
+aws sts get-caller-identity --profile <profile>
+
+# List my running instances
+aws ec2 describe-instances --profile <profile> --region <region> \
+  --filters "Name=instance-state-name,Values=running" \
+  --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`Name`].Value|[0],PrivateIpAddress,InstanceType]' \
+  --output table
+
+# Find instances by tag
+aws ec2 describe-instances --profile <profile> --region <region> \
+  --filters "Name=tag:Name,Values=*benchmark*" \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name,LaunchTime]' --output table
+
+# Get console output (useful when SSM/SSH unreachable)
+aws ec2 get-console-output --profile <profile> --instance-id <id> --output text | tail -100
+```

--- a/docs/agents/reference/troubleshooting.md
+++ b/docs/agents/reference/troubleshooting.md
@@ -1,0 +1,85 @@
+# Reference: troubleshooting benchmarks
+
+When a run fails, produces wildly wrong numbers, or won't start, work through these in order. Most problems are in the first three categories.
+
+## Logs to check first
+
+| File | What it contains |
+|---|---|
+| `~/.benchmark/logs/benchmark.log` | OSB's main log. First place to look for any failure. (`~/.osb/logs/benchmark.log` is the same file via symlink.) |
+| `~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json` | Final results + metadata for one run. |
+| stdout/stderr of the `opensearch-benchmark run` invocation | Live progress, summary table. |
+
+If you piped output to a file (`tee ~/osb-run.log`), search that for `[ERROR]` and `Traceback` first.
+
+## Common failure modes
+
+### Won't start
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `No value for mandatory configuration: section='reporting', key='datastore.type'` | Stale config in `~/.osb/` from a previous OSB version | `rm -rf ~/.osb ~/.benchmark` and rerun |
+| `Cannot connect to <host>:<port>` | Network / security group / wrong endpoint | `curl <host>:<port>` from the OSB host first |
+| `ImportError: No module named '...'` | OSB installed via pyenv shim, not venv | `source .venv/bin/activate` and verify with `which opensearch-benchmark` |
+| `Could not find workload [X]` | Workload name typo, or workload repo not synced | `opensearch-benchmark list workloads` to see what's available |
+| `another OSB instance is running` | Stale lock file from a previous crash | Pass `--kill-running-processes` |
+
+### Runs but produces garbage
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Throughput is zero or near-zero | Cluster overloaded, no warmup convergence, error rate spike | Check error count in summary; tail `benchmark.log` for the run; verify cluster health (`_cluster/health?pretty`) |
+| Latency p99 wildly higher than p50 | GC pauses, throttling, contention from concurrent runs | Run alone on the cluster; add `--telemetry=jfr,node-stats` for next run |
+| Numbers don't match a prior run | Different cluster topology, different OSB version, run-to-run noise | Compare cluster configs; use `opensearch-benchmark aggregate` over multiple runs to smooth noise |
+| Operation skipped (zero count in summary) | Bad workload parameter, missing index | Grep `benchmark.log` for the operation name; look for the skip reason |
+| `429 Too Many Requests` repeated | Client load exceeds cluster capacity | Lower `clients` in the workload; or scale up the cluster |
+
+### Run completes but no results saved
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Empty `test_run.json` | Run crashed during write-out (e.g., disk full) | `df -h` on the OSB host; clean `~/.osb/benchmarks/` if needed |
+| Results in OSB but not in metrics datastore | Datastore unreachable or misconfigured | Check `benchmark.ini` reporting section; verify datastore credentials |
+| Datastore writes succeed but values look off | Time zone / unit mismatch between datastore and viewer | Confirm both are using UTC; verify metric units (`ops/s` vs `ops/min`) |
+
+## Diagnosing slow/stuck benchmarks
+
+A benchmark that "isn't doing anything" is usually one of:
+
+1. **In long warmup.** Some workloads (vectorsearch with large datasets) warm up for many minutes. Tail `benchmark.log`; look for `[INFO] Executing warmup` followed by `[INFO] Executing test`.
+2. **Stuck on bulk-ingest.** Check `_cat/indices?v` on the target: is doc count climbing? If yes, just slow ingest. If no, ingest is wedged. Check cluster `_nodes/hot_threads`.
+3. **Network stall.** `tcpdump` or `ss -i` between OSB host and target. If the connection is idle, OSB isn't sending requests.
+4. **Client side bottleneck.** OSB workers waiting on each other or on disk I/O. Check OSB host CPU/disk usage with `top`/`iostat`.
+
+If a run has been stuck for >5x its expected duration, kill it and dig into the log rather than waiting longer.
+
+```
+# Find the specific PID first; never blanket-pkill on a shared host
+pgrep -af opensearch-benchmark
+kill <pid>
+
+# Or, if it's in a screen session
+screen -S <session-name> -X quit
+```
+
+## Capturing more signal for the next run
+
+Telemetry devices are the OSB-built-in way to grab cluster-side metrics during a run:
+
+```
+opensearch-benchmark run \
+  --workload=<...> \
+  --target-hosts=<...> \
+  --telemetry=node-stats,recovery-stats,jfr \
+  --telemetry-params='{"node-stats-include-indices":true}'
+```
+
+Full list: `opensearch-benchmark list telemetry`.
+
+For deeper JVM analysis, `jfr` produces flight-recorder dumps you can open in JMC.
+
+## When to escalate
+
+- The cluster itself is misbehaving (OOM, repeated leader election, slow log noise): that's an OpenSearch issue, not OSB. Hand off to whoever owns the cluster.
+- Reproducible OSB bug (specific workload + parameters always crashes): file at https://github.com/opensearch-project/opensearch-benchmark/issues with the workload, command, and log excerpt.
+- Performance regression on the upstream code path: file with `git bisect` results if possible.

--- a/docs/agents/skills/compare-runs.md
+++ b/docs/agents/skills/compare-runs.md
@@ -1,0 +1,87 @@
+# Skill: compare benchmark runs
+
+Goal: compare two completed OSB test runs to identify regressions or improvements.
+
+## Prerequisites
+
+- Two completed runs whose results are accessible by OSB (same machine, or both pulled into the same `~/.osb/benchmarks/test-runs/` directory).
+- The two run IDs (UUIDs). If you don't have them, list available runs with:
+
+  ```
+  opensearch-benchmark list test-runs
+  ```
+
+## The command
+
+```
+opensearch-benchmark compare \
+  --baseline=<baseline-run-id> \
+  --contender=<contender-run-id>
+```
+
+- `--baseline` is "what we're measuring against" (e.g., last week's run, the version on `main`).
+- `--contender` is "the run we want to evaluate" (e.g., today's run, a feature branch).
+
+OSB prints a delta table per operation: baseline value, contender value, and absolute and percent change.
+
+## Reading the output
+
+Each row is one metric × one operation. Columns:
+
+| Column | Meaning |
+|---|---|
+| `Metric` | Throughput, service-time (latency), error-rate, etc. |
+| `Operation` | The workload operation (e.g., `default`, `query-string`, `term-100`) |
+| `Baseline` | Value from the baseline run |
+| `Contender` | Value from the contender run |
+| `Diff` | Contender minus baseline |
+| `Unit` | `ops/s`, `ms`, `%` |
+
+For throughput, higher contender is improvement. For latency, service-time, and error-rate, lower contender is improvement.
+
+## Aggregating multiple runs
+
+OSB benchmarks have run-to-run variance. A single comparison can mislead. To smooth noise, aggregate several runs into one synthetic run:
+
+```
+opensearch-benchmark aggregate --test-runs=<id1>,<id2>,<id3>
+```
+
+This emits a new test_run ID whose metrics are the median/mean of the input runs. Use that aggregated ID as the baseline or contender for `compare`.
+
+## What to report back to the user
+
+Don't dump the raw delta table. Triage it first using a single noise threshold of ±5% (OSB has real run-to-run variance, so smaller deltas are usually unreliable from a single comparison):
+
+1. **Regressions**: metrics that got worse by more than 5% on operations the user cares about. Surface these first.
+2. **Improvements**: metrics that got better by more than 5%. Useful if the user is validating a change they expected to be a win.
+3. **No-ops**: operations within ±5% of baseline. One sentence is enough: "the remaining N operations are within ±5%."
+4. **Anomalies**: error-rate changes, missing operations in one run but not the other, mean and p99 moving in different directions on the same operation (see "Mean vs. tail latency" below).
+
+Thresholds are noise-floor heuristics, not statistical significance. If the user is making a ship decision, aggregate 3+ runs per side (see below) before quoting a delta.
+
+A useful report shape:
+
+```
+Regressions vs baseline <id-prefix>:
+- query-string service-time p99: 145ms → 198ms (+37%)
+- term-100 throughput: 4,820 ops/s → 4,350 ops/s (-10%)
+
+Improvements:
+- range latency p50: 22ms → 18ms (-18%)
+
+Other 23 metrics are within ±5%.
+```
+
+## Mean vs. tail latency
+
+If mean latency and p99 move in different directions on the same operation (e.g., mean -5% but p99 +30%), report it as a tail-latency regression: the typical request is unchanged or slightly better, but the slow tail got materially worse. Common causes: GC pauses, throttling, lock contention, or other-tenant load on the contender cluster. Don't average mean and p99 into a single "this regressed / improved" verdict: flag both directions separately.
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Test run with id X not found` | Run doesn't exist or is on a different machine | Verify with `opensearch-benchmark list test-runs` |
+| Two runs used different workloads/test-procedures | Comparison is meaningless | Re-run one with matching `--workload` and `--test-procedure` |
+| Wildly different cluster topologies in the two runs | Comparison reflects topology, not code | Use the same cluster (or identically-provisioned ones) for both runs |
+| Throughput moved but latency didn't (or vice versa) | Possible duty-cycle artifact (warmup, throttling, queueing) | Check `~/.benchmark/logs/benchmark.log` for both runs; aggregate multiple runs to confirm |

--- a/docs/agents/skills/provision-target.md
+++ b/docs/agents/skills/provision-target.md
@@ -1,0 +1,118 @@
+# Skill: provision a target cluster
+
+Goal: stand up an OpenSearch cluster on AWS to benchmark against. This is for ephemeral test clusters: production clusters are out of scope.
+
+## When to use this
+
+- You need a fresh cluster for a one-off benchmark.
+- You want to test against a specific OpenSearch version or build that isn't already deployed.
+- Existing clusters are too small, too busy, or have data you don't want to disturb.
+
+If a cluster already exists and you can reach it, use it. Provisioning takes 10-20 minutes and you'll usually want to tear it down after.
+
+## Two approaches
+
+### Option A: opensearch-cluster-cdk (recommended for AWS)
+
+The [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk) repo defines CDK stacks for spinning up OpenSearch on EC2.
+
+```
+git clone https://github.com/opensearch-project/opensearch-cluster-cdk
+cd opensearch-cluster-cdk
+npm install
+cdk deploy \
+  -c distVersion=<x.y.z> \
+  -c serverAccessType=ipv4 \
+  -c restrictServerAccessTo=<your-ip>/32 \
+  -c singleNodeCluster=true \
+  -c securityDisabled=true
+```
+
+Key context flags:
+
+| Flag | Purpose |
+|---|---|
+| `distVersion` | OpenSearch version (e.g., `3.0.0`) |
+| `singleNodeCluster` | `true` for single-node, `false` for cluster with separate data/manager nodes |
+| `dataInstanceType` | Default is `r6g.large`. For perf work, `m5.4xlarge` or larger. |
+| `securityDisabled` | `true` to skip auth. Easier for benchmarks, but never use against shared infra. |
+| `serverAccessType` | `ipv4` or `prefix` (PrefixList) |
+| `restrictServerAccessTo` | CIDR allowed to reach the cluster |
+| `enableRemoteStore` | `true` to enable segment replication / remote store |
+
+Read the repo's README before deploying: flags evolve. After `cdk deploy`, the CloudFormation outputs include the cluster endpoint.
+
+### Option B: tarball install on a single EC2
+
+Faster than CDK if you just need one node:
+
+1. Launch an EC2 instance (e.g., `r7g.4xlarge` running Amazon Linux 2023).
+2. SSH/SSM in.
+3. Download and untar the OpenSearch release:
+   ```
+   wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.0.0/opensearch-3.0.0-linux-arm64.tar.gz
+   tar -xf opensearch-3.0.0-linux-arm64.tar.gz
+   cd opensearch-3.0.0
+   ```
+4. Edit `config/opensearch.yml`:
+   ```
+   discovery.type: single-node
+   plugins.security.disabled: true
+   network.host: 0.0.0.0
+   ```
+5. Increase `vm.max_map_count`:
+   ```
+   sudo sysctl -w vm.max_map_count=262144
+   ```
+6. Start:
+   ```
+   ./opensearch-tar-install.sh
+   ```
+7. Verify from the OSB host:
+   ```
+   curl <ec2-private-ip>:9200/_cluster/health?pretty
+   ```
+
+This is faster to iterate on but you own the lifecycle (start/stop, SG rules, instance termination).
+
+## Sizing guidance
+
+For most workload smoke tests:
+- `r6g.large` is enough: single-node, ~15GB heap, fits most test-mode runs
+- `r7g.4xlarge` for moderate workloads (big5, vectorsearch with small datasets)
+- `r7g.8xlarge` or `m5.8xlarge` for full-scale runs (100GB+ corpora, nyc_taxis)
+
+Match the workload to the cluster. A 250GB workload on a 32GB-RAM node will spend the run thrashing disk.
+
+## Connecting OSB to the new cluster
+
+Once the cluster is up, the OSB invocation is just:
+
+```
+opensearch-benchmark run \
+  --workload=<workload> \
+  --target-hosts=<cluster-ip>:9200 \
+  --pipeline=benchmark-only \
+  --kill-running-processes
+```
+
+If you disabled security, no `--client-options` needed. If you didn't:
+
+```
+--client-options="basic_auth_user:admin,basic_auth_password:<pw>,use_ssl:true,verify_certs:false"
+```
+
+## Teardown
+
+**Don't forget this.** Idle EC2 + EBS volumes cost money.
+
+- CDK: `cdk destroy` from the same directory.
+- Manual: `aws ec2 terminate-instances --instance-ids <id>` and delete any associated EBS volumes that don't auto-delete-on-terminate.
+
+Confirm there are no leftover resources:
+
+```
+aws ec2 describe-instances --filters "Name=instance-state-name,Values=running,stopped" --query 'Reservations[].Instances[].[InstanceId,Tags,LaunchTime]' --output table
+```
+
+If you're operating in someone else's account, **always** confirm before tearing down: instances you didn't create may not be yours to delete. See the production safety notes in [`reference/aws-access.md`](../reference/aws-access.md).

--- a/docs/agents/skills/run-benchmark.md
+++ b/docs/agents/skills/run-benchmark.md
@@ -1,0 +1,102 @@
+# Skill: run a benchmark
+
+Goal: run an OSB benchmark against a target cluster and capture the results.
+
+## Prerequisites
+
+- An OSB checkout with `make develop` already run. See `AGENTS.md` "Build and test" if not.
+- A reachable OpenSearch cluster (HTTP, with auth credentials if it's secured).
+- For long runs on a remote host: ability to reach that host (SSH, SSM, or other; see [`reference/aws-access.md`](../reference/aws-access.md) for AWS patterns).
+
+Values like `<host>`, `<port>`, `<workload-name>`, and `<run-id>` are placeholders. Get them from the user. Do not invent IP addresses, run IDs, or credentials.
+
+## Preflight
+
+Before launching a run, confirm the cluster is reachable from wherever OSB will execute. From the OSB host:
+
+```
+curl -s <host>:<port>/_cluster/health?pretty
+```
+
+A healthy response is JSON containing `"cluster_name"` and a `"status"` of `"green"` or `"yellow"` (`"red"` means the cluster is unhealthy and a benchmark will be misleading). If the curl fails or times out, fix reachability before burning a run: see [`reference/aws-access.md`](../reference/aws-access.md) "Security groups and reachability".
+
+## The minimum command
+
+```
+opensearch-benchmark run \
+  --workload=<workload-name> \
+  --target-hosts=<host>:<port> \
+  --pipeline=benchmark-only
+```
+
+- `--workload`: which workload to run (`geonames`, `big5`, `nyc_taxis`, `pmc`, `vectorsearch`, `http_logs`, `so`, etc.). See [opensearch-benchmark-workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) for the full set.
+- `--target-hosts`: cluster endpoint. Multiple hosts: comma-separated.
+- `--pipeline=benchmark-only`: skip cluster provisioning. The cluster already exists.
+
+For a smoke test (small dataset, fast finish), add `--test-mode`.
+
+If the run fails with "another OSB instance is running", check first with `pgrep -af opensearch-benchmark`. If the PID belongs to someone else's work, leave it alone. Only add `--kill-running-processes` once you've confirmed the lock is stale (no live PID, or a PID you own).
+
+## Common additions
+
+- **Auth, basic over HTTP** (security disabled or proxy-terminated TLS): `--client-options="basic_auth_user:admin,basic_auth_password:<pw>"`
+- **Auth, basic over HTTPS with self-signed cert** (typical secured cluster): `--client-options="basic_auth_user:admin,basic_auth_password:<pw>,use_ssl:true,verify_certs:false"`
+- **Auth, sigv4** (AWS-managed OpenSearch): `--client-options="amazon_aws_log_in:environment,region:us-west-2,service:es"`
+- **Workload params:** `--workload-params='{"number_of_shards":"1","number_of_replicas":"0"}'`
+- **Local workload checkout** (e.g., to test changes to a workload before they're published): `--workload-path=/path/to/opensearch-benchmark-workloads/<workload-name>`. By default OSB clones the workloads repo to `~/.benchmark/workloads/` and uses that.
+- **Specific test procedure:** `--test-procedure=<name>`. List available: `opensearch-benchmark info --workload=<workload-name>`.
+- **Tag the run:** `--user-tag="purpose:baseline,branch:main"`. Tags are searchable when comparing runs later.
+- **Telemetry:** `--telemetry=node-stats,recovery-stats` (full list: `opensearch-benchmark list telemetry`).
+
+## Long-running runs
+
+Long runs must detach from the invoking shell so the agent doesn't sit blocked for an hour. Pick one of `screen`, `tmux`, or `systemd-run --user --scope`. Plain `nohup ... &` does not survive an SSM `send-command` exit (see [`reference/aws-access.md`](../reference/aws-access.md) SSM gotchas).
+
+Example with `screen`:
+
+```
+screen -dmS osb-run bash -c 'opensearch-benchmark run --workload=big5 --target-hosts=... --pipeline=benchmark-only 2>&1 | tee ~/osb-run.log'
+```
+
+- Tail without attaching: `tail -f ~/osb-run.log`
+- Check status: `screen -ls`
+- Attach to interact: `screen -r osb-run` (detach again with `Ctrl-a d`)
+- Kill: `screen -S osb-run -X quit`
+
+Pick a unique session name per run so concurrent benchmarks don't collide.
+
+## What success looks like
+
+A successful run ends with a summary table printed to stdout and a `test_run.json` written to:
+
+```
+~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json
+```
+
+(`~/.osb` is a symlink to `~/.benchmark` and resolves to the same file.)
+
+`<run-id>` is a UUID printed near the top of the OSB output. Save it: it's what `compare-runs.md` needs.
+
+A few signals that a run is healthy mid-flight (when tailing the log):
+- "[INFO] Executing test on" appears after warmup
+- Throughput and latency numbers are non-zero and not strictly decreasing
+- No repeated `[ERROR]` lines about connection refused, timeouts, or 429s
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Cannot connect to <host>:<port>` | Network/SG blocks OSB host from target | Verify with `curl <host>:<port>` from the OSB host first |
+| `No value for mandatory configuration: section='reporting'` | Stale config in `~/.osb/` or `~/.benchmark/` | `rm -rf ~/.osb ~/.benchmark` and rerun |
+| 401/403 from target | Missing or wrong auth | Add `--client-options` with the right credentials |
+| Run completes but result table is empty | Workload skipped due to a bad parameter | Check `~/.benchmark/logs/benchmark.log` for skipped operations |
+
+For deeper triage see [`reference/troubleshooting.md`](../reference/troubleshooting.md).
+
+## What to report back to the user
+
+When the run finishes, tell the user:
+1. The run ID (UUID from the summary)
+2. Top-line metrics (mean throughput, p50/p90/p99 latencies for the main op)
+3. Anything anomalous (warm-up that never converged, error count >0, throughput collapsed mid-run)
+4. Where the raw results are saved (`~/.osb/benchmarks/test-runs/<run-id>/`)


### PR DESCRIPTION
## Description

OSB users and contributors increasingly work alongside AI coding assistants (Claude, Codex, Cursor, Aider, local models, etc.). This PR adds vendor-neutral context for those tools at two levels:

1. **`AGENTS.md`** at the repo root, following the [agents.md](https://agents.md) convention adopted by other OpenSearch repos (e.g., [opensearch-project/OpenSearch#20780](https://github.com/opensearch-project/OpenSearch/pull/20780)). It documents repository layout, build commands, coding conventions, the operation-type / runner registration pattern (including return-shape contract), and common gotchas specific to this codebase. ~140 lines.

2. **`docs/agents/`** — task-oriented playbooks for workflows beyond editing source code:
   - `skills/run-benchmark.md` — running a benchmark end-to-end (including preflight checks, common auth patterns, long-run detachment, failure-mode triage)
   - `skills/compare-runs.md` — comparing two test runs, aggregating to smooth noise, and reporting verdicts back to the user
   - `skills/provision-target.md` — standing up a target OpenSearch cluster via opensearch-cluster-cdk or a tarball install
   - `reference/aws-access.md` — generic AWS credential refresh, SSM patterns, and reachability checks (no Amazon-internal tooling)
   - `reference/troubleshooting.md` — common OSB failure modes and what to grep for

The README gains a short pointer so AI assistants (and the humans using them) can discover these resources.

## Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.