### PR TITLE
Add optional MCP server exposing OSB as typed tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md
+
+This file is for AI coding assistants (Claude, Codex, Cursor, Aider, etc.) working in this repository. It contains facts an agent needs every session: paths, commands, conventions. Human-oriented context lives in [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Concepts
+
+Terms used throughout the codebase and these docs:
+
+- **Workload**: a benchmarking scenario (e.g., `geonames`, `big5`). Defines indexes, corpora, and test procedures. Workloads live in the separate [opensearch-benchmark-workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) repo.
+- **Test procedure**: a named sequence of operations within a workload (e.g., `append-no-conflicts`, `query-only`). One workload can ship multiple procedures.
+- **Operation**: one logical action (bulk-index, search, refresh, etc.). Each operation has a type defined in `OperationType` (`osbenchmark/workload/workload.py`).
+- **Runner**: the Python class that executes one operation. Subclass of `Runner` in `osbenchmark/worker_coordinator/runner.py`.
+- **Param source**: produces the parameter dict each runner invocation receives. Subclass of `ParamSource` in `osbenchmark/workload/params.py`.
+- **Corpora**: the document datasets a workload ingests, declared in the workload's `corpora` section.
+- **Pipeline**: top-level mode controlling whether OSB provisions a cluster (`from-sources`, `from-distribution`) or only drives an existing one (`benchmark-only`).
+- **Telemetry**: optional pluggable cluster-side data collectors (`node-stats`, `recovery-stats`, `jfr`, etc.). See `osbenchmark/telemetry.py`.
+- **Test run**: one end-to-end invocation of `opensearch-benchmark run`. Results land in `~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json` (also reachable via the `~/.osb` symlink).
+
+## Repository structure
+
+OpenSearch Benchmark (OSB) is a Python macrobenchmarking framework. Key directories:
+
+- `osbenchmark/`: the package. Major subsystems:
+  - `worker_coordinator/`: orchestrates benchmark workers. `runner.py` contains the runner class for every operation type.
+  - `workload/`: workload loading and parameter generation. `workload.py` defines the `OperationType` enum; `params.py` is the parameter source registry.
+  - `builder/`: cluster provisioning logic. Used by `from-sources` and `from-distribution` pipelines; skipped by `benchmark-only`.
+  - `client.py`: async OpenSearch client wrapper and request context manager. Read this before adding a new runner: it defines the `on_client_request_start/end` and `on_request_start/end` hooks every runner uses.
+  - `test_run_orchestrator.py`: top-level orchestration entry point.
+- `tests/`: unit tests. Run with `make test` or `python -m pytest tests/`.
+- `it/`: integration tests. Long-running; require Docker + JDK 17/21. Run with `make it310`.
+- `benchmarks/`: micro-benchmarks for OSB internals (not user-facing benchmarks).
+- `scripts/`: release and CI helpers.
+- `docs/agents/`: agent playbooks (running benchmarks, comparing runs, provisioning targets).
+
+## Build and test
+
+Python 3.10–3.13 supported, minimum 3.10.6 (see `.ci/variables.json`). `pyenv` is required.
+
+```
+make develop           # pyenv install + pip install -e .[develop]
+make test              # unit tests
+make lint              # pylint
+make it310             # full integration suite on Python 3.10 (slow: ~20–30 min, needs Docker + JDK)
+```
+
+`make develop` installs OSB and its dev dependencies into the active Python environment via `pip install -e .`. It does not create a virtualenv. If you want isolation, create one yourself before running `make develop`:
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+make develop
+```
+
+To run a single test file:
+
+```
+python -m pytest tests/worker_coordinator/runner_test.py -q
+python -m pytest tests/worker_coordinator/runner_test.py::TestQuery -q
+```
+
+Use `python -m pytest`, not the bare `pytest` from `pyenv` shims. The shim version often points at a Python without `cbor2` installed and produces misleading `ModuleNotFoundError`.
+
+## Coding conventions
+
+- Match existing style. Don't reformat unrelated code.
+- 4-space indent. snake_case for functions/variables, CapCase for classes.
+- Type hints: add them to new public functions and class attributes you create. When modifying inside an existing untyped function, match the surrounding style: don't leave a function half-typed. Don't sweep through unrelated modules adding hints.
+- Async I/O uses `asyncio`. Runners are `async def __call__(self, opensearch, params)` on a subclass of `Runner`.
+- Logging: `self.logger = logging.getLogger(__name__)`. Don't `print()`.
+- Tests: `unittest.TestCase` subclasses with `async def test_*` methods using `IsolatedAsyncioTestCase` where needed. Test file naming: `<module>_test.py`. Test methods start with `test_`.
+
+## Operation types and runners
+
+Adding a new operation type is a 3-file change:
+
+1. `osbenchmark/workload/workload.py`: add an `OperationType` enum entry (numeric ID must be unique). Update `from_hyphenated_string()`.
+2. `osbenchmark/workload/params.py`: add a `ParamSource` subclass and register it with `register_param_source_for_operation(OperationType.YourOp, YourParamSource)` near the bottom of the file.
+3. `osbenchmark/worker_coordinator/runner.py`: add a `Runner` subclass and register it inside `register_default_runners()`.
+
+Canonical examples to copy from:
+
+- Runner: `Query` in `runner.py` (search-style) or `BulkIndex` (bulk-style).
+- ParamSource: `SearchParamSource` or `BulkIndexParamSource` in `params.py`.
+- Tests: `tests/worker_coordinator/runner_test.py::TestQuery` shows the `AsyncMock` + transport-mock pattern.
+
+Each operation must have:
+- A unique hyphenated name (`OperationType.to_hyphenated_string()` derives it from the enum name)
+- A 1:1 mapping in `register_default_runners()`
+- Documentation in the documentation-website repo at `_benchmark/reference/workloads/operations.md`
+
+### Runner contract
+
+A `Runner` subclass implements `async def __call__(self, opensearch, params)`. Return shape options:
+
+- `None` (or no return statement): framework defaults `weight=1`, `unit="ops"`, `success=True`. Most simple runners do this.
+- A `dict`: must include `weight: int` and `unit: str`. Bulk-style runners also return `success: bool`, `success-count`, `error-count`, and other metadata that flows into the metrics store. See `BulkIndex` for the canonical shape.
+- A `(weight, unit)` tuple is also accepted but is legacy; prefer returning a dict or `None`.
+
+Timing hooks (from `osbenchmark/client.py`): for any runner that issues network requests outside the `opensearch` client (raw `transport.perform_request`, gRPC, custom HTTP), call `request_context_holder.on_client_request_start()` / `on_client_request_end()` around the call so OSB can measure client-observed latency. For most runners that just call `opensearch.search()` / `opensearch.bulk()` etc., the wrapper in `client.py` already handles this.
+
+Exceptions raised from `__call__` are treated as operation failures; OSB records them and continues with the next operation. Don't catch and swallow.
+
+## Database backends
+
+`osbenchmark/database/` defines the pluggable-backend registry. The `DatabaseType` enum (`database/registry.py`) currently includes `OPENSEARCH`, `MILVUS`, and `VESPA`. To add a new backend:
+
+1. Add an entry to `DatabaseType`.
+2. Implement a client factory under `osbenchmark/database/clients/<name>/` following the OpenSearch factory's shape.
+3. Call `register_database(DatabaseType.YOUR_BACKEND, YourClientFactory)` at module-import time.
+
+Per-backend Python deps go in `setup.py` `extras_require`, not the base install: keep the core lean.
+
+## Pull request conventions
+
+- Sign-off required (DCO): `git commit -s`.
+- Reference the issue in the PR body: `Closes #1234`.
+- Title format: short imperative, no period. Match recent commits in `git log --oneline`.
+- One commit per logical change. Squash before opening if you have noise.
+- Tests required for behavior changes. Doc updates required for user-visible changes (link to the matching `documentation-website` PR).
+
+## Common gotchas
+
+- `~/.osb` is a symlink to `~/.benchmark` (set up the first time OSB runs). Either path resolves to the same files. Tools and docs use them interchangeably. Stale config from a previous OSB version produces confusing errors like `No value for mandatory configuration: section='reporting'`. `rm -rf ~/.osb ~/.benchmark` is safe.
+- Forks: `origin` should be your fork, `upstream` should be `opensearch-project/opensearch-benchmark`. Always `git fetch upstream` before checking branch status; `git log upstream/main..HEAD` shows what's actually unmerged.
+- Tests using a real cluster must use the integration test harness (`it/`). Mock OpenSearch with `unittest.mock.AsyncMock`; don't ship tests that hit real network endpoints from `tests/`.
+- The `min-os-version.txt` file gates which OpenSearch versions OSB supports. Update it together with version-specific code paths.
+- Workload changes don't live here: they're in `opensearch-project/opensearch-benchmark-workloads`.
+
+## For benchmark workflows
+
+To actually run benchmarks (locally or against AWS), see `docs/agents/`:
+
+- [`docs/agents/skills/run-benchmark.md`](docs/agents/skills/run-benchmark.md)
+- [`docs/agents/skills/compare-runs.md`](docs/agents/skills/compare-runs.md)
+- [`docs/agents/skills/provision-target.md`](docs/agents/skills/provision-target.md)
+- [`docs/agents/reference/aws-access.md`](docs/agents/reference/aws-access.md)
+- [`docs/agents/reference/troubleshooting.md`](docs/agents/reference/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ How to Contribute
 
 See all details in the [contributor guidelines](<https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/CONTRIBUTING.md>).
 
+For AI coding assistants
+------------------------
+
+If you're using an AI coding assistant (Claude, Codex, Cursor, Aider, etc.) to contribute to this repo, point it at [`AGENTS.md`](AGENTS.md) — it covers repository layout, build commands, conventions, and common gotchas. Playbooks for actually running benchmarks against real clusters live under [`docs/agents/`](docs/agents/).
+
 License
 -------
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,36 @@
+# Agent playbooks
+
+This directory contains playbooks for AI coding assistants (Claude, Codex, Cursor, Aider, local models, etc.) that need to run OpenSearch Benchmark workflows end-to-end: not just edit the OSB codebase.
+
+For repository conventions (build, test, code style, PR guidelines), see [AGENTS.md](../../AGENTS.md) at the repo root.
+
+## When to use what
+
+- **Editing OSB source code:** read [AGENTS.md](../../AGENTS.md). You usually don't need anything here.
+- **Running a benchmark against a cluster:** start with [`skills/run-benchmark.md`](skills/run-benchmark.md).
+- **Comparing two test runs:** [`skills/compare-runs.md`](skills/compare-runs.md).
+- **Spinning up a target cluster on AWS:** [`skills/provision-target.md`](skills/provision-target.md).
+- **Connecting to EC2 instances or refreshing AWS credentials:** [`reference/aws-access.md`](reference/aws-access.md).
+- **Diagnosing a benchmark that failed or produced weird results:** [`reference/troubleshooting.md`](reference/troubleshooting.md).
+
+## Structure
+
+```
+docs/agents/
+├── README.md              # this file
+├── skills/                # task-oriented playbooks ("how do I do X end-to-end")
+│   ├── run-benchmark.md
+│   ├── compare-runs.md
+│   └── provision-target.md
+└── reference/             # cross-cutting context for multiple skills
+    ├── aws-access.md
+    └── troubleshooting.md
+```
+
+Each skill is a self-contained markdown file. It states the goal, lists prerequisites, gives the exact commands to run, and explains what success looks like. Anything account-specific (instance IDs, profile names, IP addresses) is left as a placeholder: the user invoking the agent supplies their own values.
+
+## Contributing
+
+These playbooks are most useful when they reflect what actually works today. If a skill is wrong or stale, fix it in the same PR as the code change. If you discover a new pattern worth keeping, add a skill rather than burying it in a commit message.
+
+Keep skills short. If a playbook grows past ~150 lines, it's probably trying to do two things: split it.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -10,6 +10,7 @@ For repository conventions (build, test, code style, PR guidelines), see [AGENTS
 - **Running a benchmark against a cluster:** start with [`skills/run-benchmark.md`](skills/run-benchmark.md).
 - **Comparing two test runs:** [`skills/compare-runs.md`](skills/compare-runs.md).
 - **Spinning up a target cluster on AWS:** [`skills/provision-target.md`](skills/provision-target.md).
+- **Using OSB through MCP tools** (when available in your LLM client): [`skills/mcp-server.md`](skills/mcp-server.md).
 - **Connecting to EC2 instances or refreshing AWS credentials:** [`reference/aws-access.md`](reference/aws-access.md).
 - **Diagnosing a benchmark that failed or produced weird results:** [`reference/troubleshooting.md`](reference/troubleshooting.md).
 

--- a/docs/agents/reference/aws-access.md
+++ b/docs/agents/reference/aws-access.md
@@ -1,0 +1,144 @@
+# Reference: AWS access patterns
+
+Generic patterns for working with AWS resources from an agent session. Specifics (account IDs, instance IDs, profile names, IP ranges) belong in the user's local notes, not here.
+
+## Production safety
+
+Before doing **anything** in AWS:
+
+1. **Confirm which account you're operating in.**
+   ```
+   aws sts get-caller-identity --profile <profile>
+   ```
+   The output includes the account ID. Verify against the account the user specified.
+
+2. **Prefer read-only over write.** `describe`, `list`, `get` first. Only mutate with explicit user direction.
+
+3. **Never tear down infrastructure you didn't create** without explicit user permission. EC2 instances, security groups, IAM roles, CloudFormation stacks: if you didn't make it, it's likely someone else's work in progress.
+
+4. **Assume production when uncertain.** If you can't tell whether a resource is prod or test, treat it as prod and don't touch it.
+
+5. **Destructive operations** (`terminate-instances`, `delete-stack`, `iam delete-role`, `cloudformation destroy`) require explicit user confirmation in the current session. A user permitting them once does not authorize them in future sessions.
+
+## Refreshing credentials
+
+Before assuming credentials are missing, diagnose:
+
+```
+aws sts get-caller-identity                        # account + role currently in use
+echo "${AWS_PROFILE:-default}"                     # which profile is active
+cat ~/.aws/config 2>/dev/null | head              # what profiles are configured
+```
+
+Then use whatever credential mechanism the environment provides: `aws configure sso`, `aws-vault`, IAM Identity Center, named profiles in `~/.aws/credentials`, environment variables, or an organization-specific helper. The skill files in this directory assume the caller has already obtained valid credentials.
+
+If `aws sts get-caller-identity` returns `ExpiredToken` mid-session, refresh and retry the failed command. Never hard-code access keys or session tokens in scripts.
+
+## Accessing EC2 hosts
+
+Two common patterns. SSM is preferred for ephemeral access; SSH is preferred for long-running interactive sessions.
+
+### SSM (preferred for one-shots)
+
+The host must have the SSM agent running and an instance profile with `AmazonSSMManagedInstanceCore`. Most modern AMIs satisfy this.
+
+**Interactive shell:**
+```
+aws ssm start-session --target <instance-id> --region <region> --profile <profile>
+```
+
+**One-shot command:**
+```
+aws ssm send-command \
+  --profile <profile> --region <region> \
+  --instance-ids <instance-id> \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["<command-here>"]' \
+  --query 'Command.CommandId' --output text
+```
+
+This returns a command ID. Poll for the result:
+
+```
+aws ssm get-command-invocation \
+  --profile <profile> --region <region> \
+  --command-id <command-id> --instance-id <instance-id> \
+  --query '[Status,StandardOutputContent,StandardErrorContent]' --output text
+```
+
+Status progresses `Pending → InProgress → Success` (or `Failed`/`TimedOut`). Output truncates around 24 KB: for longer output, redirect to a file on the host and read it back.
+
+### SSM gotchas
+
+- **Quoting:** `send-command` parses the `commands` array as JSON, then the host shell parses it again. Complex commands with nested quotes, parens, ampersands, or heredocs break in opaque ways.
+- **Escape hatch for scripts that resist JSON escaping:** base64-encode the script and decode on the host. Use this only when the script is one-shot. For anything reused, upload it to S3 (or bake it into the AMI/user-data) and invoke by path instead.
+  ```
+  SCRIPT='<your multi-line shell script>'
+  B64=$(echo "$SCRIPT" | base64 | tr -d '\n')
+  aws ssm send-command \
+    --instance-ids <instance-id> \
+    --document-name AWS-RunShellScript \
+    --parameters "{\"commands\":[\"echo $B64 | base64 -d > /tmp/script.sh && bash /tmp/script.sh\"]}" \
+    ...
+  ```
+- **Timeout:** default is 600 seconds. For long jobs (benchmark runs), set `executionTimeout`:
+  ```
+  --parameters '{"commands":["..."],"executionTimeout":["7200"]}'
+  ```
+- **Process groups:** background processes (`&`, `nohup`) started inside `send-command` are killed when the command returns. Use `screen`, `tmux`, or `systemd-run` to detach properly.
+
+### SSH
+
+If the host has an SSH key configured and the security group allows your IP:
+
+```
+ssh -i ~/.ssh/<key>.pem ec2-user@<public-ip-or-private-ip>
+```
+
+SSH preserves the connection through long commands and supports `scp`/`rsync` for file transfer. Prefer SSH when you'll be iterating interactively for more than a few commands.
+
+## Security groups and reachability
+
+A common failure mode is "OSB host can't connect to OS cluster": usually a security group issue.
+
+Diagnose:
+```
+# From the OSB host:
+nc -zv <target-host> <target-port>
+# or
+curl -v <target-host>:<target-port>
+```
+
+If unreachable, check:
+1. Is the target's security group inbound rule allowing the OSB host's security group or CIDR on the right port?
+2. Are both hosts in the same VPC, or connected via peering / transit gateway?
+3. Is the target listening on the right interface (`network.host: 0.0.0.0` vs `127.0.0.1`)?
+
+Don't open security groups to `0.0.0.0/0` to "make it work." Always narrow to the specific source.
+
+## Credential and PII hygiene
+
+- Never commit AWS access keys, session tokens, or `.aws/credentials` files.
+- Strip them from logs before sharing.
+- If a script needs credentials, read them from environment variables or named profiles, not hard-coded.
+
+## Useful commands
+
+```
+# Which account am I in?
+aws sts get-caller-identity --profile <profile>
+
+# List my running instances
+aws ec2 describe-instances --profile <profile> --region <region> \
+  --filters "Name=instance-state-name,Values=running" \
+  --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`Name`].Value|[0],PrivateIpAddress,InstanceType]' \
+  --output table
+
+# Find instances by tag
+aws ec2 describe-instances --profile <profile> --region <region> \
+  --filters "Name=tag:Name,Values=*benchmark*" \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name,LaunchTime]' --output table
+
+# Get console output (useful when SSM/SSH unreachable)
+aws ec2 get-console-output --profile <profile> --instance-id <id> --output text | tail -100
+```

--- a/docs/agents/reference/troubleshooting.md
+++ b/docs/agents/reference/troubleshooting.md
@@ -1,0 +1,85 @@
+# Reference: troubleshooting benchmarks
+
+When a run fails, produces wildly wrong numbers, or won't start, work through these in order. Most problems are in the first three categories.
+
+## Logs to check first
+
+| File | What it contains |
+|---|---|
+| `~/.benchmark/logs/benchmark.log` | OSB's main log. First place to look for any failure. (`~/.osb/logs/benchmark.log` is the same file via symlink.) |
+| `~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json` | Final results + metadata for one run. |
+| stdout/stderr of the `opensearch-benchmark run` invocation | Live progress, summary table. |
+
+If you piped output to a file (`tee ~/osb-run.log`), search that for `[ERROR]` and `Traceback` first.
+
+## Common failure modes
+
+### Won't start
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `No value for mandatory configuration: section='reporting', key='datastore.type'` | Stale config in `~/.osb/` from a previous OSB version | `rm -rf ~/.osb ~/.benchmark` and rerun |
+| `Cannot connect to <host>:<port>` | Network / security group / wrong endpoint | `curl <host>:<port>` from the OSB host first |
+| `ImportError: No module named '...'` | OSB installed via pyenv shim, not venv | `source .venv/bin/activate` and verify with `which opensearch-benchmark` |
+| `Could not find workload [X]` | Workload name typo, or workload repo not synced | `opensearch-benchmark list workloads` to see what's available |
+| `another OSB instance is running` | Stale lock file from a previous crash | Pass `--kill-running-processes` |
+
+### Runs but produces garbage
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Throughput is zero or near-zero | Cluster overloaded, no warmup convergence, error rate spike | Check error count in summary; tail `benchmark.log` for the run; verify cluster health (`_cluster/health?pretty`) |
+| Latency p99 wildly higher than p50 | GC pauses, throttling, contention from concurrent runs | Run alone on the cluster; add `--telemetry=jfr,node-stats` for next run |
+| Numbers don't match a prior run | Different cluster topology, different OSB version, run-to-run noise | Compare cluster configs; use `opensearch-benchmark aggregate` over multiple runs to smooth noise |
+| Operation skipped (zero count in summary) | Bad workload parameter, missing index | Grep `benchmark.log` for the operation name; look for the skip reason |
+| `429 Too Many Requests` repeated | Client load exceeds cluster capacity | Lower `clients` in the workload; or scale up the cluster |
+
+### Run completes but no results saved
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Empty `test_run.json` | Run crashed during write-out (e.g., disk full) | `df -h` on the OSB host; clean `~/.osb/benchmarks/` if needed |
+| Results in OSB but not in metrics datastore | Datastore unreachable or misconfigured | Check `benchmark.ini` reporting section; verify datastore credentials |
+| Datastore writes succeed but values look off | Time zone / unit mismatch between datastore and viewer | Confirm both are using UTC; verify metric units (`ops/s` vs `ops/min`) |
+
+## Diagnosing slow/stuck benchmarks
+
+A benchmark that "isn't doing anything" is usually one of:
+
+1. **In long warmup.** Some workloads (vectorsearch with large datasets) warm up for many minutes. Tail `benchmark.log`; look for `[INFO] Executing warmup` followed by `[INFO] Executing test`.
+2. **Stuck on bulk-ingest.** Check `_cat/indices?v` on the target: is doc count climbing? If yes, just slow ingest. If no, ingest is wedged. Check cluster `_nodes/hot_threads`.
+3. **Network stall.** `tcpdump` or `ss -i` between OSB host and target. If the connection is idle, OSB isn't sending requests.
+4. **Client side bottleneck.** OSB workers waiting on each other or on disk I/O. Check OSB host CPU/disk usage with `top`/`iostat`.
+
+If a run has been stuck for >5x its expected duration, kill it and dig into the log rather than waiting longer.
+
+```
+# Find the specific PID first; never blanket-pkill on a shared host
+pgrep -af opensearch-benchmark
+kill <pid>
+
+# Or, if it's in a screen session
+screen -S <session-name> -X quit
+```
+
+## Capturing more signal for the next run
+
+Telemetry devices are the OSB-built-in way to grab cluster-side metrics during a run:
+
+```
+opensearch-benchmark run \
+  --workload=<...> \
+  --target-hosts=<...> \
+  --telemetry=node-stats,recovery-stats,jfr \
+  --telemetry-params='{"node-stats-include-indices":true}'
+```
+
+Full list: `opensearch-benchmark list telemetry`.
+
+For deeper JVM analysis, `jfr` produces flight-recorder dumps you can open in JMC.
+
+## When to escalate
+
+- The cluster itself is misbehaving (OOM, repeated leader election, slow log noise): that's an OpenSearch issue, not OSB. Hand off to whoever owns the cluster.
+- Reproducible OSB bug (specific workload + parameters always crashes): file at https://github.com/opensearch-project/opensearch-benchmark/issues with the workload, command, and log excerpt.
+- Performance regression on the upstream code path: file with `git bisect` results if possible.

--- a/docs/agents/skills/compare-runs.md
+++ b/docs/agents/skills/compare-runs.md
@@ -1,0 +1,87 @@
+# Skill: compare benchmark runs
+
+Goal: compare two completed OSB test runs to identify regressions or improvements.
+
+## Prerequisites
+
+- Two completed runs whose results are accessible by OSB (same machine, or both pulled into the same `~/.osb/benchmarks/test-runs/` directory).
+- The two run IDs (UUIDs). If you don't have them, list available runs with:
+
+  ```
+  opensearch-benchmark list test-runs
+  ```
+
+## The command
+
+```
+opensearch-benchmark compare \
+  --baseline=<baseline-run-id> \
+  --contender=<contender-run-id>
+```
+
+- `--baseline` is "what we're measuring against" (e.g., last week's run, the version on `main`).
+- `--contender` is "the run we want to evaluate" (e.g., today's run, a feature branch).
+
+OSB prints a delta table per operation: baseline value, contender value, and absolute and percent change.
+
+## Reading the output
+
+Each row is one metric × one operation. Columns:
+
+| Column | Meaning |
+|---|---|
+| `Metric` | Throughput, service-time (latency), error-rate, etc. |
+| `Operation` | The workload operation (e.g., `default`, `query-string`, `term-100`) |
+| `Baseline` | Value from the baseline run |
+| `Contender` | Value from the contender run |
+| `Diff` | Contender minus baseline |
+| `Unit` | `ops/s`, `ms`, `%` |
+
+For throughput, higher contender is improvement. For latency, service-time, and error-rate, lower contender is improvement.
+
+## Aggregating multiple runs
+
+OSB benchmarks have run-to-run variance. A single comparison can mislead. To smooth noise, aggregate several runs into one synthetic run:
+
+```
+opensearch-benchmark aggregate --test-runs=<id1>,<id2>,<id3>
+```
+
+This emits a new test_run ID whose metrics are the median/mean of the input runs. Use that aggregated ID as the baseline or contender for `compare`.
+
+## What to report back to the user
+
+Don't dump the raw delta table. Triage it first using a single noise threshold of ±5% (OSB has real run-to-run variance, so smaller deltas are usually unreliable from a single comparison):
+
+1. **Regressions**: metrics that got worse by more than 5% on operations the user cares about. Surface these first.
+2. **Improvements**: metrics that got better by more than 5%. Useful if the user is validating a change they expected to be a win.
+3. **No-ops**: operations within ±5% of baseline. One sentence is enough: "the remaining N operations are within ±5%."
+4. **Anomalies**: error-rate changes, missing operations in one run but not the other, mean and p99 moving in different directions on the same operation (see "Mean vs. tail latency" below).
+
+Thresholds are noise-floor heuristics, not statistical significance. If the user is making a ship decision, aggregate 3+ runs per side (see below) before quoting a delta.
+
+A useful report shape:
+
+```
+Regressions vs baseline <id-prefix>:
+- query-string service-time p99: 145ms → 198ms (+37%)
+- term-100 throughput: 4,820 ops/s → 4,350 ops/s (-10%)
+
+Improvements:
+- range latency p50: 22ms → 18ms (-18%)
+
+Other 23 metrics are within ±5%.
+```
+
+## Mean vs. tail latency
+
+If mean latency and p99 move in different directions on the same operation (e.g., mean -5% but p99 +30%), report it as a tail-latency regression: the typical request is unchanged or slightly better, but the slow tail got materially worse. Common causes: GC pauses, throttling, lock contention, or other-tenant load on the contender cluster. Don't average mean and p99 into a single "this regressed / improved" verdict: flag both directions separately.
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Test run with id X not found` | Run doesn't exist or is on a different machine | Verify with `opensearch-benchmark list test-runs` |
+| Two runs used different workloads/test-procedures | Comparison is meaningless | Re-run one with matching `--workload` and `--test-procedure` |
+| Wildly different cluster topologies in the two runs | Comparison reflects topology, not code | Use the same cluster (or identically-provisioned ones) for both runs |
+| Throughput moved but latency didn't (or vice versa) | Possible duty-cycle artifact (warmup, throttling, queueing) | Check `~/.benchmark/logs/benchmark.log` for both runs; aggregate multiple runs to confirm |

--- a/docs/agents/skills/mcp-server.md
+++ b/docs/agents/skills/mcp-server.md
@@ -1,0 +1,64 @@
+# Skill: use the OSB MCP server
+
+Goal: use the OSB MCP tools (instead of shelling out to `opensearch-benchmark` directly) to inspect, compare, and aggregate benchmark runs.
+
+## Prerequisites
+
+- The MCP server is installed and registered with the client running you. If the tools below aren't available in your tool list, the user needs to install it. See [`osbenchmark/mcp/README.md`](../../../osbenchmark/mcp/README.md).
+- Read access to `~/.benchmark/benchmarks/test-runs/` on the machine where the MCP server runs.
+- The `opensearch-benchmark` CLI must be on PATH where the MCP server runs (compare and aggregate shell out to it).
+
+## When to use MCP tools vs. the CLI
+
+Prefer MCP tools when:
+- You need structured data back (typed dicts, not parsed CLI text)
+- You're inside an LLM tool with MCP support
+- You'd otherwise be reading run JSON files by hand
+
+Prefer the CLI when:
+- You need to actually run a benchmark (Phase 1 of the MCP server is read-only)
+- You're scripting from outside an LLM context
+- You need a flag the MCP tool doesn't expose
+
+## Tool catalog
+
+| Tool | Use when |
+|---|---|
+| `osb_list_runs(limit, workload)` | "what did I run yesterday?" or "show me all my big5 runs" |
+| `osb_get_run(run_id)` | "what were the p99 latencies for run X?" |
+| `osb_compare_runs(baseline, contender)` | "did this run regress vs. last week's?" |
+| `osb_aggregate_runs(run_ids)` | "smooth out noise across 3 runs before comparing" |
+| `osb_list_workloads()` | "what workloads are available?" |
+| `osb_list_operations()` | "what operation types could I use in a workload?" |
+
+## Typical interaction
+
+User asks: *"Did the 3.5 vectorsearch run regress vs. 3.4?"*
+
+1. `osb_list_runs(limit=20, workload="vectorsearch")` to find candidate run IDs.
+2. Ask the user which one is baseline and which is contender (or infer from `distribution_version` and `timestamp` fields if obvious).
+3. `osb_compare_runs(baseline=<id>, contender=<id>)` to get the delta table.
+4. Triage and report per [`compare-runs.md`](compare-runs.md) (±5% noise threshold, mean-vs-tail-latency framing).
+
+User asks: *"Smooth out noise — I have three runs on each side."*
+
+1. `osb_aggregate_runs(run_ids=[baseline-1, baseline-2, baseline-3])` → captures the new aggregated baseline ID.
+2. `osb_aggregate_runs(run_ids=[contender-1, contender-2, contender-3])` → new aggregated contender ID.
+3. `osb_compare_runs(baseline=<agg-baseline>, contender=<agg-contender>)` and triage as usual.
+
+## Things to know
+
+- Tool results are JSON-friendly Python dicts. Don't expect dot-notation; use bracket access.
+- All numeric values come back as their original type (`int` for whole numbers, `float` for fractional). Unparseable strings are passed through as strings; check before doing arithmetic.
+- The `service_time` and `latency` fields in `osb_get_run` use the keys `mean`, `p50`, `p90`, `p99`, `p99_9`, `p100` (not OSB's internal `50_0` / `100_0` notation).
+- `osb_get_run` includes a `source_path` field. If the user wants the raw test_run.json (e.g., for a custom analysis), read from there.
+- `osb_compare_runs` writes a temporary CSV file to read OSB's output. The temp file is cleaned up before the tool returns.
+
+## Failure modes
+
+| Symptom | Cause | Action |
+|---|---|---|
+| Tool returns "Could not invoke `opensearch-benchmark`" | CLI not on PATH where the MCP server runs | Ask user to verify their venv / PATH |
+| `osb_get_run` raises FileNotFoundError | Run is on a different machine | Ask user where the run was produced; tools only see local runs |
+| `osb_compare_runs` returns empty list | OSB CLI emitted no comparable metrics (e.g., workloads differ) | Use `osb_list_runs` to confirm workloads match |
+| `osb_aggregate_runs` returns `new_run_id: None` | OSB output format changed; we couldn't extract the new ID | Check `raw_output` field for the actual stdout |

--- a/docs/agents/skills/provision-target.md
+++ b/docs/agents/skills/provision-target.md
@@ -1,0 +1,118 @@
+# Skill: provision a target cluster
+
+Goal: stand up an OpenSearch cluster on AWS to benchmark against. This is for ephemeral test clusters: production clusters are out of scope.
+
+## When to use this
+
+- You need a fresh cluster for a one-off benchmark.
+- You want to test against a specific OpenSearch version or build that isn't already deployed.
+- Existing clusters are too small, too busy, or have data you don't want to disturb.
+
+If a cluster already exists and you can reach it, use it. Provisioning takes 10-20 minutes and you'll usually want to tear it down after.
+
+## Two approaches
+
+### Option A: opensearch-cluster-cdk (recommended for AWS)
+
+The [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk) repo defines CDK stacks for spinning up OpenSearch on EC2.
+
+```
+git clone https://github.com/opensearch-project/opensearch-cluster-cdk
+cd opensearch-cluster-cdk
+npm install
+cdk deploy \
+  -c distVersion=<x.y.z> \
+  -c serverAccessType=ipv4 \
+  -c restrictServerAccessTo=<your-ip>/32 \
+  -c singleNodeCluster=true \
+  -c securityDisabled=true
+```
+
+Key context flags:
+
+| Flag | Purpose |
+|---|---|
+| `distVersion` | OpenSearch version (e.g., `3.0.0`) |
+| `singleNodeCluster` | `true` for single-node, `false` for cluster with separate data/manager nodes |
+| `dataInstanceType` | Default is `r6g.large`. For perf work, `m5.4xlarge` or larger. |
+| `securityDisabled` | `true` to skip auth. Easier for benchmarks, but never use against shared infra. |
+| `serverAccessType` | `ipv4` or `prefix` (PrefixList) |
+| `restrictServerAccessTo` | CIDR allowed to reach the cluster |
+| `enableRemoteStore` | `true` to enable segment replication / remote store |
+
+Read the repo's README before deploying: flags evolve. After `cdk deploy`, the CloudFormation outputs include the cluster endpoint.
+
+### Option B: tarball install on a single EC2
+
+Faster than CDK if you just need one node:
+
+1. Launch an EC2 instance (e.g., `r7g.4xlarge` running Amazon Linux 2023).
+2. SSH/SSM in.
+3. Download and untar the OpenSearch release:
+   ```
+   wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.0.0/opensearch-3.0.0-linux-arm64.tar.gz
+   tar -xf opensearch-3.0.0-linux-arm64.tar.gz
+   cd opensearch-3.0.0
+   ```
+4. Edit `config/opensearch.yml`:
+   ```
+   discovery.type: single-node
+   plugins.security.disabled: true
+   network.host: 0.0.0.0
+   ```
+5. Increase `vm.max_map_count`:
+   ```
+   sudo sysctl -w vm.max_map_count=262144
+   ```
+6. Start:
+   ```
+   ./opensearch-tar-install.sh
+   ```
+7. Verify from the OSB host:
+   ```
+   curl <ec2-private-ip>:9200/_cluster/health?pretty
+   ```
+
+This is faster to iterate on but you own the lifecycle (start/stop, SG rules, instance termination).
+
+## Sizing guidance
+
+For most workload smoke tests:
+- `r6g.large` is enough: single-node, ~15GB heap, fits most test-mode runs
+- `r7g.4xlarge` for moderate workloads (big5, vectorsearch with small datasets)
+- `r7g.8xlarge` or `m5.8xlarge` for full-scale runs (100GB+ corpora, nyc_taxis)
+
+Match the workload to the cluster. A 250GB workload on a 32GB-RAM node will spend the run thrashing disk.
+
+## Connecting OSB to the new cluster
+
+Once the cluster is up, the OSB invocation is just:
+
+```
+opensearch-benchmark run \
+  --workload=<workload> \
+  --target-hosts=<cluster-ip>:9200 \
+  --pipeline=benchmark-only \
+  --kill-running-processes
+```
+
+If you disabled security, no `--client-options` needed. If you didn't:
+
+```
+--client-options="basic_auth_user:admin,basic_auth_password:<pw>,use_ssl:true,verify_certs:false"
+```
+
+## Teardown
+
+**Don't forget this.** Idle EC2 + EBS volumes cost money.
+
+- CDK: `cdk destroy` from the same directory.
+- Manual: `aws ec2 terminate-instances --instance-ids <id>` and delete any associated EBS volumes that don't auto-delete-on-terminate.
+
+Confirm there are no leftover resources:
+
+```
+aws ec2 describe-instances --filters "Name=instance-state-name,Values=running,stopped" --query 'Reservations[].Instances[].[InstanceId,Tags,LaunchTime]' --output table
+```
+
+If you're operating in someone else's account, **always** confirm before tearing down: instances you didn't create may not be yours to delete. See the production safety notes in [`reference/aws-access.md`](../reference/aws-access.md).

--- a/docs/agents/skills/run-benchmark.md
+++ b/docs/agents/skills/run-benchmark.md
@@ -1,0 +1,102 @@
+# Skill: run a benchmark
+
+Goal: run an OSB benchmark against a target cluster and capture the results.
+
+## Prerequisites
+
+- An OSB checkout with `make develop` already run. See `AGENTS.md` "Build and test" if not.
+- A reachable OpenSearch cluster (HTTP, with auth credentials if it's secured).
+- For long runs on a remote host: ability to reach that host (SSH, SSM, or other; see [`reference/aws-access.md`](../reference/aws-access.md) for AWS patterns).
+
+Values like `<host>`, `<port>`, `<workload-name>`, and `<run-id>` are placeholders. Get them from the user. Do not invent IP addresses, run IDs, or credentials.
+
+## Preflight
+
+Before launching a run, confirm the cluster is reachable from wherever OSB will execute. From the OSB host:
+
+```
+curl -s <host>:<port>/_cluster/health?pretty
+```
+
+A healthy response is JSON containing `"cluster_name"` and a `"status"` of `"green"` or `"yellow"` (`"red"` means the cluster is unhealthy and a benchmark will be misleading). If the curl fails or times out, fix reachability before burning a run: see [`reference/aws-access.md`](../reference/aws-access.md) "Security groups and reachability".
+
+## The minimum command
+
+```
+opensearch-benchmark run \
+  --workload=<workload-name> \
+  --target-hosts=<host>:<port> \
+  --pipeline=benchmark-only
+```
+
+- `--workload`: which workload to run (`geonames`, `big5`, `nyc_taxis`, `pmc`, `vectorsearch`, `http_logs`, `so`, etc.). See [opensearch-benchmark-workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) for the full set.
+- `--target-hosts`: cluster endpoint. Multiple hosts: comma-separated.
+- `--pipeline=benchmark-only`: skip cluster provisioning. The cluster already exists.
+
+For a smoke test (small dataset, fast finish), add `--test-mode`.
+
+If the run fails with "another OSB instance is running", check first with `pgrep -af opensearch-benchmark`. If the PID belongs to someone else's work, leave it alone. Only add `--kill-running-processes` once you've confirmed the lock is stale (no live PID, or a PID you own).
+
+## Common additions
+
+- **Auth, basic over HTTP** (security disabled or proxy-terminated TLS): `--client-options="basic_auth_user:admin,basic_auth_password:<pw>"`
+- **Auth, basic over HTTPS with self-signed cert** (typical secured cluster): `--client-options="basic_auth_user:admin,basic_auth_password:<pw>,use_ssl:true,verify_certs:false"`
+- **Auth, sigv4** (AWS-managed OpenSearch): `--client-options="amazon_aws_log_in:environment,region:us-west-2,service:es"`
+- **Workload params:** `--workload-params='{"number_of_shards":"1","number_of_replicas":"0"}'`
+- **Local workload checkout** (e.g., to test changes to a workload before they're published): `--workload-path=/path/to/opensearch-benchmark-workloads/<workload-name>`. By default OSB clones the workloads repo to `~/.benchmark/workloads/` and uses that.
+- **Specific test procedure:** `--test-procedure=<name>`. List available: `opensearch-benchmark info --workload=<workload-name>`.
+- **Tag the run:** `--user-tag="purpose:baseline,branch:main"`. Tags are searchable when comparing runs later.
+- **Telemetry:** `--telemetry=node-stats,recovery-stats` (full list: `opensearch-benchmark list telemetry`).
+
+## Long-running runs
+
+Long runs must detach from the invoking shell so the agent doesn't sit blocked for an hour. Pick one of `screen`, `tmux`, or `systemd-run --user --scope`. Plain `nohup ... &` does not survive an SSM `send-command` exit (see [`reference/aws-access.md`](../reference/aws-access.md) SSM gotchas).
+
+Example with `screen`:
+
+```
+screen -dmS osb-run bash -c 'opensearch-benchmark run --workload=big5 --target-hosts=... --pipeline=benchmark-only 2>&1 | tee ~/osb-run.log'
+```
+
+- Tail without attaching: `tail -f ~/osb-run.log`
+- Check status: `screen -ls`
+- Attach to interact: `screen -r osb-run` (detach again with `Ctrl-a d`)
+- Kill: `screen -S osb-run -X quit`
+
+Pick a unique session name per run so concurrent benchmarks don't collide.
+
+## What success looks like
+
+A successful run ends with a summary table printed to stdout and a `test_run.json` written to:
+
+```
+~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json
+```
+
+(`~/.osb` is a symlink to `~/.benchmark` and resolves to the same file.)
+
+`<run-id>` is a UUID printed near the top of the OSB output. Save it: it's what `compare-runs.md` needs.
+
+A few signals that a run is healthy mid-flight (when tailing the log):
+- "[INFO] Executing test on" appears after warmup
+- Throughput and latency numbers are non-zero and not strictly decreasing
+- No repeated `[ERROR]` lines about connection refused, timeouts, or 429s
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Cannot connect to <host>:<port>` | Network/SG blocks OSB host from target | Verify with `curl <host>:<port>` from the OSB host first |
+| `No value for mandatory configuration: section='reporting'` | Stale config in `~/.osb/` or `~/.benchmark/` | `rm -rf ~/.osb ~/.benchmark` and rerun |
+| 401/403 from target | Missing or wrong auth | Add `--client-options` with the right credentials |
+| Run completes but result table is empty | Workload skipped due to a bad parameter | Check `~/.benchmark/logs/benchmark.log` for skipped operations |
+
+For deeper triage see [`reference/troubleshooting.md`](../reference/troubleshooting.md).
+
+## What to report back to the user
+
+When the run finishes, tell the user:
+1. The run ID (UUID from the summary)
+2. Top-line metrics (mean throughput, p50/p90/p99 latencies for the main op)
+3. Anything anomalous (warm-up that never converged, error count >0, throughput collapsed mid-run)
+4. Where the raw results are saved (`~/.osb/benchmarks/test-runs/<run-id>/`)

--- a/osbenchmark/mcp/README.md
+++ b/osbenchmark/mcp/README.md
@@ -1,0 +1,66 @@
+# OSB MCP server
+
+This is an optional [Model Context Protocol](https://modelcontextprotocol.io) server that exposes OpenSearch Benchmark as typed tools. Once installed, any MCP-capable client (Claude Code, Claude Desktop, Cursor, Cline, Codex CLI) can list runs, fetch run details, compare runs, and explore the OSB operation catalog by calling tools instead of shelling out to the CLI.
+
+Phase 1 is read-only. Running benchmarks via MCP is planned for a follow-up.
+
+## Install
+
+```
+pip install opensearch-benchmark[mcp]
+```
+
+## Configure your MCP client
+
+Easiest path, if you use Claude Code:
+
+```
+claude mcp add opensearch-benchmark opensearch-benchmark-mcp
+```
+
+For other clients, run the installer:
+
+```
+opensearch-benchmark-mcp install                    # auto-detect
+opensearch-benchmark-mcp install --client=cursor
+opensearch-benchmark-mcp install --client=cline
+opensearch-benchmark-mcp install --client=claude-desktop
+opensearch-benchmark-mcp install --print            # just print the config snippet
+```
+
+The installer backs up the existing config to `<path>.bak-<timestamp>` before merging the new server entry, so re-running it is safe.
+
+Restart the client after install for the tools to load.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `osb_list_runs` | List recent test runs, newest first. Optionally filter by workload. |
+| `osb_get_run` | Fetch a structured per-operation summary of one run (throughput, latency p50/p90/p99/p100, service time, error rate, duration). |
+| `osb_compare_runs` | Compare two runs and return per-operation deltas. |
+| `osb_aggregate_runs` | Aggregate multiple runs into one synthetic run for noise smoothing. |
+| `osb_list_workloads` | List workloads OSB can run. |
+| `osb_list_operations` | List every OSB operation type with its hyphenated name. |
+
+All tools are read-only. They never mutate clusters, never submit requests, and never spawn benchmark runs.
+
+## How it works
+
+The server is a local Python process launched as a subprocess by your MCP client. It speaks JSON-RPC over stdio (per the MCP spec) and routes tool calls to the implementations in `osbenchmark/mcp/tools/`.
+
+Read tools read from your local `~/.benchmark/benchmarks/test-runs/` directory directly. Compare and aggregate tools shell out to the `opensearch-benchmark` CLI you already have installed; they don't reimplement that logic.
+
+## Troubleshooting
+
+**Tools don't appear after install.** Restart your MCP client. Most clients only load servers at startup.
+
+**"Could not invoke `opensearch-benchmark`".** The CLI must be on PATH from wherever the MCP server runs. If you installed OSB into a venv, the MCP client also has to launch from that venv.
+
+**Existing config has comments and the installer refuses to touch it.** The installer requires valid JSON. Either strip comments first, or use `--print` to get the snippet and add it manually.
+
+**Config path differs on Windows / Linux.** The installer handles macOS for Claude Desktop. For other OSes use `--print` and add the snippet manually.
+
+## For agent-side usage
+
+If you're an AI assistant being asked to call these tools, see [`docs/agents/skills/mcp-server.md`](../../docs/agents/skills/mcp-server.md) for tool-selection guidance and example interactions.

--- a/osbenchmark/mcp/__init__.py
+++ b/osbenchmark/mcp/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+"""
+MCP (Model Context Protocol) server for OpenSearch Benchmark.
+
+Exposes OSB capability as typed tools that any MCP-capable client
+(Claude Desktop, Claude Code, Cursor, Cline, Codex CLI, etc.) can call.
+
+Phase 1 is read-only: list and inspect test runs, compare and aggregate
+runs, list available workloads and operation types. Running benchmarks
+is intentionally not included in Phase 1.
+
+Install with: pip install opensearch-benchmark[mcp]
+Run with: opensearch-benchmark-mcp
+"""

--- a/osbenchmark/mcp/install.py
+++ b/osbenchmark/mcp/install.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Install subcommand: register opensearch-benchmark-mcp with a local MCP
+client by merging the appropriate config snippet into the client's
+settings file.
+
+Safe by default:
+  - Backs up the existing config to <path>.bak-<timestamp> before writing
+  - Merges the new server entry (does NOT overwrite other servers)
+  - Idempotent (re-running is a no-op if already installed)
+
+Supported clients in Phase 1:
+  - claude-desktop (JSON config)
+  - claude-code (delegates to `claude mcp add`)
+  - cursor (JSON config; path may vary by platform)
+  - cline (JSON config inside VS Code globalStorage)
+
+For anything else, use `--print` to get the JSON snippet and paste it
+into the client's config yourself.
+"""
+
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+_SERVER_NAME = "opensearch-benchmark"
+_SERVER_COMMAND = "opensearch-benchmark-mcp"
+
+
+@dataclass
+class ClientSpec:
+    name: str
+    config_path: Callable[[], Optional[Path]]
+    handler: Callable[[Path, bool], str]
+
+
+def run_install(client: str, print_only: bool) -> None:
+    if client == "auto":
+        installed = _detect_clients()
+        if not installed:
+            print(
+                "No supported MCP client detected. Use --print to get the JSON "
+                "snippet, or pass --client=<name> explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        for spec in installed:
+            _do_install(spec, print_only=print_only)
+        return
+
+    spec = _CLIENTS.get(client)
+    if spec is None:
+        print(f"Unknown client: {client}", file=sys.stderr)
+        sys.exit(2)
+    _do_install(spec, print_only=print_only)
+
+
+def _do_install(spec: ClientSpec, print_only: bool) -> None:
+    if print_only:
+        print(f"\n# {spec.name}")
+        print(_snippet_for_human(spec))
+        return
+    path = spec.config_path()
+    if path is None:
+        print(
+            f"Could not determine config path for {spec.name} on this platform.",
+            file=sys.stderr,
+        )
+        return
+    result = spec.handler(path, print_only)
+    print(result)
+
+
+def _snippet_for_human(spec: ClientSpec) -> str:
+    """Human-readable snippet describing what to add for a client."""
+    if spec.name == "claude-code":
+        return f"  claude mcp add {_SERVER_NAME} {_SERVER_COMMAND}"
+    snippet = {
+        "mcpServers": {
+            _SERVER_NAME: {
+                "command": _SERVER_COMMAND,
+            }
+        }
+    }
+    return json.dumps(snippet, indent=2)
+
+
+# --- per-client handlers ---------------------------------------------------
+
+
+def _claude_desktop_config_path() -> Optional[Path]:
+    system = platform.system()
+    if system == "Darwin":
+        return Path("~/Library/Application Support/Claude/claude_desktop_config.json").expanduser()
+    if system == "Linux":
+        return Path("~/.config/Claude/claude_desktop_config.json").expanduser()
+    if system == "Windows":
+        return Path("~/AppData/Roaming/Claude/claude_desktop_config.json").expanduser()
+    return None
+
+
+def _claude_desktop_install(path: Path, _print_only: bool) -> str:
+    return _merge_json_config(
+        path,
+        {"command": _SERVER_COMMAND},
+        client_label="Claude Desktop",
+    )
+
+
+def _claude_code_config_path() -> Optional[Path]:
+    # claude-code uses its own CLI for config; no static path to write.
+    return Path.home()
+
+
+def _claude_code_install(_path: Path, _print_only: bool) -> str:
+    if shutil.which("claude") is None:
+        return (
+            "Claude Code's `claude` CLI is not on PATH. Install Claude Code "
+            "first, or run with --print to see what to add manually."
+        )
+    result = subprocess.run(
+        ["claude", "mcp", "add", _SERVER_NAME, _SERVER_COMMAND],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return (
+            f"`claude mcp add` failed (exit {result.returncode}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return f"Registered with Claude Code: {result.stdout.strip() or 'ok'}"
+
+
+def _cursor_config_path() -> Optional[Path]:
+    # Cursor stores MCP config in ~/.cursor/mcp.json on most platforms.
+    candidate = Path("~/.cursor/mcp.json").expanduser()
+    return candidate
+
+
+def _cursor_install(path: Path, _print_only: bool) -> str:
+    return _merge_json_config(
+        path,
+        {"command": _SERVER_COMMAND},
+        client_label="Cursor",
+    )
+
+
+def _cline_config_path() -> Optional[Path]:
+    # Cline stores its MCP servers JSON inside VS Code globalStorage. The
+    # exact path varies by VS Code flavor; this covers the most common
+    # ones. Users on a non-standard layout should use --print.
+    candidates = [
+        Path("~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json").expanduser(),
+        Path("~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json").expanduser(),
+        Path("~/AppData/Roaming/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json").expanduser(),
+    ]
+    for path in candidates:
+        if path.parent.exists():
+            return path
+    return None
+
+
+def _cline_install(path: Path, _print_only: bool) -> str:
+    return _merge_json_config(
+        path,
+        {"command": _SERVER_COMMAND},
+        client_label="Cline",
+    )
+
+
+# --- shared JSON-merge helper ----------------------------------------------
+
+
+def _merge_json_config(
+    path: Path,
+    server_entry: dict,
+    client_label: str,
+) -> str:
+    if path.exists():
+        backup = path.with_suffix(path.suffix + f".bak-{int(time.time())}")
+        shutil.copy2(path, backup)
+        try:
+            with path.open() as f:
+                config = json.load(f)
+        except json.JSONDecodeError:
+            return (
+                f"Existing {client_label} config at {path} is not valid JSON. "
+                f"Refusing to overwrite. Fix the file or use --print."
+            )
+        backup_note = f" (backed up to {backup.name})"
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        config = {}
+        backup_note = ""
+
+    servers = config.setdefault("mcpServers", {})
+    if servers.get(_SERVER_NAME) == server_entry:
+        return f"{client_label}: {_SERVER_NAME} already registered at {path}."
+    servers[_SERVER_NAME] = server_entry
+
+    with path.open("w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+    return (
+        f"{client_label}: registered {_SERVER_NAME} in {path}{backup_note}. "
+        f"Restart {client_label} to load the new tools."
+    )
+
+
+# --- client registry --------------------------------------------------------
+
+
+_CLIENTS: Dict[str, ClientSpec] = {
+    "claude-desktop": ClientSpec(
+        name="claude-desktop",
+        config_path=_claude_desktop_config_path,
+        handler=_claude_desktop_install,
+    ),
+    "claude-code": ClientSpec(
+        name="claude-code",
+        config_path=_claude_code_config_path,
+        handler=_claude_code_install,
+    ),
+    "cursor": ClientSpec(
+        name="cursor",
+        config_path=_cursor_config_path,
+        handler=_cursor_install,
+    ),
+    "cline": ClientSpec(
+        name="cline",
+        config_path=_cline_config_path,
+        handler=_cline_install,
+    ),
+}
+
+
+def _detect_clients() -> list:
+    """Return the list of clients we can plausibly install into."""
+    found = []
+    for spec in _CLIENTS.values():
+        if spec.name == "claude-code":
+            if shutil.which("claude") is not None:
+                found.append(spec)
+            continue
+        path = spec.config_path()
+        if path is None:
+            continue
+        # Heuristic: if either the file exists or the parent dir exists,
+        # treat the client as installed.
+        if path.exists() or (path.parent and path.parent.exists()):
+            found.append(spec)
+    return found

--- a/osbenchmark/mcp/server.py
+++ b/osbenchmark/mcp/server.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+"""
+MCP server entry point. Registers all OSB tools with a FastMCP app and
+runs the stdio transport.
+
+Invoked via the `opensearch-benchmark-mcp` console script. MCP clients
+launch this as a subprocess and speak JSON-RPC over stdio.
+"""
+
+import argparse
+import sys
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:
+    print(
+        "The MCP server requires the optional `mcp` extra. "
+        "Install with: pip install opensearch-benchmark[mcp]",
+        file=sys.stderr,
+    )
+    raise
+
+
+_APP_NAME = "opensearch-benchmark"
+_VERSION = "0.1.0"
+
+
+def build_app() -> FastMCP:
+    """Construct the FastMCP app with all tools registered."""
+    app = FastMCP(_APP_NAME)
+    _register_tools(app)
+    return app
+
+
+def _register_tools(app: FastMCP) -> None:
+    """Register every OSB tool on the app. One import per tool module."""
+    from osbenchmark.mcp.tools import catalog, runs, compare
+
+    catalog.register(app)
+    runs.register(app)
+    compare.register(app)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="opensearch-benchmark-mcp",
+        description=(
+            "MCP server exposing OpenSearch Benchmark as typed tools "
+            "for AI coding assistants."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"opensearch-benchmark-mcp {_VERSION}",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    install_parser = subparsers.add_parser(
+        "install",
+        help="Register the MCP server with a local MCP client.",
+    )
+    install_parser.add_argument(
+        "--client",
+        choices=["claude-desktop", "claude-code", "cursor", "cline", "auto"],
+        default="auto",
+        help="Which MCP client to configure (default: auto-detect).",
+    )
+    install_parser.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="Print the JSON config snippet instead of writing to disk.",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "install":
+        from osbenchmark.mcp.install import run_install
+        return run_install(client=args.client, print_only=args.print_only)
+
+    # No subcommand: start the MCP server on stdio.
+    app = build_app()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/osbenchmark/mcp/tools/__init__.py
+++ b/osbenchmark/mcp/tools/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool implementations for the OSB MCP server."""

--- a/osbenchmark/mcp/tools/catalog.py
+++ b/osbenchmark/mcp/tools/catalog.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Catalog tools: enumerate workloads OSB knows about and operation types OSB
+supports. Useful for LLM-driven exploration of "what can I run?" and
+"what operation types could I use when authoring a workload?"
+"""
+
+import json
+import subprocess
+from typing import List, Optional
+
+from osbenchmark.workload.workload import OperationType
+
+
+def register(app) -> None:
+    """Register catalog tools on the FastMCP app."""
+
+    @app.tool()
+    def osb_list_operations() -> List[dict]:
+        """
+        List every OSB operation type, with its hyphenated name (what
+        appears in a workload's `operation-type` field) and whether it is
+        an administrative operation (admin ops are not normally part of
+        measured throughput).
+
+        Use this when authoring a workload to discover which operation
+        types are available. The returned list reflects the OSB version
+        currently installed; new operations show up here as soon as they
+        are added to OSB.
+        """
+        return [
+            {
+                "name": op.name,
+                "hyphenated_name": op.to_hyphenated_string(),
+                "admin_op": op.admin_op,
+            }
+            for op in OperationType
+        ]
+
+    @app.tool()
+    def osb_list_workloads(timeout_seconds: int = 30) -> List[dict]:
+        """
+        List workloads OSB can run. Returns each workload's name and a
+        short description.
+
+        This wraps `opensearch-benchmark list workloads` and inherits its
+        view of which workloads are available locally (anything in
+        `~/.benchmark/workloads/` plus the published default set).
+
+        timeout_seconds: how long to wait for the underlying CLI before
+        giving up. Increase if your workloads repo is on slow storage.
+        """
+        try:
+            result = subprocess.run(
+                ["opensearch-benchmark", "list", "workloads", "--format=json"],
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "Could not invoke `opensearch-benchmark`. Make sure it is on "
+                "PATH and that you have run `pip install opensearch-benchmark[mcp]`."
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"`opensearch-benchmark list workloads` timed out after "
+                f"{timeout_seconds}s."
+            ) from e
+
+        if result.returncode != 0:
+            # OSB doesn't ship --format=json on list yet; fall back to
+            # text parsing.
+            return _parse_text_workload_list(_run_text_workloads(timeout_seconds))
+
+        try:
+            payload = json.loads(result.stdout)
+            return _normalize_workloads(payload)
+        except json.JSONDecodeError:
+            return _parse_text_workload_list(result.stdout)
+
+
+def _run_text_workloads(timeout_seconds: int) -> str:
+    result = subprocess.run(
+        ["opensearch-benchmark", "list", "workloads"],
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`opensearch-benchmark list workloads` failed (exit "
+            f"{result.returncode}): {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout
+
+
+def _parse_text_workload_list(text: str) -> List[dict]:
+    """
+    Parse `osb list workloads` text output. The CLI prints a tabulated
+    table with at least a Name column and optionally a Description
+    column; we extract those.
+
+    Defensive: skips header/divider lines, ignores blanks, and never
+    raises on a format change. If columns can't be located, falls back
+    to one name per data row.
+    """
+    rows: List[dict] = []
+    seen_header = False
+    name_col_start: Optional[int] = None
+    desc_col_start: Optional[int] = None
+
+    def is_divider(line: str) -> bool:
+        # Divider rows are non-empty and contain only dashes, equals,
+        # or spaces (the spaces are gaps between columns).
+        s = line.strip()
+        return bool(s) and set(s) <= {"-", "=", " "}
+
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if is_divider(line):
+            continue
+        if not seen_header:
+            lower = line.lower()
+            if "name" in lower:
+                seen_header = True
+                name_col_start = lower.find("name")
+                desc_col_start = lower.find("description")
+                if desc_col_start == -1:
+                    desc_col_start = None
+            continue
+        if name_col_start is None:
+            rows.append({"name": line.strip(), "description": None})
+            continue
+        if desc_col_start is None:
+            name = line[name_col_start:].strip()
+            description = None
+        else:
+            name = line[name_col_start:desc_col_start].strip()
+            description = line[desc_col_start:].strip() or None
+        if name:
+            rows.append({"name": name, "description": description})
+    return rows
+
+
+def _normalize_workloads(payload) -> List[dict]:
+    """Normalize whatever shape `osb list workloads --format=json` returns
+    into the simple {name, description} contract this tool promises."""
+    if isinstance(payload, list):
+        return [_normalize_one(item) for item in payload]
+    if isinstance(payload, dict) and "workloads" in payload:
+        return [_normalize_one(item) for item in payload["workloads"]]
+    return []
+
+
+def _normalize_one(item) -> dict:
+    if isinstance(item, str):
+        return {"name": item, "description": None}
+    if not isinstance(item, dict):
+        return {"name": str(item), "description": None}
+    return {
+        "name": item.get("name") or item.get("workload"),
+        "description": item.get("description"),
+    }

--- a/osbenchmark/mcp/tools/compare.py
+++ b/osbenchmark/mcp/tools/compare.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Comparison and aggregation tools. Wraps `osb compare` and `osb aggregate`
+as subprocesses, then parses their CSV output into structured rows.
+
+CSV is used in preference to the default markdown so we don't have to
+parse a tabulated table; OSB's CSV output has stable columns:
+Metric, Task, Baseline, Contender, Diff, Unit.
+"""
+
+import csv
+import io
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List
+
+
+_RUN_ID_RE = re.compile(r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b")
+
+
+def register(app) -> None:
+    """Register compare/aggregate tools on the FastMCP app."""
+
+    @app.tool()
+    def osb_compare_runs(
+        baseline: str,
+        contender: str,
+        timeout_seconds: int = 60,
+    ) -> List[dict]:
+        """
+        Compare two OSB test runs and return per-operation deltas.
+
+        Each returned row is {metric, task, baseline, contender, diff,
+        unit}, matching the columns of `osb compare --results-format=csv`.
+        For throughput metrics, contender > baseline is an improvement;
+        for latency / service-time / error-rate metrics, contender <
+        baseline is an improvement.
+
+        baseline: run id of the baseline (the run you are comparing
+            against).
+        contender: run id of the contender (the run you are evaluating).
+        timeout_seconds: how long to wait for `osb compare` before giving
+            up. Comparisons should be fast; bump only if needed.
+        """
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".csv", delete=False
+        ) as tmp:
+            results_path = Path(tmp.name)
+        try:
+            cmd = [
+                "opensearch-benchmark",
+                "compare",
+                f"--baseline={baseline}",
+                f"--contender={contender}",
+                "--results-format=csv",
+                f"--results-file={results_path}",
+            ]
+            _run_subprocess(cmd, timeout_seconds)
+            return _parse_compare_csv(results_path.read_text())
+        finally:
+            try:
+                results_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    @app.tool()
+    def osb_aggregate_runs(
+        run_ids: List[str],
+        timeout_seconds: int = 120,
+    ) -> dict:
+        """
+        Aggregate multiple OSB test runs into a single synthetic run.
+        Returns the new aggregated run id, which you can then pass to
+        osb_get_run or osb_compare_runs to smooth out run-to-run noise.
+
+        run_ids: list of UUIDs to aggregate. All runs should target the
+            same workload and test procedure; mixing across workloads is
+            not meaningful.
+        timeout_seconds: how long to wait for `osb aggregate`. Default
+            120s covers most cases.
+        """
+        if not run_ids:
+            raise ValueError("osb_aggregate_runs requires at least one run id.")
+        joined = ",".join(run_ids)
+        cmd = ["opensearch-benchmark", "aggregate", f"--test-runs={joined}"]
+        output = _run_subprocess(cmd, timeout_seconds)
+
+        # `osb aggregate` prints the new run id somewhere in stdout. Be
+        # tolerant of phrasing changes: grep for any UUID that is NOT one
+        # of the inputs.
+        candidates = set(_RUN_ID_RE.findall(output)) - set(run_ids)
+        new_run_id = next(iter(candidates), None)
+        return {
+            "new_run_id": new_run_id,
+            "source_runs": run_ids,
+            "raw_output": output,
+        }
+
+
+def _run_subprocess(cmd: list, timeout_seconds: int) -> str:
+    """Run an OSB CLI subcommand. Returns combined stdout/stderr text on
+    success; raises RuntimeError on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "Could not invoke `opensearch-benchmark`. Make sure it is on "
+            "PATH and that the [mcp] extra is installed."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"`{' '.join(cmd)}` timed out after {timeout_seconds}s."
+        ) from e
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`{' '.join(cmd)}` failed (exit {result.returncode}). "
+            f"stderr: {result.stderr.strip()}"
+        )
+    return result.stdout + result.stderr
+
+
+def _parse_compare_csv(text: str) -> List[dict]:
+    """
+    Parse the CSV that `osb compare --results-format=csv` writes. The
+    file has a header row: Metric, Task, Baseline, Contender, Diff, Unit.
+    """
+    rows: List[dict] = []
+    reader = csv.DictReader(io.StringIO(text))
+    for row in reader:
+        rows.append(
+            {
+                "metric": row.get("Metric"),
+                "task": row.get("Task"),
+                "baseline": _maybe_number(row.get("Baseline")),
+                "contender": _maybe_number(row.get("Contender")),
+                "diff": _maybe_number(row.get("Diff")),
+                "unit": row.get("Unit"),
+            }
+        )
+    return rows
+
+
+def _maybe_number(value):
+    """Convert numeric strings to int/float; leave non-numeric alone.
+    OSB sometimes emits empty strings, 'N/A', or formatted numbers; pass
+    those through as-is rather than crash."""
+    if value is None:
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    try:
+        if "." in s or "e" in s.lower():
+            return float(s)
+        return int(s)
+    except ValueError:
+        return s

--- a/osbenchmark/mcp/tools/runs.py
+++ b/osbenchmark/mcp/tools/runs.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Run-inspection tools: list completed OSB test runs and fetch the
+metrics summary of any one of them.
+
+Reads from `~/.benchmark/benchmarks/test-runs/<run-id>/test_run.json`,
+which is where OSB persists every run's final report. `~/.osb` is a
+symlink to `~/.benchmark` so both paths resolve to the same files.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import List, Optional
+
+
+def _test_runs_dir() -> Path:
+    """Resolve the test-runs directory, honoring OSB_CONFIG_DIR overrides
+    used by some advanced setups."""
+    override = os.environ.get("OSB_TEST_RUNS_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path("~/.benchmark/benchmarks/test-runs").expanduser()
+
+
+def register(app) -> None:
+    """Register run tools on the FastMCP app."""
+
+    @app.tool()
+    def osb_list_runs(
+        limit: int = 20,
+        workload: Optional[str] = None,
+    ) -> List[dict]:
+        """
+        List recent OSB test runs in reverse-chronological order, newest
+        first. Each row gives enough info to identify and compare runs:
+        run id, timestamp, workload, test procedure, pipeline, and any
+        user tags applied at run time.
+
+        limit: maximum number of runs to return. Default 20.
+        workload: filter to a single workload (e.g., "big5", "geonames").
+            Omit to return runs across all workloads.
+        """
+        runs = _load_all_runs()
+        if workload:
+            runs = [r for r in runs if r.get("workload") == workload]
+        runs.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
+        return runs[: max(0, limit)]
+
+    @app.tool()
+    def osb_get_run(run_id: str) -> dict:
+        """
+        Return a structured summary of one OSB test run by id. Includes
+        per-operation throughput, latency percentiles (p50/p99/p100),
+        service time, error rate, and duration.
+
+        The raw test_run.json file is large (100KB+); this tool extracts
+        the LLM-useful subset. For the full file, read the path returned
+        in the result's `source_path` field.
+
+        run_id: UUID of the run, as printed by OSB at run completion and
+            shown by osb_list_runs.
+        """
+        run_dir = _test_runs_dir() / run_id
+        path = run_dir / "test_run.json"
+        if not path.exists():
+            raise FileNotFoundError(
+                f"No test_run.json found for run id {run_id}. "
+                f"Looked under {run_dir}. "
+                f"Use osb_list_runs to see available run ids."
+            )
+        with path.open() as f:
+            raw = json.load(f)
+        return _summarize_run(raw, source_path=str(path))
+
+
+def _load_all_runs() -> List[dict]:
+    """Walk the test-runs directory and return a summary row per run."""
+    root = _test_runs_dir()
+    if not root.exists():
+        return []
+    rows: List[dict] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        path = entry / "test_run.json"
+        if not path.exists():
+            continue
+        try:
+            with path.open() as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        rows.append(_summarize_row(raw, run_id=entry.name))
+    return rows
+
+
+def _summarize_row(raw: dict, run_id: str) -> dict:
+    """Shape one test_run.json into a listing row."""
+    cluster = raw.get("cluster") or {}
+    return {
+        "run_id": raw.get("test-run-id") or run_id,
+        "timestamp": raw.get("test-run-timestamp"),
+        "workload": raw.get("workload"),
+        "test_procedure": raw.get("test_procedure"),
+        "pipeline": raw.get("pipeline"),
+        "user_tags": raw.get("user-tags") or {},
+        "distribution_version": cluster.get("distribution-version"),
+        "distribution_flavor": cluster.get("distribution-flavor"),
+    }
+
+
+def _summarize_run(raw: dict, source_path: str) -> dict:
+    """Shape one test_run.json into a full-detail summary."""
+    base = _summarize_row(raw, run_id=raw.get("test-run-id") or "")
+    base["source_path"] = source_path
+    base["operations"] = _summarize_op_metrics(
+        raw.get("results", {}).get("op_metrics") or []
+    )
+    return base
+
+
+def _summarize_op_metrics(op_metrics: list) -> List[dict]:
+    """Extract the LLM-useful metric fields per operation."""
+    out: List[dict] = []
+    for op in op_metrics:
+        if not isinstance(op, dict):
+            continue
+        out.append(
+            {
+                "operation": op.get("operation"),
+                "task": op.get("task"),
+                "throughput": _scalar_metric(op.get("throughput")),
+                "latency": _percentile_metric(op.get("latency")),
+                "service_time": _percentile_metric(op.get("service_time")),
+                "error_rate": op.get("error_rate"),
+                "duration_seconds": op.get("duration"),
+            }
+        )
+    return out
+
+
+def _scalar_metric(metric) -> Optional[dict]:
+    """Throughput-style metric: min/mean/median/max/unit."""
+    if not isinstance(metric, dict):
+        return None
+    return {
+        "min": metric.get("min"),
+        "mean": metric.get("mean"),
+        "median": metric.get("median"),
+        "max": metric.get("max"),
+        "unit": metric.get("unit"),
+    }
+
+
+def _percentile_metric(metric) -> Optional[dict]:
+    """Latency/service-time metric. Keep mean + commonly-used percentiles."""
+    if not isinstance(metric, dict):
+        return None
+    return {
+        "mean": metric.get("mean"),
+        "p50": metric.get("50_0"),
+        "p90": metric.get("90_0"),
+        "p99": metric.get("99_0"),
+        "p99_9": metric.get("99_9"),
+        "p100": metric.get("100_0"),
+        "unit": metric.get("unit"),
+    }

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,13 @@ develop_require = [
     "pylint-quotes==0.2.1"
 ]
 
+# Optional: MCP server exposing OSB as typed tools to AI coding assistants.
+# Install with: pip install opensearch-benchmark[mcp]
+mcp_require = [
+    # License: MIT
+    "mcp>=1.0.0",
+]
+
 python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor)
                               for major, minor in supported_python_versions]
 
@@ -202,12 +209,14 @@ setup(name="opensearch-benchmark",
       test_suite="tests",
       tests_require=tests_require,
       extras_require={
-          "develop": tests_require + develop_require
+          "develop": tests_require + develop_require,
+          "mcp": mcp_require,
       },
       entry_points={
           "console_scripts": [
               "opensearch-benchmark=osbenchmark.benchmark:main",
               "opensearch-benchmarkd=osbenchmark.benchmarkd:main",
+              "opensearch-benchmark-mcp=osbenchmark.mcp.server:main",
               "osb=osbenchmark.benchmark:main",
               "osbd=osbenchmark.benchmarkd:main",
           ],

--- a/tests/mcp/__init__.py
+++ b/tests/mcp/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for MCP tool tests."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fake_test_runs_dir(tmp_path, monkeypatch):
+    """
+    Build a temporary directory shaped like ~/.benchmark/benchmarks/test-runs/
+    with the two fixture runs in it. Point the MCP tools at this dir via
+    OSB_TEST_RUNS_DIR.
+    """
+    runs_root = tmp_path / "test-runs"
+    runs_root.mkdir()
+
+    for name in ("test_run_a.json", "test_run_b.json"):
+        raw = json.loads((FIXTURES_DIR / name).read_text())
+        run_id = raw["test-run-id"]
+        run_dir = runs_root / run_id
+        run_dir.mkdir()
+        (run_dir / "test_run.json").write_text(json.dumps(raw))
+
+    monkeypatch.setenv("OSB_TEST_RUNS_DIR", str(runs_root))
+    return runs_root

--- a/tests/mcp/fixtures/test_run_a.json
+++ b/tests/mcp/fixtures/test_run_a.json
@@ -1,0 +1,27 @@
+{
+  "benchmark-version": "1.18.0",
+  "test-run-id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "test-run-timestamp": "20260101T000000Z",
+  "pipeline": "benchmark-only",
+  "user-tags": {"purpose": "baseline"},
+  "workload": "geonames",
+  "test_procedure": "append-no-conflicts",
+  "cluster": {
+    "distribution-version": "3.0.0",
+    "distribution-flavor": "oss",
+    "cluster-config-revision": "abcdef"
+  },
+  "results": {
+    "op_metrics": [
+      {
+        "task": "index-append",
+        "operation": "index-append",
+        "throughput": {"min": 100, "mean": 110, "median": 108, "max": 120, "unit": "docs/s"},
+        "latency": {"50_0": 50, "90_0": 60, "99_0": 80, "mean": 55, "unit": "ms"},
+        "service_time": {"50_0": 49, "90_0": 59, "99_0": 79, "mean": 54, "unit": "ms"},
+        "error_rate": 0.0,
+        "duration": 10.5
+      }
+    ]
+  }
+}

--- a/tests/mcp/fixtures/test_run_b.json
+++ b/tests/mcp/fixtures/test_run_b.json
@@ -1,0 +1,27 @@
+{
+  "benchmark-version": "1.18.0",
+  "test-run-id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "test-run-timestamp": "20260102T000000Z",
+  "pipeline": "benchmark-only",
+  "user-tags": {"purpose": "contender"},
+  "workload": "geonames",
+  "test_procedure": "append-no-conflicts",
+  "cluster": {
+    "distribution-version": "3.1.0",
+    "distribution-flavor": "oss",
+    "cluster-config-revision": "fedcba"
+  },
+  "results": {
+    "op_metrics": [
+      {
+        "task": "index-append",
+        "operation": "index-append",
+        "throughput": {"min": 95, "mean": 105, "median": 103, "max": 115, "unit": "docs/s"},
+        "latency": {"50_0": 52, "90_0": 65, "99_0": 90, "mean": 58, "unit": "ms"},
+        "service_time": {"50_0": 51, "90_0": 64, "99_0": 89, "mean": 57, "unit": "ms"},
+        "error_rate": 0.001,
+        "duration": 10.7
+      }
+    ]
+  }
+}

--- a/tests/mcp/test_catalog.py
+++ b/tests/mcp/test_catalog.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for catalog.py (osb_list_operations, osb_list_workloads)."""
+
+from osbenchmark.mcp.tools import catalog
+from osbenchmark.workload.workload import OperationType
+
+
+def test_list_operations_text_parser_extracts_rows():
+    text = """
+Available workloads:
+
+Name              Description
+----              -----------
+big5              Big5 mixed query/index workload
+geonames          Geonames workload from rally
+http_logs         HTTP logs workload
+"""
+    rows = catalog._parse_text_workload_list(text)
+    names = [r["name"] for r in rows]
+    assert names == ["big5", "geonames", "http_logs"]
+    assert rows[1]["description"] == "Geonames workload from rally"
+
+
+def test_list_operations_text_parser_tolerates_no_description_column():
+    text = """
+Name
+----
+big5
+geonames
+"""
+    rows = catalog._parse_text_workload_list(text)
+    assert {r["name"] for r in rows} == {"big5", "geonames"}
+
+
+def test_normalize_workloads_handles_listed_dicts():
+    payload = [
+        {"name": "big5", "description": "mixed"},
+        {"name": "geonames", "description": None},
+    ]
+    out = catalog._normalize_workloads(payload)
+    assert out == payload
+
+
+def test_normalize_workloads_handles_wrapped_payload():
+    payload = {"workloads": [{"name": "big5"}, "geonames"]}
+    out = catalog._normalize_workloads(payload)
+    assert out == [
+        {"name": "big5", "description": None},
+        {"name": "geonames", "description": None},
+    ]
+
+
+def test_operations_enum_to_hyphenated():
+    # Smoke test: every operation type produces a hyphenated name without
+    # crashing. This is the data that osb_list_operations returns.
+    rows = [
+        {
+            "name": op.name,
+            "hyphenated_name": op.to_hyphenated_string(),
+            "admin_op": op.admin_op,
+        }
+        for op in OperationType
+    ]
+    assert len(rows) > 50  # OSB has ~59 operation types
+    assert any(r["hyphenated_name"] == "bulk" for r in rows)
+    assert any(r["hyphenated_name"] == "create-snapshot" and r["admin_op"] for r in rows)

--- a/tests/mcp/test_compare.py
+++ b/tests/mcp/test_compare.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for compare.py (osb_compare_runs, osb_aggregate_runs)."""
+
+from osbenchmark.mcp.tools import compare
+
+
+def test_parse_compare_csv_round_trips():
+    csv_text = (
+        "Metric,Task,Baseline,Contender,Diff,Unit\n"
+        "Min Throughput,index-append,100,95,-5,docs/s\n"
+        "Mean Throughput,index-append,110.5,105.2,-5.3,docs/s\n"
+        "50th percentile latency,index-append,50,52,2,ms\n"
+        "Error rate,index-append,0.0,0.001,0.001,%\n"
+    )
+    rows = compare._parse_compare_csv(csv_text)
+    assert len(rows) == 4
+    assert rows[0] == {
+        "metric": "Min Throughput",
+        "task": "index-append",
+        "baseline": 100,
+        "contender": 95,
+        "diff": -5,
+        "unit": "docs/s",
+    }
+    # float parsing for fractional values
+    assert rows[1]["baseline"] == 110.5
+    assert rows[1]["diff"] == -5.3
+    # tiny floats survive
+    assert rows[3]["diff"] == 0.001
+
+
+def test_parse_compare_csv_handles_empty_diff():
+    csv_text = (
+        "Metric,Task,Baseline,Contender,Diff,Unit\n"
+        "Some metric,index-append,N/A,N/A,,docs/s\n"
+    )
+    rows = compare._parse_compare_csv(csv_text)
+    assert rows[0]["baseline"] == "N/A"
+    assert rows[0]["diff"] is None
+
+
+def test_maybe_number_parses_ints_and_floats():
+    assert compare._maybe_number("42") == 42
+    assert compare._maybe_number("3.14") == 3.14
+    assert compare._maybe_number("1e-3") == 0.001
+    assert compare._maybe_number("not-a-number") == "not-a-number"
+    assert compare._maybe_number("") is None
+    assert compare._maybe_number(None) is None
+
+
+def test_aggregate_extracts_new_run_id_from_output(monkeypatch):
+    # Simulate `osb aggregate` stdout that includes the new run id.
+    fake_stdout = (
+        "[INFO] Aggregating runs\n"
+        "[INFO] New aggregated test_run: 11111111-2222-3333-4444-555555555555\n"
+    )
+    def fake_run(cmd, timeout_seconds):
+        return fake_stdout
+
+    monkeypatch.setattr(compare, "_run_subprocess", fake_run)
+
+    # Drive the registered tool through a minimal app stub.
+    class _App:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def wrap(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+            return wrap
+
+    app = _App()
+    compare.register(app)
+    result = app.tools["osb_aggregate_runs"](["aaa", "bbb"])
+    assert result["new_run_id"] == "11111111-2222-3333-4444-555555555555"
+    assert result["source_runs"] == ["aaa", "bbb"]
+
+
+def test_aggregate_rejects_empty_run_list(monkeypatch):
+    monkeypatch.setattr(compare, "_run_subprocess", lambda *a, **kw: "")
+
+    class _App:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def wrap(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+            return wrap
+
+    app = _App()
+    compare.register(app)
+    try:
+        app.tools["osb_aggregate_runs"]([])
+    except ValueError as e:
+        assert "at least one run id" in str(e)
+    else:
+        raise AssertionError("expected ValueError for empty run_ids")

--- a/tests/mcp/test_runs.py
+++ b/tests/mcp/test_runs.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for runs.py (osb_list_runs, osb_get_run)."""
+
+from osbenchmark.mcp.tools import runs
+
+
+def test_list_runs_returns_newest_first(fake_test_runs_dir):
+    rows = sorted(runs._load_all_runs(), key=lambda r: r["timestamp"], reverse=True)
+    assert [r["run_id"][:8] for r in rows] == ["bbbbbbbb", "aaaaaaaa"]
+
+
+def test_list_runs_filters_by_workload(fake_test_runs_dir):
+    rows = runs._load_all_runs()
+    # both fixtures use 'geonames'; verify the workload field is populated
+    assert all(r["workload"] == "geonames" for r in rows)
+    assert {r["workload"] for r in rows} == {"geonames"}
+
+
+def test_list_runs_summary_shape(fake_test_runs_dir):
+    rows = runs._load_all_runs()
+    expected_keys = {
+        "run_id",
+        "timestamp",
+        "workload",
+        "test_procedure",
+        "pipeline",
+        "user_tags",
+        "distribution_version",
+        "distribution_flavor",
+    }
+    assert expected_keys == set(rows[0].keys())
+
+
+def test_get_run_extracts_per_op_metrics(fake_test_runs_dir):
+    run_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    path = fake_test_runs_dir / run_id / "test_run.json"
+
+    import json
+    raw = json.loads(path.read_text())
+    summary = runs._summarize_run(raw, source_path=str(path))
+
+    assert summary["run_id"] == run_id
+    assert summary["workload"] == "geonames"
+    assert summary["distribution_version"] == "3.0.0"
+    assert len(summary["operations"]) == 1
+    op = summary["operations"][0]
+    assert op["operation"] == "index-append"
+    assert op["throughput"]["mean"] == 110
+    assert op["service_time"]["p99"] == 79
+    assert op["service_time"]["unit"] == "ms"
+    assert op["error_rate"] == 0.0
+
+
+def test_get_run_handles_missing_percentiles(fake_test_runs_dir):
+    # Synthesize a run that lacks 99_0 to confirm we don't KeyError.
+    raw = {
+        "test-run-id": "ccc",
+        "test-run-timestamp": "20260101T000000Z",
+        "workload": "tiny",
+        "results": {
+            "op_metrics": [
+                {
+                    "operation": "x",
+                    "service_time": {"50_0": 1, "mean": 1, "unit": "ms"},
+                }
+            ]
+        },
+    }
+    summary = runs._summarize_run(raw, source_path="/nowhere")
+    assert summary["operations"][0]["service_time"]["p99"] is None


### PR DESCRIPTION
## Description

Adds an optional [Model Context Protocol](https://modelcontextprotocol.io) server that exposes OpenSearch Benchmark as typed tools. Any MCP-capable client (Claude Code, Claude Desktop, Cursor, Cline, Codex CLI, ...) can call these tools instead of shelling out to the CLI.

This is **Phase 1: read-only**. Running benchmarks via MCP is deferred to a follow-up — that surface needs more thought around long-run handling and production safety, and the read-only tools deliver the bulk of the value on their own.

## Why

OSB users increasingly work alongside AI coding assistants (cf. #1078 which adds AGENTS.md + agent playbooks). Those assistants currently have to remember and shell out CLI invocations, then parse text output. With MCP, the assistant gets structured JSON back from typed tools, which the LLM handles much better.

## Tools (all `osb_*` namespaced, all read-only)

| Tool | Purpose |
|---|---|
| `osb_list_runs(limit, workload)` | Enumerate recent test runs |
| `osb_get_run(run_id)` | Structured per-operation summary of one run |
| `osb_compare_runs(baseline, contender)` | Per-operation deltas between two runs |
| `osb_aggregate_runs(run_ids)` | Combine multiple runs into a synthetic one |
| `osb_list_workloads()` | Workloads OSB can run |
| `osb_list_operations()` | OSB's operation-type catalog |

## Install

The MCP dependency is gated behind an optional extra so it stays out of the core install:

```
pip install opensearch-benchmark[mcp]
```

A new `opensearch-benchmark-mcp` console script is registered. With no args it speaks MCP over stdio. With `install`, it registers the server with the user's MCP client(s):

```
opensearch-benchmark-mcp install                    # auto-detect
opensearch-benchmark-mcp install --client=cursor    # explicit
opensearch-benchmark-mcp install --print            # just print the config snippet
```

For Claude Code users, the simpler path is `claude mcp add opensearch-benchmark opensearch-benchmark-mcp` — the install subcommand actually delegates to that for `--client=claude-code`.

## Code layout

```
osbenchmark/mcp/
├── __init__.py
├── server.py              # FastMCP app + entry point + install CLI
├── install.py             # per-client config-merge logic
├── tools/
│   ├── catalog.py         # osb_list_workloads, osb_list_operations
│   ├── compare.py         # osb_compare_runs, osb_aggregate_runs
│   └── runs.py            # osb_list_runs, osb_get_run
└── README.md              # user-facing install walkthrough

tests/mcp/                 # 15 new unit tests, no real CLI invocation
docs/agents/skills/
└── mcp-server.md          # agent-facing skill (links from agents README)
```

## Validation

- 15 new unit tests pass (mocked subprocess for compare/aggregate, real fixture files for run reading)
- Full existing OSB test suite still passes (1417 tests, no regressions)
- Self-validated against the real MCP protocol: spawned the server over stdio, performed `initialize` + `tools/list` + `tools/call` on `osb_list_operations` and `osb_list_runs`, confirmed correct results
- Registered with Claude Code locally and exercised the tools against my real `~/.benchmark/`

## Design choices

- **In-repo, not separate package.** Keeps the MCP code in sync with OSB CLI changes. Easier to ship coupled patches. Can be split to a standalone package later if maintainers prefer; the code is small enough that a split is cheap.
- **Optional extra.** Core OSB install stays lean; no new transitive deps unless user opts in.
- **FastMCP over the low-level SDK.** Smaller surface area, schema generation from type hints, less boilerplate. Easy to drop to the low-level API if we later need streaming/resources.
- **Read-only Phase 1.** Run/cancel benchmark tools come in Phase 2 once the read-only tools have shaped what the LLM actually wants.
- **CSV output of `osb compare`** instead of markdown for parsing reliability. The CSV columns are stable.

## Dependencies

- Depends on #1078 (AGENTS.md / agent playbooks) for the skill cross-reference. Could be rebased to stand alone if #1078 lands later.

## Marked as draft

Opening as draft to invite feedback on:

- Whether `osbenchmark/mcp/` is the right home, or if maintainers prefer a separate published package
- The tool surface (any missing read tools you'd want? any of these you'd remove?)
- Whether the optional-extra pattern is right
- Naming: `osb_*` prefix vs. unprefixed

Happy to split into smaller PRs (e.g., the install command alone, or skills doc separately) if reviewers prefer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.