### PR TITLE
Add ClickHouse engine support

### DIFF
--- a/osbenchmark/engine/__init__.py
+++ b/osbenchmark/engine/__init__.py
@@ -90,6 +90,12 @@ def _ensure_builtin_engines():
             register_engine("milvus", milvus_engine)
         except ImportError as e:
             logger.debug("Milvus engine not available: %s", e)
+    if "clickhouse" not in _ENGINE_REGISTRY:
+        try:
+            from osbenchmark.engine import clickhouse as clickhouse_engine  # pylint: disable=import-outside-toplevel
+            register_engine("clickhouse", clickhouse_engine)
+        except ImportError as e:
+            logger.debug("ClickHouse engine not available: %s", e)
 
 
 def get_engine(name):

--- a/osbenchmark/engine/clickhouse/__init__.py
+++ b/osbenchmark/engine/clickhouse/__init__.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+ClickHouse engine module.
+
+Exposes the engine-registry interface for ClickHouse: create_client_factory,
+create_async_client, register_runners, wait_for_client, on_execute_error.
+
+ClickHouse runners expect bodies to already contain pre-translated SQL. The
+workload's ClickHouse-native param source (e.g. `clickhouse-query-param-source`)
+generates such bodies. Workloads that send OpenSearch-style DSL queries to the
+ClickHouse runner will fail with a clear error pointing at the ClickHouse-native
+procedure.
+"""
+
+from osbenchmark.engine.clickhouse.client import ClickHouseClientFactory, ClickHouseDatabaseClient  # noqa: F401
+
+
+def create_client_factory(hosts, client_options):
+    """Return a ClickHouseClientFactory. Its .create() returns a sync ClickHouseDatabaseClient."""
+    return ClickHouseClientFactory(hosts, client_options)
+
+
+def create_async_client(hosts, client_options, cfg=None):
+    """Return an async ClickHouse client. cfg is accepted for interface symmetry but not used."""
+    return ClickHouseClientFactory(hosts, client_options).create_async()
+
+
+def register_runners():
+    """Register ClickHouse runners, overriding OS defaults for shared operation types.
+
+    Called AFTER runner.register_default_runners() so ClickHouse implementations win
+    over OS defaults for ops that both engines support (Bulk, Search, VectorSearch,
+    CreateIndex, DeleteIndex, ClusterHealth, IndexStats, Refresh, ForceMerge).
+    """
+    # pylint: disable=import-outside-toplevel
+    from osbenchmark import workload
+    from osbenchmark.worker_coordinator import runner
+    from osbenchmark.engine.clickhouse import runners as ch_runners
+
+    runner.register_runner(workload.OperationType.Bulk, ch_runners.ClickHouseBulkIndex(), async_runner=True)
+    runner.register_runner(workload.OperationType.Search, ch_runners.ClickHouseQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.PaginatedSearch, ch_runners.ClickHouseQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.ScrollSearch, ch_runners.ClickHouseScrollQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.VectorSearch, ch_runners.ClickHouseVectorSearch(), async_runner=True)
+    runner.register_runner(workload.OperationType.BulkVectorDataSet, ch_runners.ClickHouseBulkVectorDataSet(), async_runner=True)
+    runner.register_runner(workload.OperationType.CreateIndex, ch_runners.ClickHouseCreateTable(), async_runner=True)
+    runner.register_runner(workload.OperationType.DeleteIndex, ch_runners.ClickHouseDropTable(), async_runner=True)
+    runner.register_runner(workload.OperationType.Refresh, ch_runners.ClickHouseNoOp("refresh"), async_runner=True)
+    runner.register_runner(workload.OperationType.ForceMerge, ch_runners.ClickHouseOptimizeTable(), async_runner=True)
+    runner.register_runner(workload.OperationType.ClusterHealth, ch_runners.ClickHouseClusterHealth(), async_runner=True)
+    runner.register_runner(workload.OperationType.IndexStats, ch_runners.ClickHouseSystemParts(), async_runner=True)
+    runner.register_runner("warmup-knn-indices", ch_runners.ClickHouseNoOp("warmup-knn-indices"), async_runner=True)
+    for op_type in [workload.OperationType.PutPipeline, workload.OperationType.DeletePipeline,
+                    workload.OperationType.CreateSearchPipeline, workload.OperationType.PutSettings]:
+        runner.register_runner(op_type, ch_runners.ClickHouseNoOp(str(op_type)), async_runner=True)
+
+
+def wait_for_client(ch_client, max_attempts=40):
+    """Wait for ClickHouse /ping (or SELECT 1) to become available.
+
+    Delegates to the helpers function that implements the polling loop.
+    """
+    # pylint: disable=import-outside-toplevel
+    from osbenchmark.engine.clickhouse.helpers import wait_for_clickhouse
+    return wait_for_clickhouse(ch_client, max_attempts=max_attempts)
+
+
+def on_execute_error(e):
+    """Translate clickhouse-connect / httpx exceptions to OSB's (ops, unit, meta, fatal) tuple.
+
+    Returns None if the exception is not engine-specific.
+    """
+    # pylint: disable=import-outside-toplevel
+    try:
+        import httpx
+        if isinstance(e, httpx.ConnectError):
+            return 0, "ops", {"success": False, "error-type": "transport",
+                              "error-description": f"ClickHouse connection error: {e}"}, True
+        if isinstance(e, httpx.TimeoutException):
+            return 0, "ops", {"success": False, "error-type": "transport",
+                              "error-description": "ClickHouse request timed out"}, False
+        if isinstance(e, httpx.HTTPStatusError):
+            return 0, "ops", {"success": False, "error-type": "transport",
+                              "http-status": e.response.status_code,
+                              "error-description": str(e)}, False
+    except ImportError:
+        pass
+
+    try:
+        import clickhouse_connect.driver.exceptions as ch_exc  # pylint: disable=import-outside-toplevel
+        if isinstance(e, ch_exc.ClickHouseError):
+            return 0, "ops", {"success": False, "error-type": "clickhouse",
+                              "error-description": str(e)}, False
+    except ImportError:
+        pass
+
+    return None

--- a/osbenchmark/engine/clickhouse/__init__.py
+++ b/osbenchmark/engine/clickhouse/__init__.py
@@ -54,28 +54,54 @@ def register_runners():
     Called AFTER runner.register_default_runners() so ClickHouse implementations win
     over OS defaults for ops that both engines support (Bulk, Search, VectorSearch,
     CreateIndex, DeleteIndex, ClusterHealth, IndexStats, Refresh, ForceMerge).
+
+    Admin ops are wrapped in Retry(...) to match OS default retry semantics.
+    Data-plane ops (Bulk, Search, VectorSearch, ScrollSearch, BulkVectorDataSet)
+    are NOT wrapped - retrying a bulk on transient failure would double-insert rows.
     """
     # pylint: disable=import-outside-toplevel
     from osbenchmark import workload
     from osbenchmark.worker_coordinator import runner
+    from osbenchmark.worker_coordinator.runner import Retry
     from osbenchmark.engine.clickhouse import runners as ch_runners
 
-    runner.register_runner(workload.OperationType.Bulk, ch_runners.ClickHouseBulkIndex(), async_runner=True)
-    runner.register_runner(workload.OperationType.Search, ch_runners.ClickHouseQuery(), async_runner=True)
-    runner.register_runner(workload.OperationType.PaginatedSearch, ch_runners.ClickHouseQuery(), async_runner=True)
-    runner.register_runner(workload.OperationType.ScrollSearch, ch_runners.ClickHouseScrollQuery(), async_runner=True)
-    runner.register_runner(workload.OperationType.VectorSearch, ch_runners.ClickHouseVectorSearch(), async_runner=True)
-    runner.register_runner(workload.OperationType.BulkVectorDataSet, ch_runners.ClickHouseBulkVectorDataSet(), async_runner=True)
-    runner.register_runner(workload.OperationType.CreateIndex, ch_runners.ClickHouseCreateTable(), async_runner=True)
-    runner.register_runner(workload.OperationType.DeleteIndex, ch_runners.ClickHouseDropTable(), async_runner=True)
-    runner.register_runner(workload.OperationType.Refresh, ch_runners.ClickHouseNoOp("refresh"), async_runner=True)
-    runner.register_runner(workload.OperationType.ForceMerge, ch_runners.ClickHouseOptimizeTable(), async_runner=True)
-    runner.register_runner(workload.OperationType.ClusterHealth, ch_runners.ClickHouseClusterHealth(), async_runner=True)
-    runner.register_runner(workload.OperationType.IndexStats, ch_runners.ClickHouseSystemParts(), async_runner=True)
-    runner.register_runner("warmup-knn-indices", ch_runners.ClickHouseNoOp("warmup-knn-indices"), async_runner=True)
+    # Data-plane runners: NO Retry wrapping.
+    runner.register_runner(workload.OperationType.Bulk,
+                           ch_runners.ClickHouseBulkIndex(), async_runner=True)
+    runner.register_runner(workload.OperationType.Search,
+                           ch_runners.ClickHouseQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.PaginatedSearch,
+                           ch_runners.ClickHouseQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.ScrollSearch,
+                           ch_runners.ClickHouseScrollQuery(), async_runner=True)
+    runner.register_runner(workload.OperationType.VectorSearch,
+                           ch_runners.ClickHouseVectorSearch(), async_runner=True)
+    runner.register_runner(workload.OperationType.BulkVectorDataSet,
+                           ch_runners.ClickHouseBulkVectorDataSet(), async_runner=True)
+
+    # Admin-plane runners: WRAP in Retry to match OS default semantics.
+    runner.register_runner(workload.OperationType.CreateIndex,
+                           Retry(ch_runners.ClickHouseCreateTable()), async_runner=True)
+    runner.register_runner(workload.OperationType.DeleteIndex,
+                           Retry(ch_runners.ClickHouseDropTable()), async_runner=True)
+    runner.register_runner(workload.OperationType.Refresh,
+                           ch_runners.ClickHouseNoOp("refresh"), async_runner=True)
+    runner.register_runner(workload.OperationType.ForceMerge,
+                           Retry(ch_runners.ClickHouseOptimizeTable()), async_runner=True)
+    runner.register_runner(workload.OperationType.ClusterHealth,
+                           Retry(ch_runners.ClickHouseClusterHealth()), async_runner=True)
+    runner.register_runner(workload.OperationType.IndexStats,
+                           Retry(ch_runners.ClickHouseSystemParts()), async_runner=True)
+
+    # NoOp stubs.
+    runner.register_runner("warmup-knn-indices",
+                           ch_runners.ClickHouseNoOp("warmup-knn-indices"), async_runner=True)
     for op_type in [workload.OperationType.PutPipeline, workload.OperationType.DeletePipeline,
-                    workload.OperationType.CreateSearchPipeline, workload.OperationType.PutSettings]:
+                    workload.OperationType.CreateSearchPipeline]:
         runner.register_runner(op_type, ch_runners.ClickHouseNoOp(str(op_type)), async_runner=True)
+    # PutSettings is admin-plane -> wrap in Retry.
+    runner.register_runner(workload.OperationType.PutSettings,
+                           Retry(ch_runners.ClickHouseNoOp("put-settings")), async_runner=True)
 
 
 def wait_for_client(ch_client, max_attempts=40):

--- a/osbenchmark/engine/clickhouse/__init__.py
+++ b/osbenchmark/engine/clickhouse/__init__.py
@@ -55,17 +55,24 @@ def register_runners():
     over OS defaults for ops that both engines support (Bulk, Search, VectorSearch,
     CreateIndex, DeleteIndex, ClusterHealth, IndexStats, Refresh, ForceMerge).
 
-    Admin ops are wrapped in Retry(...) to match OS default retry semantics.
-    Data-plane ops (Bulk, Search, VectorSearch, ScrollSearch, BulkVectorDataSet)
-    are NOT wrapped - retrying a bulk on transient failure would double-insert rows.
+    We deliberately do NOT wrap admin runners in ``Retry(...)``. The Retry class
+    in ``worker_coordinator/runner.py`` only catches ``socket.timeout``,
+    ``opensearchpy.ConnectionError`` and ``opensearchpy.TransportError``;
+    ClickHouse's ``httpx.ConnectError`` and ``clickhouse_connect.ClickHouseError``
+    bypass it entirely, so the retry never fires and the wrapper only obscures
+    the exception path. Admin ops (CREATE TABLE, DROP TABLE, OPTIMIZE, ...) are
+    one-shot at benchmark start; a legitimate error should surface immediately
+    so operators can fix the workload rather than disappear into a phantom retry.
+
+    Follow-up (P8): wire ``engine.clickhouse.on_execute_error`` into the sample
+    error path so transient httpx/ClickHouse exceptions get consistent handling.
     """
     # pylint: disable=import-outside-toplevel
     from osbenchmark import workload
     from osbenchmark.worker_coordinator import runner
-    from osbenchmark.worker_coordinator.runner import Retry
     from osbenchmark.engine.clickhouse import runners as ch_runners
 
-    # Data-plane runners: NO Retry wrapping.
+    # Data-plane runners.
     runner.register_runner(workload.OperationType.Bulk,
                            ch_runners.ClickHouseBulkIndex(), async_runner=True)
     runner.register_runner(workload.OperationType.Search,
@@ -79,19 +86,19 @@ def register_runners():
     runner.register_runner(workload.OperationType.BulkVectorDataSet,
                            ch_runners.ClickHouseBulkVectorDataSet(), async_runner=True)
 
-    # Admin-plane runners: WRAP in Retry to match OS default semantics.
+    # Admin-plane runners. NOT wrapped in Retry - see docstring.
     runner.register_runner(workload.OperationType.CreateIndex,
-                           Retry(ch_runners.ClickHouseCreateTable()), async_runner=True)
+                           ch_runners.ClickHouseCreateTable(), async_runner=True)
     runner.register_runner(workload.OperationType.DeleteIndex,
-                           Retry(ch_runners.ClickHouseDropTable()), async_runner=True)
+                           ch_runners.ClickHouseDropTable(), async_runner=True)
     runner.register_runner(workload.OperationType.Refresh,
                            ch_runners.ClickHouseNoOp("refresh"), async_runner=True)
     runner.register_runner(workload.OperationType.ForceMerge,
-                           Retry(ch_runners.ClickHouseOptimizeTable()), async_runner=True)
+                           ch_runners.ClickHouseOptimizeTable(), async_runner=True)
     runner.register_runner(workload.OperationType.ClusterHealth,
-                           Retry(ch_runners.ClickHouseClusterHealth()), async_runner=True)
+                           ch_runners.ClickHouseClusterHealth(), async_runner=True)
     runner.register_runner(workload.OperationType.IndexStats,
-                           Retry(ch_runners.ClickHouseSystemParts()), async_runner=True)
+                           ch_runners.ClickHouseSystemParts(), async_runner=True)
 
     # NoOp stubs.
     runner.register_runner("warmup-knn-indices",
@@ -99,9 +106,8 @@ def register_runners():
     for op_type in [workload.OperationType.PutPipeline, workload.OperationType.DeletePipeline,
                     workload.OperationType.CreateSearchPipeline]:
         runner.register_runner(op_type, ch_runners.ClickHouseNoOp(str(op_type)), async_runner=True)
-    # PutSettings is admin-plane -> wrap in Retry.
     runner.register_runner(workload.OperationType.PutSettings,
-                           Retry(ch_runners.ClickHouseNoOp("put-settings")), async_runner=True)
+                           ch_runners.ClickHouseNoOp("put-settings"), async_runner=True)
 
 
 def wait_for_client(ch_client, max_attempts=40):

--- a/osbenchmark/engine/clickhouse/__init__.py
+++ b/osbenchmark/engine/clickhouse/__init__.py
@@ -55,21 +55,26 @@ def register_runners():
     over OS defaults for ops that both engines support (Bulk, Search, VectorSearch,
     CreateIndex, DeleteIndex, ClusterHealth, IndexStats, Refresh, ForceMerge).
 
-    We deliberately do NOT wrap admin runners in ``Retry(...)``. The Retry class
-    in ``worker_coordinator/runner.py`` only catches ``socket.timeout``,
-    ``opensearchpy.ConnectionError`` and ``opensearchpy.TransportError``;
-    ClickHouse's ``httpx.ConnectError`` and ``clickhouse_connect.ClickHouseError``
-    bypass it entirely, so the retry never fires and the wrapper only obscures
-    the exception path. Admin ops (CREATE TABLE, DROP TABLE, OPTIMIZE, ...) are
-    one-shot at benchmark start; a legitimate error should surface immediately
-    so operators can fix the workload rather than disappear into a phantom retry.
+    ClusterHealth is wrapped in ``Retry(...)`` so workloads can set
+    ``retry-until-success: true`` and get the same polling semantics as the OS
+    default. Retry's return-value-based retry path (``retry-on-error`` /
+    ``retry-until-success``) works engine-agnostically — it inspects the
+    runner's dict return, not exception types — so this wrapping is genuinely
+    useful even though Retry's exception-based branches only recognize
+    opensearchpy transport errors.
 
-    Follow-up (P8): wire ``engine.clickhouse.on_execute_error`` into the sample
+    Other admin runners (CREATE TABLE, DROP TABLE, OPTIMIZE, SystemParts) are
+    NOT wrapped: they are one-shot at benchmark start with no retry-until-success
+    use case, and Retry's exception clauses can't catch ClickHouse's httpx /
+    clickhouse-connect exceptions anyway.
+
+    Follow-up: wire ``engine.clickhouse.on_execute_error`` into the sample
     error path so transient httpx/ClickHouse exceptions get consistent handling.
     """
     # pylint: disable=import-outside-toplevel
     from osbenchmark import workload
     from osbenchmark.worker_coordinator import runner
+    from osbenchmark.worker_coordinator.runner import Retry
     from osbenchmark.engine.clickhouse import runners as ch_runners
 
     # Data-plane runners.
@@ -86,7 +91,7 @@ def register_runners():
     runner.register_runner(workload.OperationType.BulkVectorDataSet,
                            ch_runners.ClickHouseBulkVectorDataSet(), async_runner=True)
 
-    # Admin-plane runners. NOT wrapped in Retry - see docstring.
+    # Admin-plane runners.
     runner.register_runner(workload.OperationType.CreateIndex,
                            ch_runners.ClickHouseCreateTable(), async_runner=True)
     runner.register_runner(workload.OperationType.DeleteIndex,
@@ -95,8 +100,10 @@ def register_runners():
                            ch_runners.ClickHouseNoOp("refresh"), async_runner=True)
     runner.register_runner(workload.OperationType.ForceMerge,
                            ch_runners.ClickHouseOptimizeTable(), async_runner=True)
+    # ClusterHealth wraps in Retry: preserves retry-until-success/retry-on-error
+    # (return-value based, engine-agnostic) that workloads use for bootstrap.
     runner.register_runner(workload.OperationType.ClusterHealth,
-                           ch_runners.ClickHouseClusterHealth(), async_runner=True)
+                           Retry(ch_runners.ClickHouseClusterHealth()), async_runner=True)
     runner.register_runner(workload.OperationType.IndexStats,
                            ch_runners.ClickHouseSystemParts(), async_runner=True)
 

--- a/osbenchmark/engine/clickhouse/client.py
+++ b/osbenchmark/engine/clickhouse/client.py
@@ -26,21 +26,27 @@ except ImportError:
 
 
 class _NodesProxy:
-    """Sync proxy for the ``client.nodes`` namespace.
+    """Async proxy for the ``client.nodes`` namespace.
 
-    Avoids having ``client.nodes.stats(...)`` resolve to the async
-    ``stats(index, metric, ...)`` on the client (which would silently
-    return a coroutine when telemetry devices call it synchronously).
+    Both ``stats`` and ``info`` are async because OSB's default NodeStats runner
+    does ``await opensearch.nodes.stats(...)``. Returning a coroutine from a sync
+    method (or awaiting a sync method) would raise TypeError when telemetry
+    fires. Both return OS-shaped envelopes (with a populated ``nodes`` key) so
+    downstream iterators don't KeyError.
     """
 
     def __init__(self, parent: "ClickHouseDatabaseClient") -> None:
         self._parent = parent
 
-    def stats(self, *args: Any, **kwargs: Any) -> Dict:
+    async def stats(self, *args: Any, **kwargs: Any) -> Dict:
         return self._parent.nodes_stats(*args, **kwargs)
 
-    def info(self, *_args: Any, **_kwargs: Any) -> Dict:
-        return {}
+    async def info(self, *_args: Any, **_kwargs: Any) -> Dict:
+        return {
+            "nodes": {},
+            "cluster_name": self._parent.client_options.get("cluster_name", "clickhouse"),
+            "cluster_uuid": "clickhouse",
+        }
 
 
 class ClickHouseDatabaseClient(RequestContextHolder):
@@ -158,6 +164,9 @@ class ClickHouseDatabaseClient(RequestContextHolder):
         from osbenchmark.engine.clickhouse.helpers import parse_hosts  # pylint: disable=import-outside-toplevel
         host, port, secure = parse_hosts(self._hosts)
         scheme = "https" if secure else "http"
+        # IPv6 addresses contain colons; wrap in brackets so the URL is unambiguous.
+        if ":" in host:
+            host = f"[{host}]"
         return f"{scheme}://{host}:{port}"
 
     # -----------------------------------------------------------------
@@ -253,7 +262,8 @@ class ClickHouseDatabaseClient(RequestContextHolder):
         items = [{"index": {"_index": index, "_id": d.get("_id"), "status": 201}} for d in docs]
         return {"took": took, "errors": False, "items": items}
 
-    async def index(self, index: str, body: Dict, id: Any = None,  # pylint: disable=redefined-builtin
+    # pylint: disable-next=redefined-builtin,too-many-positional-arguments
+    async def index(self, index: str, body: Dict, id: Any = None,
                     doc_type: Any = None, params: Optional[Dict] = None,
                     **_kwargs: Any) -> Dict:
         client = await self._ensure_client()
@@ -313,9 +323,21 @@ class ClickHouseDatabaseClient(RequestContextHolder):
         if not ddl:
             ddl_file = body.get("ddl-file")
             if ddl_file:
-                # Resolve relative paths against params["workload-path"] (OSB standard)
-                if not os.path.isabs(ddl_file) and params and params.get("workload-path"):
-                    ddl_file = os.path.join(params["workload-path"], ddl_file)
+                # Resolve relative paths against params["workload-path"] (OSB standard).
+                # Also accept the legacy underscore variant and fall back to cwd when
+                # neither is present, emitting a WARNING so users aren't surprised.
+                if not os.path.isabs(ddl_file):
+                    workload_path = None
+                    if params:
+                        workload_path = (params.get("workload-path")
+                                         or params.get("workload_path"))
+                    if not workload_path:
+                        workload_path = os.getcwd()
+                        self.logger.warning(
+                            "ddl-file %r is relative but no 'workload-path' param was "
+                            "supplied; resolving against cwd %r", ddl_file, workload_path
+                        )
+                    ddl_file = os.path.join(workload_path, ddl_file)
                 with open(ddl_file, "r", encoding="utf-8") as fp:
                     ddl = fp.read()
         if not ddl:
@@ -442,28 +464,47 @@ class ClickHouseDatabaseClient(RequestContextHolder):
     # Transport namespace
     # -----------------------------------------------------------------
 
+    # pylint: disable-next=too-many-positional-arguments
     async def perform_request(self, method: str, url: str, params: Any = None,
                               body: Any = None, headers: Any = None) -> Any:
-        """Minimal escape hatch.
+        """Unsupported for ClickHouse.
 
-        Routes body-carrying calls through client.command so tests / rarely-used
-        workload paths can still exercise the client. Returns {} for GET-shape calls
-        since ClickHouse's transport is HTTP+SQL, not the REST-DSL that the URL
-        argument implies.
+        OSB's default runners (SubmitAsyncSearch, ML ops, RawRequest,
+        CreatePointInTime, ...) call ``client.transport.perform_request`` with a
+        REST-DSL URL. ClickHouse has no OS-shaped REST API, so a silent stub
+        would fabricate success. Raise loudly instead so workloads using these
+        runners fail fast and switch to a ClickHouse-native operation.
         """
-        client = await self._ensure_client()
-        if body is not None:
-            # Assume the body is either a SQL string or a JSON-encoded string
-            sql_body = body if isinstance(body, str) else _json.dumps(body)
-            await client.command(sql_body)
-        return {}
+        # Reference params/headers so pylint doesn't complain about unused args
+        # while keeping the OSB-compatible signature.
+        _ = (params, headers)
+        raise exceptions.BenchmarkError(
+            f"ClickHouseDatabaseClient.transport.perform_request is not supported; "
+            f"the {method} {url} operation has no ClickHouse equivalent. "
+            f"Use a ClickHouse-native operation."
+        )
 
     # -----------------------------------------------------------------
     # Sync helpers
     # -----------------------------------------------------------------
 
     def info(self, **_kwargs: Any) -> Dict:
-        from osbenchmark.engine.clickhouse.helpers import parse_version  # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel
+        from osbenchmark.engine.clickhouse.helpers import parse_version
+        # Narrow the expected-exception set. Anything outside these is unexpected
+        # and should log at WARNING (with the exception type) so it surfaces in
+        # operator logs rather than being silently masked.
+        expected_exc: tuple = ()
+        try:
+            import clickhouse_connect.driver.exceptions as ch_exc
+            expected_exc = expected_exc + (ch_exc.ClickHouseError,)
+        except ImportError:
+            pass
+        try:
+            import httpx
+            expected_exc = expected_exc + (httpx.HTTPError,)
+        except ImportError:
+            pass
         try:
             sync = self._ensure_sync_client()
             result = sync.query("SELECT version()")
@@ -475,9 +516,17 @@ class ClickHouseDatabaseClient(RequestContextHolder):
                     "Could not parse ClickHouse version %r; using fallback %s. "
                     "Metrics store version field may be misleading.", version_str, semver
                 )
-        except Exception as exc:  # pylint: disable=broad-except
+        except expected_exc as exc:
             self.logger.warning(
                 "ClickHouse info() failed: %s - using fallback version 24.8.0", exc
+            )
+            semver = "24.8.0"
+        except Exception as exc:  # pylint: disable=broad-except
+            # Unexpected exception - still return a fallback so metrics store
+            # doesn't crash, but WARN with the exception type so it's visible.
+            self.logger.warning(
+                "ClickHouse info() raised unexpected %s: %s - using fallback version 24.8.0",
+                type(exc).__name__, exc
             )
             semver = "24.8.0"
         return {
@@ -493,7 +542,7 @@ class ClickHouseDatabaseClient(RequestContextHolder):
             "tagline": "You Know, for Analytics",
         }
 
-    def return_raw_response(self) -> None:
+    def return_raw_response(self) -> None:  # pylint: disable=arguments-differ
         return None
 
     # -----------------------------------------------------------------

--- a/osbenchmark/engine/clickhouse/client.py
+++ b/osbenchmark/engine/clickhouse/client.py
@@ -9,7 +9,9 @@ See the sibling engine/vespa/client.py for the pattern this file follows.
 from __future__ import annotations  # ensure all type hints are stringified
 
 import asyncio
+import json as _json
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from osbenchmark import exceptions
@@ -21,6 +23,24 @@ try:
 except ImportError:
     clickhouse_connect = None  # type: ignore
     CLICKHOUSE_CONNECT_AVAILABLE = False
+
+
+class _NodesProxy:
+    """Sync proxy for the ``client.nodes`` namespace.
+
+    Avoids having ``client.nodes.stats(...)`` resolve to the async
+    ``stats(index, metric, ...)`` on the client (which would silently
+    return a coroutine when telemetry devices call it synchronously).
+    """
+
+    def __init__(self, parent: "ClickHouseDatabaseClient") -> None:
+        self._parent = parent
+
+    def stats(self, *args: Any, **kwargs: Any) -> Dict:
+        return self._parent.nodes_stats(*args, **kwargs)
+
+    def info(self, *_args: Any, **_kwargs: Any) -> Dict:
+        return {}
 
 
 class ClickHouseDatabaseClient(RequestContextHolder):
@@ -42,15 +62,471 @@ class ClickHouseDatabaseClient(RequestContextHolder):
         self._client = None  # clickhouse_connect.AsyncClient, initialized lazily
         self._sync_client = None  # clickhouse_connect.Client, for info()/wait_for_client
         self._client_lock = asyncio.Lock()  # prevents duplicate init under contention
-        self._database = None
+        self._database: Optional[str] = None
+        self._stats_caveat_logged = False
 
-        # namespace proxies (Vespa pattern). See "nodes_stats" below for the sync stub.
+        # namespace proxies (Vespa pattern). nodes uses a sync proxy so telemetry
+        # devices can call it synchronously.
         self.indices = self
         self.cluster = self
         self.transport = self
-        self.nodes = self
+        self.nodes = _NodesProxy(self)
 
-    # methods stubbed here — filled in P3
+    # -----------------------------------------------------------------
+    # Client init / lifecycle
+    # -----------------------------------------------------------------
+
+    async def _ensure_client(self):
+        # Fast path: no lock needed if client already exists
+        if self._client is not None:
+            return self._client
+        async with self._client_lock:
+            # Double-check inside lock - another task may have initialized while we waited
+            if self._client is not None:
+                return self._client
+            if not CLICKHOUSE_CONNECT_AVAILABLE:
+                raise exceptions.SystemSetupError(
+                    "clickhouse_connect not installed. Install with: "
+                    "pip install 'opensearch-benchmark[clickhouse]'"
+                )
+            # Defensive API check (pyvespa lesson): fail loud if SDK is missing get_async_client
+            if not hasattr(clickhouse_connect, "get_async_client"):
+                raise exceptions.SystemSetupError(
+                    "Installed clickhouse-connect is missing get_async_client - expected >=0.9.2"
+                )
+            from osbenchmark.engine.clickhouse.helpers import parse_hosts  # pylint: disable=import-outside-toplevel
+            host, port, secure = parse_hosts(self._hosts)
+            username = self.client_options.get(
+                "basic_auth_user", self.client_options.get("username", "default"))
+            password = self.client_options.get(
+                "basic_auth_password", self.client_options.get("password", ""))
+            database = self.client_options.get("database", "default")
+            # Default settings ensure durable writes. Users can opt into fire-and-forget
+            # via client_options["async_insert_fire_and_forget"] = True.
+            default_settings = {"async_insert": 1, "wait_for_async_insert": 1}
+            if self.client_options.get("async_insert_fire_and_forget"):
+                default_settings["wait_for_async_insert"] = 0
+                self.logger.warning(
+                    "async_insert_fire_and_forget=True: bulk throughput numbers will not "
+                    "reflect durable writes; data may not be queryable immediately after "
+                    "bulk completes."
+                )
+            self._client = await clickhouse_connect.get_async_client(
+                host=host,
+                port=port,
+                username=username,
+                password=password,
+                database=database,
+                secure=secure,
+                connect_timeout=self.client_options.get("connect_timeout", 10),
+                send_receive_timeout=self.client_options.get("request_timeout", 300),
+                compress=self.client_options.get("compress", True),
+                verify=self.client_options.get("ssl_verify", True),
+                settings=default_settings,
+            )
+            self._database = database
+            return self._client
+
+    def _ensure_sync_client(self):
+        if self._sync_client is not None:
+            return self._sync_client
+        if not CLICKHOUSE_CONNECT_AVAILABLE:
+            raise exceptions.SystemSetupError(
+                "clickhouse_connect not installed. Install with: "
+                "pip install 'opensearch-benchmark[clickhouse]'"
+            )
+        from osbenchmark.engine.clickhouse.helpers import parse_hosts  # pylint: disable=import-outside-toplevel
+        host, port, secure = parse_hosts(self._hosts)
+        self._sync_client = clickhouse_connect.get_client(
+            host=host,
+            port=port,
+            username=self.client_options.get(
+                "basic_auth_user", self.client_options.get("username", "default")),
+            password=self.client_options.get(
+                "basic_auth_password", self.client_options.get("password", "")),
+            database=self.client_options.get("database", "default"),
+            secure=secure,
+            connect_timeout=self.client_options.get("connect_timeout", 10),
+            send_receive_timeout=self.client_options.get("request_timeout", 300),
+            compress=self.client_options.get("compress", True),
+            verify=self.client_options.get("ssl_verify", True),
+        )
+        return self._sync_client
+
+    @property
+    def endpoint(self) -> str:
+        from osbenchmark.engine.clickhouse.helpers import parse_hosts  # pylint: disable=import-outside-toplevel
+        host, port, secure = parse_hosts(self._hosts)
+        scheme = "https" if secure else "http"
+        return f"{scheme}://{host}:{port}"
+
+    # -----------------------------------------------------------------
+    # Public escape hatch for runners
+    # -----------------------------------------------------------------
+
+    async def execute_query(self, sql: str, parameters: Optional[Dict] = None,
+                            settings: Optional[Dict] = None) -> Any:
+        """Public wrapper around AsyncClient.query.
+
+        Runners that need raw QueryResult objects (VectorSearch for scoring,
+        ScrollSearch for pagination) call this instead of reaching into
+        _ensure_client(). Enables instrumentation subclasses to intercept
+        query execution.
+        """
+        from osbenchmark.engine.clickhouse.helpers import coerce_parameters  # pylint: disable=import-outside-toplevel
+        client = await self._ensure_client()
+        if parameters is not None:
+            parameters = coerce_parameters(parameters)
+        if settings:
+            return await client.query(sql, parameters=parameters, settings=settings)
+        if parameters is not None:
+            return await client.query(sql, parameters=parameters)
+        return await client.query(sql)
+
+    # -----------------------------------------------------------------
+    # Sync stub for telemetry
+    # -----------------------------------------------------------------
+
+    def nodes_stats(self, **_kwargs: Any) -> Dict:
+        """Sync stub. Real Node telemetry is deferred to v2.
+
+        Called synchronously by OSB telemetry devices (NodeStats). Returns an
+        empty envelope with an OS-shaped 'nodes' key so callers that iterate
+        over it don't KeyError.
+        """
+        return {"nodes": {}, "cluster_name": self.client_options.get("cluster_name", "clickhouse")}
+
+    # -----------------------------------------------------------------
+    # Top-level engine client interface
+    # -----------------------------------------------------------------
+
+    async def bulk(self, body: Any, index: Optional[str] = None,
+                   doc_type: Any = None, params: Optional[Dict] = None,
+                   **kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import (  # pylint: disable=import-outside-toplevel
+            parse_bulk_body, rows_from_docs, docs_have_extra_keys, _ns_to_ms
+        )
+        client = await self._ensure_client()
+        docs = parse_bulk_body(body)
+        if not docs:
+            return {"took": 0, "errors": False, "items": []}
+
+        columns = (params or {}).get("column-names") or kwargs.get("column_names")
+        insert_mode = (params or {}).get("insert-mode", "auto")  # "native" | "json" | "auto"
+        use_json_fallback = (
+            insert_mode == "json"
+            or not columns
+            or docs_have_extra_keys(docs, columns)
+        )
+
+        if use_json_fallback:
+            # JSONEachRow fallback - schema-flexible, ignores missing/extra columns
+            ndjson = "\n".join(_json.dumps(d.get("_source", {})) for d in docs).encode("utf-8")
+            try:
+                table_expr = index  # workload passes the table name; may include db.table
+                summary = await client.command(
+                    f"INSERT INTO {table_expr} FORMAT JSONEachRow",
+                    data=ndjson,
+                    settings={
+                        "input_format_skip_unknown_fields": 1,
+                        "input_format_null_as_default": 1,
+                    },
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                # ClickHouse INSERT is all-or-nothing; DO NOT fabricate per-doc errors.
+                self.logger.warning("ClickHouse bulk (JSONEachRow) failed: %s", exc)
+                return {"took": 0, "errors": True, "items": [], "_bulk_error": str(exc)}
+        else:
+            # Fast Native-format path (strict - errors if any doc missing a declared column)
+            try:
+                rows = rows_from_docs(docs, columns, strict=True)
+                summary = await client.insert(index, rows, column_names=columns)
+            except exceptions.BenchmarkError:
+                raise  # strict mismatch - surface the clean column-name error
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.warning("ClickHouse bulk (Native) failed: %s", exc)
+                return {"took": 0, "errors": True, "items": [], "_bulk_error": str(exc)}
+
+        # Success path: summary is QuerySummary; summary.summary is Dict[str, str]
+        summary_dict = getattr(summary, "summary", {}) if summary else {}
+        took = _ns_to_ms(summary_dict)
+        items = [{"index": {"_index": index, "_id": d.get("_id"), "status": 201}} for d in docs]
+        return {"took": took, "errors": False, "items": items}
+
+    async def index(self, index: str, body: Dict, id: Any = None,  # pylint: disable=redefined-builtin
+                    doc_type: Any = None, params: Optional[Dict] = None,
+                    **_kwargs: Any) -> Dict:
+        client = await self._ensure_client()
+        # Standardized convention: read column names from params dict, same as bulk
+        columns = (params or {}).get("column-names") or list(body.keys())
+        row = tuple(body.get(col) for col in columns)
+        await client.insert(index, [row], column_names=columns)
+        return {"_index": index, "_id": id or "", "result": "created", "_version": 1}
+
+    async def search(self, index: Optional[str] = None, body: Optional[Dict] = None,
+                     doc_type: Any = None, **_kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import (  # pylint: disable=import-outside-toplevel
+            convert_query_result_to_search_response, coerce_parameters,
+        )
+        client = await self._ensure_client()
+        body = body or {}
+        sql = body.get("sql")
+        if not sql:
+            raise exceptions.BenchmarkError(
+                "ClickHouse search body missing 'sql' key - see "
+                "docs/user-guides/clickhouse-support.md"
+            )
+        # Warn about unknown top-level keys (commonly happens when copy-pasting OS bodies)
+        unknown = set(body.keys()) - {"sql", "parameters", "settings"}
+        if unknown:
+            self.logger.warning("Ignoring unknown ClickHouse search body keys: %s", sorted(unknown))
+
+        query_params = coerce_parameters(body.get("parameters"))
+        settings = body.get("settings") or None
+        if settings and query_params is not None:
+            result = await client.query(sql, parameters=query_params, settings=settings)
+        elif query_params is not None:
+            result = await client.query(sql, parameters=query_params)
+        elif settings:
+            result = await client.query(sql, settings=settings)
+        else:
+            result = await client.query(sql)
+        elapsed_ns = 0
+        if result.summary:
+            try:
+                elapsed_ns = int(result.summary.get("elapsed_ns", 0))
+            except (TypeError, ValueError):
+                elapsed_ns = 0
+        return convert_query_result_to_search_response(
+            result.result_rows, result.column_names, elapsed_ns=elapsed_ns
+        )
+
+    # -----------------------------------------------------------------
+    # Indices namespace (via self.indices = self)
+    # -----------------------------------------------------------------
+
+    async def create(self, index: Optional[str] = None, body: Optional[Dict] = None,
+                     params: Optional[Dict] = None, **_kwargs: Any) -> Dict:
+        client = await self._ensure_client()
+        body = body or {}
+        ddl = body.get("ddl")
+        if not ddl:
+            ddl_file = body.get("ddl-file")
+            if ddl_file:
+                # Resolve relative paths against params["workload-path"] (OSB standard)
+                if not os.path.isabs(ddl_file) and params and params.get("workload-path"):
+                    ddl_file = os.path.join(params["workload-path"], ddl_file)
+                with open(ddl_file, "r", encoding="utf-8") as fp:
+                    ddl = fp.read()
+        if not ddl:
+            raise exceptions.BenchmarkError(
+                f"ClickHouse CREATE TABLE for '{index}' requires a 'ddl' or 'ddl-file' key "
+                f"in workload.indices[i].body"
+            )
+        await client.command(ddl)
+        return {"acknowledged": True, "shards_acknowledged": True, "index": index}
+
+    async def delete(self, index: Optional[str] = None, **_kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import quote_identifier  # pylint: disable=import-outside-toplevel
+        client = await self._ensure_client()
+        # Support db.table syntax
+        if "." in (index or ""):
+            db, tbl = index.split(".", 1)
+            target = f"{quote_identifier(db)}.{quote_identifier(tbl)}"
+        else:
+            target = quote_identifier(index)
+        await client.command(f"DROP TABLE IF EXISTS {target}")
+        return {"acknowledged": True}
+
+    async def exists(self, index: Optional[str] = None,
+                     database: Optional[str] = None, **_kwargs: Any) -> bool:
+        """Check table existence. Accepts explicit database kwarg or db.table syntax."""
+        client = await self._ensure_client()
+        # Support db.table syntax as an alternative to the database kwarg
+        if database is None and "." in (index or ""):
+            database, index = index.split(".", 1)
+        if database is not None:
+            result = await client.query(
+                "SELECT count() FROM system.tables "
+                "WHERE database = {db:String} AND name = {name:String}",
+                parameters={"db": database, "name": index},
+            )
+        else:
+            result = await client.query(
+                "SELECT count() FROM system.tables "
+                "WHERE database = currentDatabase() AND name = {name:String}",
+                parameters={"name": index},
+            )
+        return bool(result.result_rows and result.result_rows[0][0] > 0)
+
+    async def refresh(self, index: Optional[str] = None, **_kwargs: Any) -> Dict:
+        return {"_shards": {"total": 0, "successful": 0, "failed": 0}}
+
+    async def stats(self, index: Optional[str] = None, metric: Optional[str] = None,
+                    database: Optional[str] = None, **_kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import build_stats_response  # pylint: disable=import-outside-toplevel
+        client = await self._ensure_client()
+        # Support db.table syntax
+        if database is None and index and "." in index:
+            database, index = index.split(".", 1)
+
+        # Log the per-node caveat once per client
+        if not self._stats_caveat_logged:
+            self.logger.warning(
+                "ClickHouse stats reflect single-node values from system.parts. "
+                "For ReplicatedMergeTree clusters, multiply by replica count for cluster totals."
+            )
+            self._stats_caveat_logged = True
+
+        if database is not None:
+            base_where = "database = {db:String}"
+            base_params: Dict[str, Any] = {"db": database}
+        else:
+            base_where = "database = currentDatabase()"
+            base_params = {}
+        sql = (f"SELECT ifNull(sum(rows), 0) AS rows, "
+               f"ifNull(sum(bytes_on_disk), 0) AS bytes "
+               f"FROM system.parts WHERE active AND {base_where}")
+        if index:
+            sql += " AND table = {name:String}"
+            base_params["name"] = index
+        if base_params:
+            result = await client.query(sql, parameters=base_params)
+        else:
+            result = await client.query(sql)
+        rows_count, bytes_on_disk = (result.result_rows[0] if result.result_rows else (0, 0))
+        return build_stats_response(
+            rows=int(rows_count), bytes_on_disk=int(bytes_on_disk), index_name=index
+        )
+
+    async def forcemerge(self, index: Optional[Any] = None, **_kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import quote_identifier  # pylint: disable=import-outside-toplevel
+        client = await self._ensure_client()
+        if index:
+            names = index.split(",") if isinstance(index, str) else index
+            for name in names:
+                name = name.strip()
+                if "." in name:
+                    db, tbl = name.split(".", 1)
+                    target = f"{quote_identifier(db)}.{quote_identifier(tbl)}"
+                else:
+                    target = quote_identifier(name)
+                await client.command(f"OPTIMIZE TABLE {target} FINAL")
+        return {"_shards": {"total": 1, "successful": 1, "failed": 0}}
+
+    # -----------------------------------------------------------------
+    # Cluster namespace
+    # -----------------------------------------------------------------
+
+    async def health(self, **_kwargs: Any) -> Dict:
+        client = await self._ensure_client()
+        ok = await client.ping()
+        status = "green" if ok else "red"
+        return {
+            "cluster_name": self.client_options.get("cluster_name", "clickhouse"),
+            "status": status,
+            "timed_out": False,
+            "number_of_nodes": 1,
+            "number_of_data_nodes": 1,
+            "active_primary_shards": 0,
+            "active_shards": 0,
+            "relocating_shards": 0,
+            "initializing_shards": 0,
+            "unassigned_shards": 0,
+        }
+
+    async def put_settings(self, body: Optional[Dict] = None, **_kwargs: Any) -> Dict:
+        return {"acknowledged": True}
+
+    # -----------------------------------------------------------------
+    # Transport namespace
+    # -----------------------------------------------------------------
+
+    async def perform_request(self, method: str, url: str, params: Any = None,
+                              body: Any = None, headers: Any = None) -> Any:
+        """Minimal escape hatch.
+
+        Routes body-carrying calls through client.command so tests / rarely-used
+        workload paths can still exercise the client. Returns {} for GET-shape calls
+        since ClickHouse's transport is HTTP+SQL, not the REST-DSL that the URL
+        argument implies.
+        """
+        client = await self._ensure_client()
+        if body is not None:
+            # Assume the body is either a SQL string or a JSON-encoded string
+            sql_body = body if isinstance(body, str) else _json.dumps(body)
+            await client.command(sql_body)
+        return {}
+
+    # -----------------------------------------------------------------
+    # Sync helpers
+    # -----------------------------------------------------------------
+
+    def info(self, **_kwargs: Any) -> Dict:
+        from osbenchmark.engine.clickhouse.helpers import parse_version  # pylint: disable=import-outside-toplevel
+        try:
+            sync = self._ensure_sync_client()
+            result = sync.query("SELECT version()")
+            version_str = str(result.result_rows[0][0]) if result.result_rows else ""
+            semver = parse_version(version_str)
+            if semver == "24.8.0" and version_str and not version_str.startswith("24.8."):
+                # Distinct WARNING when fallback is triggered
+                self.logger.warning(
+                    "Could not parse ClickHouse version %r; using fallback %s. "
+                    "Metrics store version field may be misleading.", version_str, semver
+                )
+        except Exception as exc:  # pylint: disable=broad-except
+            self.logger.warning(
+                "ClickHouse info() failed: %s - using fallback version 24.8.0", exc
+            )
+            semver = "24.8.0"
+        return {
+            "name": "clickhouse",
+            "cluster_name": self.client_options.get("cluster_name", "clickhouse"),
+            "cluster_uuid": "clickhouse-benchmark",
+            "version": {
+                "number": semver,
+                "distribution": "clickhouse",
+                "build_type": "release",
+                "build_hash": "unknown",
+            },
+            "tagline": "You Know, for Analytics",
+        }
+
+    def return_raw_response(self) -> None:
+        return None
+
+    # -----------------------------------------------------------------
+    # Lifecycle
+    # -----------------------------------------------------------------
+
+    async def __aenter__(self) -> "ClickHouseDatabaseClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._client is not None:
+            close_method = getattr(self._client, "aclose", None) or getattr(self._client, "close", None)
+            if close_method:
+                try:
+                    result = close_method()
+                    if hasattr(result, "__await__"):
+                        # Bounded timeout - clickhouse-connect close can hang on pending requests
+                        await asyncio.wait_for(result, timeout=10)
+                except asyncio.TimeoutError:
+                    self.logger.warning("Timeout closing async ClickHouse client; forcing null")
+                except Exception as exc:  # pylint: disable=broad-except
+                    self.logger.warning("Error closing async ClickHouse client: %s", exc)
+            self._client = None
+        if self._sync_client is not None:
+            try:
+                self._sync_client.close()
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.warning("Error closing sync ClickHouse client: %s", exc)
+            finally:
+                self._sync_client = None
 
 
 class ClickHouseClientFactory:
@@ -67,4 +543,7 @@ class ClickHouseClientFactory:
         return ClickHouseDatabaseClient(self.hosts, self.client_options)
 
     def wait_for_rest_layer(self, max_attempts: int = 40) -> bool:
-        raise NotImplementedError  # filled in P3
+        from osbenchmark.engine.clickhouse.helpers import wait_for_clickhouse  # pylint: disable=import-outside-toplevel
+        # Build a lightweight duck-typed object that wait_for_clickhouse accepts.
+        ephemeral = ClickHouseDatabaseClient(self.hosts, self.client_options)
+        return wait_for_clickhouse(ephemeral, max_attempts=max_attempts)

--- a/osbenchmark/engine/clickhouse/client.py
+++ b/osbenchmark/engine/clickhouse/client.py
@@ -71,8 +71,11 @@ class ClickHouseDatabaseClient(RequestContextHolder):
         self._database: Optional[str] = None
         self._stats_caveat_logged = False
 
-        # namespace proxies (Vespa pattern). nodes uses a sync proxy so telemetry
-        # devices can call it synchronously.
+        # namespace proxies (Vespa pattern). indices/cluster/transport are
+        # self-references — runners resolve client.indices.create() etc. to
+        # methods on this class directly. nodes is a dedicated async proxy
+        # (see _NodesProxy) so the OS-default NodeStats runner's
+        # `await client.nodes.stats(...)` resolves to an awaitable.
         self.indices = self
         self.cluster = self
         self.transport = self
@@ -197,11 +200,11 @@ class ClickHouseDatabaseClient(RequestContextHolder):
     # -----------------------------------------------------------------
 
     def nodes_stats(self, **_kwargs: Any) -> Dict:
-        """Sync stub. Real Node telemetry is deferred to v2.
+        """Return an OS-shaped nodes-stats stub.
 
-        Called synchronously by OSB telemetry devices (NodeStats). Returns an
-        empty envelope with an OS-shaped 'nodes' key so callers that iterate
-        over it don't KeyError.
+        Called by ``_NodesProxy.stats`` (which is async and wraps this method).
+        Real Node telemetry is deferred to v2. The 'nodes' key is populated
+        (with an empty dict) so callers that iterate over it don't KeyError.
         """
         return {"nodes": {}, "cluster_name": self.client_options.get("cluster_name", "clickhouse")}
 
@@ -211,12 +214,16 @@ class ClickHouseDatabaseClient(RequestContextHolder):
 
     async def bulk(self, body: Any, index: Optional[str] = None,
                    doc_type: Any = None, params: Optional[Dict] = None,
+                   parsed_docs: Optional[List[Dict[str, Any]]] = None,
                    **kwargs: Any) -> Dict:
         from osbenchmark.engine.clickhouse.helpers import (  # pylint: disable=import-outside-toplevel
             parse_bulk_body, rows_from_docs, docs_have_extra_keys, _ns_to_ms
         )
         client = await self._ensure_client()
-        docs = parse_bulk_body(body)
+        # If the caller already parsed the body (e.g. ClickHouseBulkIndex parses
+        # up front for the zero-doc guard), reuse those docs to avoid a
+        # second full parse of the NDJSON stream on the hot path.
+        docs = parsed_docs if parsed_docs is not None else parse_bulk_body(body)
         if not docs:
             return {"took": 0, "errors": False, "items": []}
 
@@ -523,10 +530,12 @@ class ClickHouseDatabaseClient(RequestContextHolder):
             semver = "24.8.0"
         except Exception as exc:  # pylint: disable=broad-except
             # Unexpected exception - still return a fallback so metrics store
-            # doesn't crash, but WARN with the exception type so it's visible.
+            # doesn't crash, but log the full traceback so operators can
+            # diagnose. exc_info=True is critical: without it, WARN loses the
+            # stack trace and the narrower except clause has no diagnostic value.
             self.logger.warning(
                 "ClickHouse info() raised unexpected %s: %s - using fallback version 24.8.0",
-                type(exc).__name__, exc
+                type(exc).__name__, exc, exc_info=True
             )
             semver = "24.8.0"
         return {

--- a/osbenchmark/engine/clickhouse/client.py
+++ b/osbenchmark/engine/clickhouse/client.py
@@ -1,0 +1,70 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ClickHouse database client for OpenSearch Benchmark.
+
+See the sibling engine/vespa/client.py for the pattern this file follows.
+"""
+
+from __future__ import annotations  # ensure all type hints are stringified
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from osbenchmark import exceptions
+from osbenchmark.context import RequestContextHolder
+
+try:
+    import clickhouse_connect  # type: ignore
+    CLICKHOUSE_CONNECT_AVAILABLE = True
+except ImportError:
+    clickhouse_connect = None  # type: ignore
+    CLICKHOUSE_CONNECT_AVAILABLE = False
+
+
+class ClickHouseDatabaseClient(RequestContextHolder):
+    """Async ClickHouse client that duck-types the OSB engine client interface.
+
+    Follows the Vespa pattern: self.indices = self, self.cluster = self, etc.,
+    so runners can call client.indices.create(...) and resolve to methods on
+    this class directly. Inherits from RequestContextHolder (same as
+    VespaDatabaseClient) so OSB can attach request lifecycle hooks; multi-engine
+    does NOT have a DatabaseClient ABC to satisfy, so duck-typing is sufficient
+    for the runner interface.
+    """
+
+    def __init__(self, hosts: List[Dict], client_options: Dict) -> None:
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+        self._hosts = hosts
+        self.client_options = client_options or {}
+        self._client = None  # clickhouse_connect.AsyncClient, initialized lazily
+        self._sync_client = None  # clickhouse_connect.Client, for info()/wait_for_client
+        self._client_lock = asyncio.Lock()  # prevents duplicate init under contention
+        self._database = None
+
+        # namespace proxies (Vespa pattern). See "nodes_stats" below for the sync stub.
+        self.indices = self
+        self.cluster = self
+        self.transport = self
+        self.nodes = self
+
+    # methods stubbed here — filled in P3
+
+
+class ClickHouseClientFactory:
+    """Factory called by osbenchmark.engine.clickhouse.create_client_factory."""
+
+    def __init__(self, hosts: List[Dict], client_options: Dict) -> None:
+        self.hosts = hosts
+        self.client_options = client_options or {}
+
+    def create(self) -> "ClickHouseDatabaseClient":
+        return ClickHouseDatabaseClient(self.hosts, self.client_options)
+
+    def create_async(self) -> "ClickHouseDatabaseClient":
+        return ClickHouseDatabaseClient(self.hosts, self.client_options)
+
+    def wait_for_rest_layer(self, max_attempts: int = 40) -> bool:
+        raise NotImplementedError  # filled in P3

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import requests
 

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -1,0 +1,11 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure helpers for the ClickHouse backend.
+
+Everything here is I/O-free and unit-testable in isolation.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# populated in P2

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -3,9 +3,418 @@
 
 """Pure helpers for the ClickHouse backend.
 
-Everything here is I/O-free and unit-testable in isolation.
+Everything here (except wait_for_clickhouse) is I/O-free and unit-testable.
 """
 
-from typing import Any, Dict, List, Optional
+import json
+import logging
+import re
+import time
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
-# populated in P2
+import requests
+
+from osbenchmark import exceptions
+
+logger = logging.getLogger(__name__)
+
+# Actions supported by ClickHouseDatabaseClient.bulk. Non-index
+# actions ("update", "delete") are not currently routable to ClickHouse's
+# insert-only path and MUST be rejected at parse time.
+_SUPPORTED_BULK_ACTIONS = frozenset({"index", "create"})
+_ALL_BULK_ACTIONS = frozenset({"index", "create", "update", "delete"})
+
+# Semver validator used by info()
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _ns_to_ms(summary_dict: Optional[Mapping[str, Any]]) -> int:
+    """Coerce elapsed_ns (a string from the X-ClickHouse-Summary header) to ms.
+
+    Handles the string->int conversion BEFORE floor-division, avoiding the
+    ``TypeError: unsupported operand type(s) for //: 'str' and 'int'`` bug
+    that would otherwise occur on every ClickHouse RPC.
+    """
+    if not summary_dict:
+        return 0
+    raw = summary_dict.get("elapsed_ns", 0)
+    try:
+        return int(raw) // 1_000_000
+    except (TypeError, ValueError):
+        return 0
+
+
+def quote_identifier(name: str) -> str:
+    """Return `name` as a backticked ClickHouse identifier.
+
+    Escapes embedded backticks by doubling. Rejects None, empty strings, and
+    strings containing NUL/CR/LF, which ClickHouse rejects even when backticked.
+    This is used for table and column names originating from workload YAML.
+    Do NOT use it for values (use parameterized queries for values).
+    """
+    if name is None:
+        raise ValueError("Cannot quote a None identifier")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"Cannot quote empty or non-string identifier: {name!r}")
+    if "\x00" in name or "\r" in name or "\n" in name:
+        raise ValueError(f"Identifier contains disallowed control character: {name!r}")
+    escaped = name.replace("`", "``")
+    return f"`{escaped}`"
+
+
+def parse_bulk_body(body: Any) -> List[Dict[str, Any]]:
+    """Normalize an OSB bulk body into a list of {"_id","_source","_action"} dicts.
+
+    Accepts bytes (NDJSON), string (NDJSON), or a Python list of alternating
+    action/doc dicts. Rejects any 'update' or 'delete' action with a
+    BenchmarkError, since ClickHouse's insert-only bulk path cannot route
+    these actions.
+
+    Fails LOUD on excessive corruption: if more than 1% of lines could not be
+    parsed as JSON, raises BenchmarkError. Prevents silent throughput fraud
+    from a truncated bulk feed.
+    """
+    # bytes -> str
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8")
+
+    docs: List[Dict[str, Any]] = []
+
+    if isinstance(body, str):
+        raw_lines = [line for line in body.split("\n") if line.strip()]
+        parsed: List[Dict[str, Any]] = []
+        skipped = 0
+        for line in raw_lines:
+            try:
+                parsed.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping invalid bulk NDJSON: %s", exc)
+                skipped += 1
+        if raw_lines and skipped / len(raw_lines) > 0.01:
+            raise exceptions.BenchmarkError(
+                f"parse_bulk_body: {skipped}/{len(raw_lines)} lines could not be parsed as JSON "
+                f"(>1% corruption). Bulk feed is likely truncated or malformed."
+            )
+        # Reject delete actions BEFORE pair-consumption to prevent mis-pairing
+        i = 0
+        while i < len(parsed):
+            action_meta = parsed[i]
+            action = _extract_action(action_meta)
+            _reject_non_index_actions(action)
+            # index/create actions must have a source line
+            if i + 1 >= len(parsed):
+                raise exceptions.BenchmarkError(
+                    f"parse_bulk_body: action '{action}' at position {i} has no source line"
+                )
+            source = parsed[i + 1]
+            doc_id = _extract_doc_id(action_meta)
+            docs.append({"_id": doc_id, "_source": source, "_action": action})
+            i += 2
+        return docs
+
+    if isinstance(body, list):
+        if body and isinstance(body[0], dict) and "_source" in body[0]:
+            return body  # already normalized
+        i = 0
+        while i < len(body):
+            action_meta = body[i]
+            action = _extract_action(action_meta)
+            _reject_non_index_actions(action)
+            if i + 1 >= len(body):
+                raise exceptions.BenchmarkError(
+                    f"parse_bulk_body: action '{action}' at position {i} has no source dict"
+                )
+            source = body[i + 1]
+            doc_id = _extract_doc_id(action_meta)
+            docs.append({"_id": doc_id, "_source": source, "_action": action})
+            i += 2
+        return docs
+
+    raise ValueError(f"Unsupported bulk body type: {type(body).__name__}")
+
+
+def _reject_non_index_actions(action: str) -> None:
+    if action in ("update", "delete"):
+        raise exceptions.BenchmarkError(
+            f"ClickHouse bulk does not support '{action}' actions in v1. "
+            f"Only 'index' and 'create' actions are routed to client.insert(). "
+            f"See Follow-ups / v2 for ReplacingMergeTree-based upsert support."
+        )
+    if action not in _SUPPORTED_BULK_ACTIONS:
+        raise exceptions.BenchmarkError(f"Unknown bulk action: {action}")
+
+
+def _extract_action(action_meta: Dict[str, Any]) -> str:
+    for key in _ALL_BULK_ACTIONS:
+        if key in action_meta:
+            return key
+    return "index"
+
+
+def _extract_doc_id(action_meta: Dict[str, Any]) -> Optional[str]:
+    for key in _ALL_BULK_ACTIONS:
+        if key in action_meta:
+            meta = action_meta[key] or {}
+            return meta.get("_id")
+    return None
+
+
+def rows_from_docs(docs: List[Dict[str, Any]], columns: List[str], strict: bool = False) -> List[Tuple]:
+    """Project docs into positional row tuples aligned with `columns`.
+
+    Missing columns become None. If any doc contains keys NOT in `columns`,
+    they are silently dropped from the fast path - the caller is expected to
+    detect this and switch to the JSONEachRow fallback.
+
+    When strict=True, raises BenchmarkError on any missing column instead of
+    substituting None.
+    """
+    rows: List[Tuple] = []
+    columns_set = set(columns)
+    for i, doc in enumerate(docs):
+        source = doc.get("_source", {}) or {}
+        if strict:
+            missing = columns_set - set(source.keys())
+            if missing:
+                raise exceptions.BenchmarkError(
+                    f"rows_from_docs: doc {i} (_id={doc.get('_id')}) is missing "
+                    f"columns {sorted(missing)} required by column-names."
+                )
+        rows.append(tuple(source.get(col) for col in columns))
+    return rows
+
+
+def docs_have_extra_keys(docs: List[Dict[str, Any]], columns: List[str]) -> bool:
+    """Return True if any doc contains keys not present in `columns`.
+
+    Used by client.bulk() to trigger the JSONEachRow fallback path.
+    """
+    columns_set = set(columns)
+    for doc in docs:
+        source = doc.get("_source", {}) or {}
+        if set(source.keys()) - columns_set:
+            return True
+    return False
+
+
+def coerce_parameters(params: Any) -> Any:
+    """Recursively convert numpy scalars and arrays to Python built-ins.
+
+    clickhouse-connect's ``parameters`` argument expects Python lists (for
+    Array-typed parameters) and Python scalars. numpy types serialize as
+    ``str(x)`` which produces ``'[1.0 2.0 3.0]'`` - no commas, ClickHouse
+    parses as a text-cast failure. This helper handles the coercion.
+    Safe to call on non-numpy inputs (returns them unchanged).
+    """
+    if params is None:
+        return None
+    # numpy is optional at import time - only coerce when it is available.
+    try:
+        import numpy as np  # type: ignore  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        return params
+
+    def _coerce(value: Any) -> Any:
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, dict):
+            return {k: _coerce(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return type(value)(_coerce(v) for v in value)
+        return value
+
+    return _coerce(params)
+
+
+def convert_query_result_to_search_response(
+    result_rows: List[Tuple],
+    column_names: Tuple[str, ...],
+    elapsed_ns: Optional[Any] = None,
+    total_hits: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Convert a clickhouse_connect QueryResult into an OpenSearch-shaped dict.
+
+    Note on ``hits.total.value``: unless the caller supplies ``total_hits`` from
+    a companion COUNT query, this value equals ``len(hits)`` - i.e. the number
+    of returned rows, NOT the number of matched rows. Workloads that make
+    assertions on total match count MUST supply ``total_hits`` from a separate
+    COUNT query.
+    """
+    hits = []
+    for row in result_rows:
+        source = dict(zip(column_names, row))
+        hit_id = source.pop("_id", "") if "_id" in source else ""
+        hits.append({
+            "_index": "",
+            "_id": str(hit_id) if hit_id != "" else "",
+            "_score": None,
+            "_source": source,
+        })
+
+    took_ms = _ns_to_ms({"elapsed_ns": elapsed_ns}) if elapsed_ns is not None else 0
+    hits_count = total_hits if total_hits is not None else len(hits)
+    return {
+        "took": took_ms,
+        "timed_out": False,
+        "hits": {
+            "total": {"value": hits_count, "relation": "eq"},
+            "max_score": None,
+            "hits": hits,
+        },
+    }
+
+
+def convert_query_result_for_vector_search(
+    result_rows: List[Tuple],
+    column_names: Tuple[str, ...],
+    score_column: str = "score",
+    id_column: str = "id",
+    elapsed_ns: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Convert a k-NN QueryResult to OpenSearch-shaped hits with _score populated."""
+    hits = []
+    max_score = None
+    for row in result_rows:
+        source = dict(zip(column_names, row))
+        score = source.pop(score_column, None) if score_column in source else None
+        hit_id = source.pop(id_column, "") if id_column in source else ""
+        if score is not None:
+            if max_score is None or score > max_score:
+                max_score = score
+        hits.append({
+            "_index": "",
+            "_id": str(hit_id) if hit_id != "" else "",
+            "_score": score,
+            "_source": source,
+        })
+    took_ms = _ns_to_ms({"elapsed_ns": elapsed_ns}) if elapsed_ns is not None else 0
+    return {
+        "took": took_ms,
+        "timed_out": False,
+        "hits": {
+            "total": {"value": len(hits), "relation": "eq"},
+            "max_score": max_score,
+            "hits": hits,
+        },
+    }
+
+
+def build_stats_response(rows: int, bytes_on_disk: int, index_name: Optional[str]) -> Dict[str, Any]:
+    """Fabricate an OS-shaped indices/stats response from ClickHouse system.parts row.
+
+    Caveat: on ReplicatedMergeTree tables, ``system.parts`` reflects only the local
+    node - cluster-wide byte totals are 2-3x higher. Callers should log a warning
+    on first use and users should multiply by replica count.
+    """
+    stats = {
+        "docs": {"count": rows, "deleted": 0},
+        "store": {"size_in_bytes": bytes_on_disk},
+    }
+    envelope = {
+        "_all": {"primaries": stats, "total": stats},
+        "indices": {},
+    }
+    if index_name:
+        envelope["indices"][index_name] = {"primaries": stats, "total": stats}
+    return envelope
+
+
+def parse_version(version_str: str) -> str:
+    """Return a strict semver (e.g. '24.8.1') from a ClickHouse version string.
+
+    Handles ``'24.8.1.2684'``, ``'25.5.1.11-stable'``, ``'24.8.1.2684-cloud'``,
+    and other well-formed builds. Returns the '24.8.0' fallback for
+    non-semver-parseable inputs like ``'head-fcbd7a4'`` or ``'24.8'``.
+    """
+    if not version_str or not isinstance(version_str, str):
+        return "24.8.0"
+    parts = version_str.split(".")
+    if len(parts) < 3:
+        return "24.8.0"
+    # Take first three parts, strip any build suffix from the third.
+    third = parts[2].split("-")[0]
+    candidate = f"{parts[0]}.{parts[1]}.{third}"
+    if not _SEMVER_RE.match(candidate):
+        return "24.8.0"
+    return candidate
+
+
+def wait_for_clickhouse(
+    ch_client: Any,
+    max_attempts: int = 40,
+    sleep_seconds: float = 3.0,
+) -> bool:
+    """Poll GET {ch_client.endpoint}/ping until the server returns 200 or attempts exhausted.
+
+    Mirrors wait_for_vespa: same retry loop, INFO on ready, DEBUG on retry,
+    WARNING for SSL errors.
+
+    Accepts any 200 response (not just body == 'Ok.'), because ClickHouse cloud
+    proxies can return JSON like '{"status":"ok"}' at /ping.
+    """
+    # Duck-typed endpoint resolution.
+    endpoint = getattr(ch_client, "endpoint", None)
+    verify: Any = True
+    if endpoint is None:
+        # Derive from the client's hosts/options as a fallback.
+        hosts = getattr(ch_client, "_hosts", None) or []
+        options = getattr(ch_client, "client_options", {}) or {}
+        host, port, secure = parse_hosts(hosts) if hosts else ("localhost", 8123, False)
+        scheme = "https" if secure else "http"
+        endpoint = f"{scheme}://{host}:{port}"
+        verify = options.get("ssl_verify", True)
+    else:
+        options = getattr(ch_client, "client_options", {}) or {}
+        verify = options.get("ssl_verify", True)
+
+    endpoint = endpoint.rstrip("/")
+    url = f"{endpoint}/ping"
+    for attempt in range(max_attempts):
+        try:
+            resp = requests.get(url, timeout=5, verify=verify)
+            if resp.status_code == 200:
+                logger.info("ClickHouse ready after %d attempt(s)", attempt + 1)
+                return True
+            logger.debug("ClickHouse not ready yet (status=%s, body=%r)", resp.status_code, resp.text[:64])
+        except requests.exceptions.SSLError as exc:
+            # Distinct WARNING for SSL - usually indicates a misconfigured verify=
+            logger.warning("ClickHouse ping attempt %d failed with SSL error: %s", attempt + 1, exc)
+        except requests.RequestException as exc:
+            logger.debug("ClickHouse ping attempt %d failed: %s", attempt + 1, exc)
+        time.sleep(sleep_seconds)
+    return False
+
+
+def parse_hosts(hosts: Any) -> Tuple[str, int, bool]:
+    """Extract (host, port, secure) from OSB's hosts list.
+
+    Validates port range 1-65535. Supports IPv6 by unwrapping brackets.
+    Sets secure=True for both port 8443 (HTTPS) and 9440 (native TLS -
+    though only 8443 works with clickhouse-connect's HTTP driver). Rejects
+    port 9000 (native binary protocol) with a clear message.
+    """
+    if isinstance(hosts, dict):
+        hosts = hosts.get("default", [])
+    if not hosts:
+        raise exceptions.SystemSetupError("No ClickHouse hosts configured")
+    first = hosts[0]
+    host = first.get("host", "localhost")
+    # IPv6: strip brackets if present so clickhouse-connect can parse
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    try:
+        port = int(first.get("port", 8123))
+    except (TypeError, ValueError) as exc:
+        raise exceptions.SystemSetupError(f"Invalid ClickHouse port: {first.get('port')!r}") from exc
+    if not 1 <= port <= 65535:
+        raise exceptions.SystemSetupError(f"ClickHouse port out of range: {port}")
+    if port == 9000:
+        raise exceptions.SystemSetupError(
+            "Port 9000 is ClickHouse's native binary protocol. clickhouse-connect uses HTTP; "
+            "use port 8123 (HTTP) or 8443 (HTTPS) instead."
+        )
+    # secure defaults to True for TLS ports; user can override with use_ssl.
+    secure = bool(first.get("use_ssl", port in (8443, 9440)))
+    return host, port, secure

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -70,9 +70,9 @@ def parse_bulk_body(body: Any) -> List[Dict[str, Any]]:
     BenchmarkError, since ClickHouse's insert-only bulk path cannot route
     these actions.
 
-    Fails LOUD on excessive corruption: if more than 1% of lines could not be
-    parsed as JSON, raises BenchmarkError. Prevents silent throughput fraud
-    from a truncated bulk feed.
+    Fails LOUD on the very first parse error. A silent tolerance is worse than
+    a benchmark abort because a single skipped line mis-aligns the pair-consumer
+    below, silently misattributing every downstream doc.
     """
     # bytes -> str
     if isinstance(body, (bytes, bytearray)):
@@ -83,18 +83,15 @@ def parse_bulk_body(body: Any) -> List[Dict[str, Any]]:
     if isinstance(body, str):
         raw_lines = [line for line in body.split("\n") if line.strip()]
         parsed: List[Dict[str, Any]] = []
-        skipped = 0
-        for line in raw_lines:
+        for lineno, line in enumerate(raw_lines):
             try:
                 parsed.append(json.loads(line))
             except json.JSONDecodeError as exc:
-                logger.warning("Skipping invalid bulk NDJSON: %s", exc)
-                skipped += 1
-        if raw_lines and skipped / len(raw_lines) > 0.01:
-            raise exceptions.BenchmarkError(
-                f"parse_bulk_body: {skipped}/{len(raw_lines)} lines could not be parsed as JSON "
-                f"(>1% corruption). Bulk feed is likely truncated or malformed."
-            )
+                raise exceptions.BenchmarkError(
+                    f"parse_bulk_body: line {lineno} could not be parsed as JSON "
+                    f"({exc}). Bulk feed is truncated or malformed - aborting to avoid "
+                    f"silent pair-consumer misalignment."
+                ) from exc
         # Reject delete actions BEFORE pair-consumption to prevent mis-pairing
         i = 0
         while i < len(parsed):
@@ -148,7 +145,15 @@ def _extract_action(action_meta: Dict[str, Any]) -> str:
     for key in _ALL_BULK_ACTIONS:
         if key in action_meta:
             return key
-    return "index"
+    # No recognized action key. This means either the bulk body is misaligned
+    # (a source doc appeared where an action-meta was expected) or the workload
+    # emitted an unknown action. Raising here surfaces the corruption loudly
+    # instead of silently coercing to 'index'.
+    raise exceptions.BenchmarkError(
+        f"parse_bulk_body: action_meta {action_meta!r} has no recognized action key "
+        f"(expected one of {sorted(_ALL_BULK_ACTIONS)}). This indicates a misaligned "
+        f"bulk body or an unsupported action type."
+    )
 
 
 def _extract_doc_id(action_meta: Dict[str, Any]) -> Optional[str]:
@@ -246,9 +251,12 @@ def convert_query_result_to_search_response(
     for row in result_rows:
         source = dict(zip(column_names, row))
         hit_id = source.pop("_id", "") if "_id" in source else ""
+        # Coerce SQL NULL (Python None) to empty string BEFORE the "" check so
+        # None doesn't become the literal string 'None' downstream.
+        hit_id = "" if hit_id is None else str(hit_id)
         hits.append({
             "_index": "",
-            "_id": str(hit_id) if hit_id != "" else "",
+            "_id": hit_id if hit_id != "" else "",
             "_score": None,
             "_source": source,
         })
@@ -280,12 +288,15 @@ def convert_query_result_for_vector_search(
         source = dict(zip(column_names, row))
         score = source.pop(score_column, None) if score_column in source else None
         hit_id = source.pop(id_column, "") if id_column in source else ""
+        # Coerce SQL NULL (Python None) to empty string BEFORE the "" check so
+        # None doesn't become the literal string 'None' downstream.
+        hit_id = "" if hit_id is None else str(hit_id)
         if score is not None:
             if max_score is None or score > max_score:
                 max_score = score
         hits.append({
             "_index": "",
-            "_id": str(hit_id) if hit_id != "" else "",
+            "_id": hit_id if hit_id != "" else "",
             "_score": score,
             "_source": source,
         })
@@ -399,6 +410,14 @@ def parse_hosts(hosts: Any) -> Tuple[str, int, bool]:
         hosts = hosts.get("default", [])
     if not hosts:
         raise exceptions.SystemSetupError("No ClickHouse hosts configured")
+    if len(hosts) > 1:
+        # Multi-host load balancing is a v2 follow-up. Warn so users know their
+        # extra hosts are being dropped instead of silently used.
+        logger.warning(
+            "ClickHouse client received %d hosts but only the first (%r) will be used. "
+            "Multi-host load balancing is a v2 follow-up.",
+            len(hosts), hosts[0]
+        )
     first = hosts[0]
     host = first.get("host", "localhost")
     # IPv6: strip brackets if present so clickhouse-connect can parse

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -31,10 +31,12 @@ _ALL_BULK_ACTIONS = ("index", "create", "update", "delete")
 # Semver validator used by info()
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
-# Module-level flag to dedupe the multi-host warning. parse_hosts is called
+# Dedupe the multi-host warning per unique host tuple. parse_hosts is called
 # from _ensure_client, _ensure_sync_client, and endpoint property; without
-# dedupe the same message logs N * 3 times per worker.
-_MULTI_HOST_WARNED = False
+# dedupe the same message logs N * 3 times per worker. Keyed by the host set
+# so a second benchmark launched in the same Python process against a
+# DIFFERENT multi-host config still warns (a plain bool would silence it).
+_MULTI_HOST_WARNED_KEYS: set = set()
 
 
 def _ns_to_ms(summary_dict: Optional[Mapping[str, Any]]) -> int:
@@ -420,18 +422,20 @@ def parse_hosts(hosts: Any) -> Tuple[str, int, bool]:
     if not hosts:
         raise exceptions.SystemSetupError("No ClickHouse hosts configured")
     if len(hosts) > 1:
-        # Multi-host load balancing is a v2 follow-up. Warn ONCE per process
-        # (parse_hosts is called by _ensure_client, _ensure_sync_client, and
-        # endpoint — dedupe so we don't log the same message ~24 times per
-        # 8-worker benchmark).
-        global _MULTI_HOST_WARNED  # pylint: disable=global-statement
-        if not _MULTI_HOST_WARNED:
+        # Multi-host load balancing is a v2 follow-up. Warn ONCE per unique
+        # host set (parse_hosts is called by _ensure_client,
+        # _ensure_sync_client, and endpoint — dedupe so we don't log the same
+        # message ~24 times per 8-worker benchmark). Keying on the host tuple
+        # ensures a second benchmark against a different multi-host config
+        # still emits its own warning.
+        key = tuple(sorted((h.get("host"), h.get("port")) for h in hosts))
+        if key not in _MULTI_HOST_WARNED_KEYS:
             logger.warning(
                 "ClickHouse client received %d hosts but only the first (%r) will be used. "
                 "Multi-host load balancing is a v2 follow-up.",
                 len(hosts), hosts[0]
             )
-            _MULTI_HOST_WARNED = True
+            _MULTI_HOST_WARNED_KEYS.add(key)
     first = hosts[0]
     host = first.get("host", "localhost")
     # IPv6: strip brackets if present so clickhouse-connect can parse

--- a/osbenchmark/engine/clickhouse/helpers.py
+++ b/osbenchmark/engine/clickhouse/helpers.py
@@ -22,10 +22,19 @@ logger = logging.getLogger(__name__)
 # actions ("update", "delete") are not currently routable to ClickHouse's
 # insert-only path and MUST be rejected at parse time.
 _SUPPORTED_BULK_ACTIONS = frozenset({"index", "create"})
-_ALL_BULK_ACTIONS = frozenset({"index", "create", "update", "delete"})
+# Fixed-order tuple, not a frozenset: iteration order matters when an
+# action_meta dict happens to contain multiple recognized keys. A set-based
+# iteration would return different actions across Python runs (PYTHONHASHSEED
+# randomization) and produce non-deterministic behavior.
+_ALL_BULK_ACTIONS = ("index", "create", "update", "delete")
 
 # Semver validator used by info()
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+# Module-level flag to dedupe the multi-host warning. parse_hosts is called
+# from _ensure_client, _ensure_sync_client, and endpoint property; without
+# dedupe the same message logs N * 3 times per worker.
+_MULTI_HOST_WARNED = False
 
 
 def _ns_to_ms(summary_dict: Optional[Mapping[str, Any]]) -> int:
@@ -151,7 +160,7 @@ def _extract_action(action_meta: Dict[str, Any]) -> str:
     # instead of silently coercing to 'index'.
     raise exceptions.BenchmarkError(
         f"parse_bulk_body: action_meta {action_meta!r} has no recognized action key "
-        f"(expected one of {sorted(_ALL_BULK_ACTIONS)}). This indicates a misaligned "
+        f"(expected one of {list(_ALL_BULK_ACTIONS)}). This indicates a misaligned "
         f"bulk body or an unsupported action type."
     )
 
@@ -251,12 +260,12 @@ def convert_query_result_to_search_response(
     for row in result_rows:
         source = dict(zip(column_names, row))
         hit_id = source.pop("_id", "") if "_id" in source else ""
-        # Coerce SQL NULL (Python None) to empty string BEFORE the "" check so
-        # None doesn't become the literal string 'None' downstream.
+        # Coerce SQL NULL (Python None) to empty string so None doesn't
+        # become the literal string 'None' downstream.
         hit_id = "" if hit_id is None else str(hit_id)
         hits.append({
             "_index": "",
-            "_id": hit_id if hit_id != "" else "",
+            "_id": hit_id,
             "_score": None,
             "_source": source,
         })
@@ -288,15 +297,15 @@ def convert_query_result_for_vector_search(
         source = dict(zip(column_names, row))
         score = source.pop(score_column, None) if score_column in source else None
         hit_id = source.pop(id_column, "") if id_column in source else ""
-        # Coerce SQL NULL (Python None) to empty string BEFORE the "" check so
-        # None doesn't become the literal string 'None' downstream.
+        # Coerce SQL NULL (Python None) to empty string so None doesn't
+        # become the literal string 'None' downstream.
         hit_id = "" if hit_id is None else str(hit_id)
         if score is not None:
             if max_score is None or score > max_score:
                 max_score = score
         hits.append({
             "_index": "",
-            "_id": hit_id if hit_id != "" else "",
+            "_id": hit_id,
             "_score": score,
             "_source": source,
         })
@@ -411,13 +420,18 @@ def parse_hosts(hosts: Any) -> Tuple[str, int, bool]:
     if not hosts:
         raise exceptions.SystemSetupError("No ClickHouse hosts configured")
     if len(hosts) > 1:
-        # Multi-host load balancing is a v2 follow-up. Warn so users know their
-        # extra hosts are being dropped instead of silently used.
-        logger.warning(
-            "ClickHouse client received %d hosts but only the first (%r) will be used. "
-            "Multi-host load balancing is a v2 follow-up.",
-            len(hosts), hosts[0]
-        )
+        # Multi-host load balancing is a v2 follow-up. Warn ONCE per process
+        # (parse_hosts is called by _ensure_client, _ensure_sync_client, and
+        # endpoint — dedupe so we don't log the same message ~24 times per
+        # 8-worker benchmark).
+        global _MULTI_HOST_WARNED  # pylint: disable=global-statement
+        if not _MULTI_HOST_WARNED:
+            logger.warning(
+                "ClickHouse client received %d hosts but only the first (%r) will be used. "
+                "Multi-host load balancing is a v2 follow-up.",
+                len(hosts), hosts[0]
+            )
+            _MULTI_HOST_WARNED = True
     first = hosts[0]
     host = first.get("host", "localhost")
     # IPv6: strip brackets if present so clickhouse-connect can parse

--- a/osbenchmark/engine/clickhouse/runners.py
+++ b/osbenchmark/engine/clickhouse/runners.py
@@ -4,11 +4,34 @@
 """ClickHouse-native runners for OSB operations."""
 
 import logging
+import re
 
 from osbenchmark import exceptions
 from osbenchmark.worker_coordinator.runner import Runner, request_context_holder
 
 logger = logging.getLogger(__name__)
+
+# Match ORDER BY as a real SQL clause boundary (whitespace-separated tokens).
+# Applied after stripping SQL comments and single-quoted string literals so it
+# doesn't false-match on identifiers or string contents like 'ORDER BYPASS'.
+_ORDER_BY_RE = re.compile(r"\bORDER\s+BY\b", re.IGNORECASE)
+# Line comment: `-- ...` to end of line. Block comment: `/* ... */`.
+_SQL_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_SQL_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Single-quoted string literal. Handles doubled '' escapes.
+_SQL_STRING_LITERAL_RE = re.compile(r"'(?:''|[^'])*'")
+
+
+def _strip_sql_noise(sql: str) -> str:
+    """Return `sql` with comments and single-quoted string literals removed.
+
+    Used to make ``ORDER BY``-in-SQL detection robust against string contents
+    and comments. NOT suitable as a SQL sanitizer for execution.
+    """
+    stripped = _SQL_BLOCK_COMMENT_RE.sub(" ", sql)
+    stripped = _SQL_LINE_COMMENT_RE.sub(" ", stripped)
+    stripped = _SQL_STRING_LITERAL_RE.sub(" ", stripped)
+    return stripped
 
 
 def _compute_recall(hits, neighbors, k):
@@ -47,25 +70,48 @@ class ClickHouseBulkIndex(Runner):
     multi_cluster = False
 
     async def __call__(self, clickhouse_client, params):
+        # pylint: disable=import-outside-toplevel
+        from osbenchmark.engine.clickhouse.helpers import parse_bulk_body
         index = params.get("index") or params.get("table")
         body = params.get("body")
         bulk_size = params.get("bulk-size", 0)
         unit = params.get("unit", "docs")
 
-        # Guard against 0-doc batches when bulk-size was expected
-        if bulk_size > 0 and (not body or (isinstance(body, list) and len(body) == 0)):
-            self.logger.warning("Bulk operation on %s had 0 docs but bulk-size=%d",
-                                index, bulk_size)
-            return {"weight": 0, "unit": unit, "success": False, "error-count": 1, "took": 0}
+        # Zero-doc guard: parse the body ONCE up front so we can detect an empty
+        # feed regardless of whether the workload declared bulk-size. A missing
+        # bulk-size (defaults to 0) previously bypassed this check and let empty
+        # bulks silently "succeed".
+        try:
+            parsed_docs = parse_bulk_body(body) if body else []
+        except exceptions.BenchmarkError:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            # Parse errors surface as a runner failure, not a raised exception
+            # (which would abort the whole benchmark).
+            self.logger.warning("Bulk body parse failed: %s", exc)
+            return {"weight": bulk_size, "unit": unit, "success": False,
+                    "error-count": 1, "took": 0}
+        if not parsed_docs:
+            raise exceptions.BenchmarkError(
+                f"Bulk operation on {index!r} produced 0 parsed docs "
+                f"(bulk-size={bulk_size}). Workload params-source is likely "
+                f"misconfigured - non-zero bulk-size with an empty body is a bug."
+            )
 
         request_context_holder.on_client_request_start()
         request_context_holder.on_request_start()
         try:
             response = await clickhouse_client.bulk(body=body, index=index, params=params)
         except Exception as exc:  # pylint: disable=broad-except
-            # Handle mid-run server failures: reset client so next call re-connects
+            # Surface the failure to the sample stream. We deliberately do NOT
+            # mutate clickhouse_client._client here: forcing a re-init on any
+            # transient error is a race against _ensure_client's lock, and if
+            # the underlying client is genuinely broken the next _ensure_client
+            # call won't detect that anyway. Retry semantics belong in a retry
+            # decorator, not ad-hoc private-field mutation.
+            # TODO(P8): wire engine.clickhouse.on_execute_error into the sample
+            #   error path so transient httpx errors get consistent handling.
             self.logger.warning("Bulk RPC raised: %s", exc)
-            clickhouse_client._client = None  # trigger re-init in next _ensure_client call
             request_context_holder.on_request_end()
             request_context_holder.on_client_request_end()
             return {"weight": bulk_size, "unit": unit, "success": False,
@@ -110,8 +156,8 @@ class ClickHouseQuery(Runner):
             try:
                 response = await clickhouse_client.search(body=body)
             except Exception as exc:  # pylint: disable=broad-except
+                # Do NOT mutate clickhouse_client._client (race with _ensure_client's lock).
                 self.logger.warning("Search RPC raised: %s", exc)
-                clickhouse_client._client = None
                 return {"weight": 1, "unit": "ops", "success": False,
                         "error-count": 1, "took": 0}
         finally:
@@ -161,8 +207,10 @@ class ClickHouseVectorSearch(Runner):
         score_field = params.get("score-field", "score")
 
         settings = dict(body.get("settings") or {})
-        if ef_search:
-            settings["hnsw_candidate_list_size_for_search"] = ef_search
+        # Use `is not None` so an explicit hnsw_ef_search=0 reaches ClickHouse
+        # unchanged (0 disables candidate expansion in HNSW-style queries).
+        if ef_search is not None:
+            settings["hnsw_candidate_list_size_for_search"] = int(ef_search)
             settings.setdefault("max_limit_for_vector_search_queries", max(1000, k))
 
         parameters = coerce_parameters(body.get("parameters"))
@@ -177,8 +225,8 @@ class ClickHouseVectorSearch(Runner):
                     settings=settings or None,
                 )
             except Exception as exc:  # pylint: disable=broad-except
+                # Do NOT mutate clickhouse_client._client (race with _ensure_client's lock).
                 self.logger.warning("Vector search RPC raised: %s", exc)
-                clickhouse_client._client = None
                 return {"weight": 1, "unit": "ops", "success": False,
                         "error-count": 1, "took": 0}
         finally:
@@ -238,7 +286,9 @@ class ClickHouseScrollQuery(Runner):
                 "injection is unsafe because it corrupts SQL with existing LIMIT, "
                 "ORDER BY, or FORMAT clauses."
             )
-        if "ORDER BY" not in base_sql.upper():
+        # Strip comments and string literals BEFORE checking for ORDER BY so
+        # e.g. `WHERE label = 'ORDER BYPASS'` doesn't false-match.
+        if not _ORDER_BY_RE.search(_strip_sql_noise(base_sql)):
             raise exceptions.BenchmarkError(
                 "ClickHouseScrollQuery requires the workload SQL to include ORDER BY on a "
                 "deterministic key; pagination without ordering returns different rows per page."
@@ -259,8 +309,8 @@ class ClickHouseScrollQuery(Runner):
                         base_sql, parameters=base_params, settings=body.get("settings"),
                     )
                 except Exception as exc:  # pylint: disable=broad-except
+                    # Do NOT mutate clickhouse_client._client (race with _ensure_client's lock).
                     self.logger.warning("Scroll RPC raised: %s", exc)
-                    clickhouse_client._client = None
                     return {
                         "weight": 1, "unit": "ops", "success": False,
                         "error-count": 1, "pages_actual": pages_actual, "took": 0,
@@ -292,9 +342,11 @@ class ClickHouseBulkVectorDataSet(Runner):
     ``clickhouse_client.bulk`` which requires ``column-names`` for the fast
     Native path (or triggers the JSONEachRow fallback if absent).
 
-    RETURN SHAPE: returns 2-tuple ``(size, unit)`` - this is the ONE runner
-    that uses the tuple return; every other ClickHouse runner returns a dict.
-    Matches OSB's BulkVectorDataSet sampling contract.
+    RETURN SHAPE: returns a 2-tuple ``(size, "docs")`` on success and a dict on
+    failure. The tuple return matches OSB's BulkVectorDataSet sampling contract
+    (execute_single treats a 2-tuple as ``(weight, unit)`` with success=True);
+    a dict return with ``success: False`` short-circuits the success path so
+    ClickHouse errors don't fabricate throughput.
     """
     multi_cluster = False
 
@@ -317,8 +369,15 @@ class ClickHouseBulkVectorDataSet(Runner):
             try:
                 await clickhouse_client.bulk(body=docs, index=params.get("index"), params=params)
             except Exception as exc:  # pylint: disable=broad-except
+                # Do NOT swallow: return an error dict so execute_single records
+                # success=False and does NOT fabricate throughput on ClickHouse crash.
+                # Do NOT mutate clickhouse_client._client (race with _ensure_client).
                 self.logger.warning("BulkVectorDataSet RPC raised: %s", exc)
-                clickhouse_client._client = None
+                return {
+                    "weight": 0, "unit": "docs", "success": False,
+                    "error-count": 1, "error-type": "clickhouse",
+                    "error-description": str(exc),
+                }
         finally:
             request_context_holder.on_request_end()
             request_context_holder.on_client_request_end()
@@ -356,6 +415,17 @@ class ClickHouseDropTable(Runner):
         indices = params.get("indices", [])
         if not indices and params.get("index"):
             indices = [params["index"]]
+        # Split any comma-separated entries so `indices=['a,b']` (OSB's typical
+        # DeleteIndex shape) drops both tables individually. Without this, the
+        # exists()/delete() calls would receive the literal string 'a,b' and
+        # fail to match either table.
+        expanded = []
+        for entry in indices:
+            if isinstance(entry, str) and "," in entry:
+                expanded.extend(part.strip() for part in entry.split(",") if part.strip())
+            else:
+                expanded.append(entry)
+        indices = expanded
         only_if_exists = params.get("only-if-exists", False)
         deleted = 0
         request_context_holder.on_client_request_start()

--- a/osbenchmark/engine/clickhouse/runners.py
+++ b/osbenchmark/engine/clickhouse/runners.py
@@ -1,0 +1,17 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ClickHouse-native runners for OSB operations."""
+
+import logging
+
+from osbenchmark import exceptions
+from osbenchmark.workload import workload
+from osbenchmark.worker_coordinator import runner
+from osbenchmark.worker_coordinator.runner import Runner, Retry, register_runner, request_context_holder
+
+logger = logging.getLogger(__name__)
+
+# Runner classes are filled in P4. Registration lives in
+# osbenchmark/engine/clickhouse/__init__.py:register_runners() — do NOT define a
+# module-level register_clickhouse_runners here (see the engine module docstring).

--- a/osbenchmark/engine/clickhouse/runners.py
+++ b/osbenchmark/engine/clickhouse/runners.py
@@ -21,7 +21,7 @@ _ORDER_BY_RE = re.compile(r"(?:^|[\s,()])ORDER\s+BY(?=[\s(]|$)", re.IGNORECASE)
 # SQL dialect) requires whitespace after -- to distinguish a comment from
 # arithmetic operators or identifier fragments. Matching the whitespace here
 # avoids false-stripping legitimate SQL like `WHERE x = 'a--b'`.
-_SQL_LINE_COMMENT_RE = re.compile(r"--\s[^\n]*")
+_SQL_LINE_COMMENT_RE = re.compile(r"--[ \t\r\f\v][^\n]*")
 _SQL_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 # Single-quoted string literal. Handles doubled '' escapes.
 _SQL_STRING_LITERAL_RE = re.compile(r"'(?:''|[^'])*'")

--- a/osbenchmark/engine/clickhouse/runners.py
+++ b/osbenchmark/engine/clickhouse/runners.py
@@ -11,12 +11,17 @@ from osbenchmark.worker_coordinator.runner import Runner, request_context_holder
 
 logger = logging.getLogger(__name__)
 
-# Match ORDER BY as a real SQL clause boundary (whitespace-separated tokens).
-# Applied after stripping SQL comments and single-quoted string literals so it
-# doesn't false-match on identifiers or string contents like 'ORDER BYPASS'.
-_ORDER_BY_RE = re.compile(r"\bORDER\s+BY\b", re.IGNORECASE)
-# Line comment: `-- ...` to end of line. Block comment: `/* ... */`.
-_SQL_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+# Match ORDER BY as a real SQL clause boundary. We require ORDER to be
+# preceded by a non-word character (space/newline/paren) and followed by
+# whitespace + BY + a non-word character. This matches real SQL clauses but
+# NOT identifiers like 'ORDER_BY_ID' or truncated substrings inside a longer
+# identifier like 'ORDER BYPASS_COL'.
+_ORDER_BY_RE = re.compile(r"(?:^|[\s,()])ORDER\s+BY(?=[\s(]|$)", re.IGNORECASE)
+# Line comment: `-- ...` to end of line. ClickHouse (and every ISO-compliant
+# SQL dialect) requires whitespace after -- to distinguish a comment from
+# arithmetic operators or identifier fragments. Matching the whitespace here
+# avoids false-stripping legitimate SQL like `WHERE x = 'a--b'`.
+_SQL_LINE_COMMENT_RE = re.compile(r"--\s[^\n]*")
 _SQL_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 # Single-quoted string literal. Handles doubled '' escapes.
 _SQL_STRING_LITERAL_RE = re.compile(r"'(?:''|[^'])*'")
@@ -27,10 +32,16 @@ def _strip_sql_noise(sql: str) -> str:
 
     Used to make ``ORDER BY``-in-SQL detection robust against string contents
     and comments. NOT suitable as a SQL sanitizer for execution.
+
+    Ordering: strip block comments first (they can contain -- or '), then
+    string literals (they can contain -- or /* */), then line comments last
+    (they can appear anywhere). This ordering prevents the classic bug where
+    stripping line comments first eats content inside a string literal like
+    ``WHERE label = 'first--second'``.
     """
     stripped = _SQL_BLOCK_COMMENT_RE.sub(" ", sql)
-    stripped = _SQL_LINE_COMMENT_RE.sub(" ", stripped)
     stripped = _SQL_STRING_LITERAL_RE.sub(" ", stripped)
+    stripped = _SQL_LINE_COMMENT_RE.sub(" ", stripped)
     return stripped
 
 
@@ -77,21 +88,32 @@ class ClickHouseBulkIndex(Runner):
         bulk_size = params.get("bulk-size", 0)
         unit = params.get("unit", "docs")
 
-        # Zero-doc guard: parse the body ONCE up front so we can detect an empty
-        # feed regardless of whether the workload declared bulk-size. A missing
-        # bulk-size (defaults to 0) previously bypassed this check and let empty
-        # bulks silently "succeed".
+        # Zero-doc guard + one-shot parse. We parse the body once here and
+        # thread the result to client.bulk() so it doesn't re-parse. This
+        # avoids the double-parse hot-path cost on every bulk operation.
+        #
+        # parse_bulk_body raises BenchmarkError on data corruption (malformed
+        # NDJSON, misaligned action/source pairs, unsupported action types).
+        # These are per-sample failures, NOT benchmark-aborting configuration
+        # errors, so catch here and return an error dict rather than letting
+        # the exception propagate through the actor system.
         try:
             parsed_docs = parse_bulk_body(body) if body else []
-        except exceptions.BenchmarkError:
-            raise
-        except Exception as exc:  # pylint: disable=broad-except
-            # Parse errors surface as a runner failure, not a raised exception
-            # (which would abort the whole benchmark).
+        except exceptions.BenchmarkError as exc:
             self.logger.warning("Bulk body parse failed: %s", exc)
             return {"weight": bulk_size, "unit": unit, "success": False,
-                    "error-count": 1, "took": 0}
+                    "error-count": 1, "error-type": "clickhouse",
+                    "error-description": str(exc), "took": 0}
+        except Exception:  # pylint: disable=broad-except
+            # Programmer error inside parse_bulk_body: re-raise so the actor
+            # log captures it. This is intentionally different from the
+            # BenchmarkError branch above.
+            self.logger.exception("Unexpected parse error")
+            raise
         if not parsed_docs:
+            # Empty body IS a workload configuration bug (non-zero bulk-size
+            # with nothing to insert), NOT a data corruption issue. Raise so
+            # operators fix their workload before continuing.
             raise exceptions.BenchmarkError(
                 f"Bulk operation on {index!r} produced 0 parsed docs "
                 f"(bulk-size={bulk_size}). Workload params-source is likely "
@@ -101,7 +123,9 @@ class ClickHouseBulkIndex(Runner):
         request_context_holder.on_client_request_start()
         request_context_holder.on_request_start()
         try:
-            response = await clickhouse_client.bulk(body=body, index=index, params=params)
+            # Pass pre-parsed docs to skip re-parsing inside client.bulk().
+            response = await clickhouse_client.bulk(
+                body=body, index=index, params=params, parsed_docs=parsed_docs)
         except Exception as exc:  # pylint: disable=broad-except
             # Surface the failure to the sample stream. We deliberately do NOT
             # mutate clickhouse_client._client here: forcing a re-init on any
@@ -109,13 +133,14 @@ class ClickHouseBulkIndex(Runner):
             # the underlying client is genuinely broken the next _ensure_client
             # call won't detect that anyway. Retry semantics belong in a retry
             # decorator, not ad-hoc private-field mutation.
-            # TODO(P8): wire engine.clickhouse.on_execute_error into the sample
+            # Follow-up: wire engine.clickhouse.on_execute_error into the sample
             #   error path so transient httpx errors get consistent handling.
             self.logger.warning("Bulk RPC raised: %s", exc)
             request_context_holder.on_request_end()
             request_context_holder.on_client_request_end()
             return {"weight": bulk_size, "unit": unit, "success": False,
-                    "error-count": 1, "took": 0}
+                    "error-count": 1, "error-type": "clickhouse",
+                    "error-description": str(exc), "took": 0}
         request_context_holder.on_request_end()
         request_context_holder.on_client_request_end()
 

--- a/osbenchmark/engine/clickhouse/runners.py
+++ b/osbenchmark/engine/clickhouse/runners.py
@@ -6,12 +6,463 @@
 import logging
 
 from osbenchmark import exceptions
-from osbenchmark.workload import workload
-from osbenchmark.worker_coordinator import runner
-from osbenchmark.worker_coordinator.runner import Runner, Retry, register_runner, request_context_holder
+from osbenchmark.worker_coordinator.runner import Runner, request_context_holder
 
 logger = logging.getLogger(__name__)
 
-# Runner classes are filled in P4. Registration lives in
-# osbenchmark/engine/clickhouse/__init__.py:register_runners() — do NOT define a
-# module-level register_clickhouse_runners here (see the engine module docstring).
+
+def _compute_recall(hits, neighbors, k):
+    """Compute recall@k and recall@1 with integer-normalization when possible.
+
+    If both retrieved and truth IDs parse as integers, compare as integers to
+    handle zero-padded truth IDs (e.g. '00001' vs '1').
+    """
+    def _normalize(value):
+        s = str(value)
+        try:
+            return int(s)
+        except (TypeError, ValueError):
+            return s
+    retrieved_ids = {_normalize(h["_id"]) for h in hits}
+    truth = {_normalize(n) for n in neighbors[:k]}
+    if not truth:
+        return 0.0, 0.0
+    recall_k = len(retrieved_ids & truth) / len(truth)
+    recall_1 = 1.0 if hits and _normalize(hits[0]["_id"]) in truth else 0.0
+    return recall_k, recall_1
+
+
+class ClickHouseBulkIndex(Runner):
+    """Bulk-insert docs into ClickHouse.
+
+    Params consumed:
+      - index: str (table name)
+      - body: list[dict] or bytes/str (NDJSON) - the OSB bulk body
+      - bulk-size: int - count of docs
+      - unit: str - "docs" typically
+      - column-names: list[str] - REQUIRED for the fast Native path; if absent
+        or if docs have extra keys, the client automatically falls back to
+        JSONEachRow.
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        index = params.get("index") or params.get("table")
+        body = params.get("body")
+        bulk_size = params.get("bulk-size", 0)
+        unit = params.get("unit", "docs")
+
+        # Guard against 0-doc batches when bulk-size was expected
+        if bulk_size > 0 and (not body or (isinstance(body, list) and len(body) == 0)):
+            self.logger.warning("Bulk operation on %s had 0 docs but bulk-size=%d",
+                                index, bulk_size)
+            return {"weight": 0, "unit": unit, "success": False, "error-count": 1, "took": 0}
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            response = await clickhouse_client.bulk(body=body, index=index, params=params)
+        except Exception as exc:  # pylint: disable=broad-except
+            # Handle mid-run server failures: reset client so next call re-connects
+            self.logger.warning("Bulk RPC raised: %s", exc)
+            clickhouse_client._client = None  # trigger re-init in next _ensure_client call
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+            return {"weight": bulk_size, "unit": unit, "success": False,
+                    "error-count": 1, "took": 0}
+        request_context_holder.on_request_end()
+        request_context_holder.on_client_request_end()
+
+        errored = response.get("errors", False)
+        # ClickHouse INSERT is all-or-nothing. On failure, count as 1 error, not bulk_size.
+        error_count = 1 if errored else 0
+        return {
+            "weight": bulk_size,
+            "unit": unit,
+            "success": not errored,
+            "error-count": error_count,
+            "took": response.get("took", 0),
+        }
+
+    def __repr__(self):
+        return "clickhouse-bulk-index"
+
+
+class ClickHouseQuery(Runner):
+    """Executes a SQL query.
+
+    Params consumed:
+      - body: {"sql": "SELECT ...", "parameters": {...}, "settings": {...}} - REQUIRED
+      - detailed-results: bool (currently ignored)
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        body = params.get("body") or {}
+        if "sql" not in body:
+            raise exceptions.BenchmarkError(
+                "ClickHouse runner received a body without a 'sql' key. Workloads must "
+                "supply a ClickHouse-native param source that produces {'sql': 'SELECT ...'}."
+            )
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            try:
+                response = await clickhouse_client.search(body=body)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.warning("Search RPC raised: %s", exc)
+                clickhouse_client._client = None
+                return {"weight": 1, "unit": "ops", "success": False,
+                        "error-count": 1, "took": 0}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        hits = response.get("hits", {})
+        return {
+            "weight": 1,
+            "unit": "ops",
+            "success": True,
+            "hits": hits.get("total", {}).get("value", 0),
+            "hits_relation": hits.get("total", {}).get("relation", "eq"),
+            "timed_out": response.get("timed_out", False),
+            "took": response.get("took", 0),
+        }
+
+    def __repr__(self):
+        return "clickhouse-query"
+
+
+class ClickHouseVectorSearch(Runner):
+    """k-NN search using ClickHouse vector_similarity index.
+
+    Uses the client's public ``execute_query``.
+
+    Recall computation caveat: ID type mismatches between the workload's
+    ground-truth ``neighbors`` and the returned rows silently produce
+    recall=0.0. This runner attempts integer normalization when both sides
+    parse as integers; workloads with non-integer IDs must ensure their
+    param source emits string IDs matching the ClickHouse output format.
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        # pylint: disable=import-outside-toplevel
+        from osbenchmark.engine.clickhouse.helpers import (
+            convert_query_result_for_vector_search, coerce_parameters,
+        )
+        body = params.get("body") or {}
+        if "sql" not in body:
+            raise exceptions.BenchmarkError(
+                "ClickHouseVectorSearch requires a 'sql' key in the body."
+            )
+        k = params.get("k", 10)
+        ef_search = params.get("hnsw_ef_search")
+        id_field = params.get("id-field", "id")
+        score_field = params.get("score-field", "score")
+
+        settings = dict(body.get("settings") or {})
+        if ef_search:
+            settings["hnsw_candidate_list_size_for_search"] = ef_search
+            settings.setdefault("max_limit_for_vector_search_queries", max(1000, k))
+
+        parameters = coerce_parameters(body.get("parameters"))
+
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            try:
+                result = await clickhouse_client.execute_query(
+                    body["sql"],
+                    parameters=parameters,
+                    settings=settings or None,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.warning("Vector search RPC raised: %s", exc)
+                clickhouse_client._client = None
+                return {"weight": 1, "unit": "ops", "success": False,
+                        "error-count": 1, "took": 0}
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+
+        elapsed_ns = 0
+        if result.summary:
+            try:
+                elapsed_ns = int(result.summary.get("elapsed_ns", 0))
+            except (TypeError, ValueError):
+                elapsed_ns = 0
+        response = convert_query_result_for_vector_search(
+            result.result_rows, result.column_names,
+            score_column=score_field, id_column=id_field, elapsed_ns=elapsed_ns,
+        )
+        hits = response["hits"]["hits"]
+        out = {
+            "weight": 1, "unit": "ops", "success": True,
+            "hits": len(hits), "hits_relation": "eq",
+            "timed_out": False, "took": response.get("took", 0),
+        }
+        if params.get("calculate-recall") and params.get("neighbors"):
+            recall_k, recall_1 = _compute_recall(hits, params["neighbors"], k)
+            out["recall@k"] = recall_k
+            out["recall@1"] = recall_1
+        return out
+
+    def __repr__(self):
+        return "clickhouse-vector-search"
+
+
+class ClickHouseScrollQuery(Runner):
+    """Simulates OS scroll via workload-supplied {limit:UInt32}/{offset:UInt32} parameters.
+
+    IMPORTANT: the workload SQL MUST contain ClickHouse-style
+    ``{limit:UInt32}`` and ``{offset:UInt32}`` parameter placeholders and MUST
+    include an ``ORDER BY`` on a deterministic key. The runner refuses to
+    proceed if either constraint is violated; it does NOT rewrite user SQL.
+
+    Cost warning: OFFSET-based pagination in ClickHouse is O(N*pages). For
+    non-trivial datasets, prefer keyset pagination in the workload SQL rather
+    than this runner. This runner exists for OS-parity smoke tests.
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        body = params.get("body") or {}
+        if "sql" not in body:
+            raise exceptions.BenchmarkError("ClickHouseScrollQuery requires a 'sql' key.")
+        base_sql = body["sql"]
+        # Reject workload SQL that lacks the required parameter placeholders.
+        if "{limit:" not in base_sql or "{offset:" not in base_sql:
+            raise exceptions.BenchmarkError(
+                "ClickHouseScrollQuery requires the workload SQL to contain "
+                "{limit:UInt32} and {offset:UInt32} placeholders. Naive LIMIT/OFFSET "
+                "injection is unsafe because it corrupts SQL with existing LIMIT, "
+                "ORDER BY, or FORMAT clauses."
+            )
+        if "ORDER BY" not in base_sql.upper():
+            raise exceptions.BenchmarkError(
+                "ClickHouseScrollQuery requires the workload SQL to include ORDER BY on a "
+                "deterministic key; pagination without ordering returns different rows per page."
+            )
+
+        pages_requested = params.get("pages", 10)
+        per_page = params.get("results-per-page", 1000)
+        total_hits = 0
+        pages_actual = 0
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            for page in range(pages_requested):
+                base_params = dict(body.get("parameters") or {})
+                base_params.update({"limit": per_page, "offset": page * per_page})
+                try:
+                    result = await clickhouse_client.execute_query(
+                        base_sql, parameters=base_params, settings=body.get("settings"),
+                    )
+                except Exception as exc:  # pylint: disable=broad-except
+                    self.logger.warning("Scroll RPC raised: %s", exc)
+                    clickhouse_client._client = None
+                    return {
+                        "weight": 1, "unit": "ops", "success": False,
+                        "error-count": 1, "pages_actual": pages_actual, "took": 0,
+                    }
+                pages_actual += 1
+                got = len(result.result_rows)
+                total_hits += got
+                if got < per_page:
+                    break
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return {
+            "weight": 1, "unit": "ops", "success": True,
+            "pages": pages_requested, "pages_actual": pages_actual,
+            "hits": total_hits, "hits_relation": "eq",
+            "timed_out": False, "took": 0,
+        }
+
+    def __repr__(self):
+        return "clickhouse-scroll-query"
+
+
+class ClickHouseBulkVectorDataSet(Runner):
+    """Bulk-ingest vector datasets, pairing alternating action/vector dicts.
+
+    NOTE: the workload param source MUST include ``column-names`` for this
+    runner, same as ClickHouseBulkIndex. The runner delegates to
+    ``clickhouse_client.bulk`` which requires ``column-names`` for the fast
+    Native path (or triggers the JSONEachRow fallback if absent).
+
+    RETURN SHAPE: returns 2-tuple ``(size, unit)`` - this is the ONE runner
+    that uses the tuple return; every other ClickHouse runner returns a dict.
+    Matches OSB's BulkVectorDataSet sampling contract.
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        size = params.get("size", 0)
+        body = params.get("body", [])
+        docs = []
+        vec_field = params.get("vector-field", "vec")
+        for i in range(0, len(body) - 1, 2):
+            action = body[i]
+            vector_doc = body[i + 1]
+            # Ensure numpy arrays are converted to Python lists
+            candidate = vector_doc.get(vec_field, None)
+            if hasattr(candidate, "tolist"):
+                vector_doc = {**vector_doc, vec_field: candidate.tolist()}
+            docs.extend([action, vector_doc])
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            try:
+                await clickhouse_client.bulk(body=docs, index=params.get("index"), params=params)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.logger.warning("BulkVectorDataSet RPC raised: %s", exc)
+                clickhouse_client._client = None
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return size, "docs"
+
+    def __repr__(self):
+        return "clickhouse-bulk-vector-data-set"
+
+
+class ClickHouseCreateTable(Runner):
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        indices = params.get("indices", [])
+        if not indices and params.get("index"):
+            indices = [(params["index"], params.get("body", {}))]
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            for name, body in indices:
+                await clickhouse_client.indices.create(index=name, body=body, params=params)
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return {"weight": len(indices), "unit": "ops", "success": True}
+
+    def __repr__(self):
+        return "clickhouse-create-table"
+
+
+class ClickHouseDropTable(Runner):
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        indices = params.get("indices", [])
+        if not indices and params.get("index"):
+            indices = [params["index"]]
+        only_if_exists = params.get("only-if-exists", False)
+        deleted = 0
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            for name in indices:
+                if only_if_exists and not await clickhouse_client.indices.exists(index=name):
+                    continue
+                await clickhouse_client.indices.delete(index=name)
+                deleted += 1
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return {"weight": deleted, "unit": "ops", "success": True}
+
+    def __repr__(self):
+        return "clickhouse-drop-table"
+
+
+class ClickHouseSystemParts(Runner):
+    """Return shape matches the OS IndicesStats runner.
+
+    OS returns: {"weight":1,"unit":"ops","success":True,"stats":stats,
+                 "index":str,"primaries":dict}. This mirror populates each key
+    so downstream sample consumers work unchanged.
+    """
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        index = params.get("index")
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            stats = await clickhouse_client.indices.stats(index=index)
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        primaries = stats.get("_all", {}).get("primaries", {})
+        return {
+            "weight": 1, "unit": "ops", "success": True,
+            "stats": stats, "index": index or "_all",
+            "primaries": primaries,
+        }
+
+    def __repr__(self):
+        return "clickhouse-system-parts"
+
+
+class ClickHouseClusterHealth(Runner):
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            health = await clickhouse_client.cluster.health()
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        status = health.get("status", "unknown")
+        return {
+            "weight": 1, "unit": "ops",
+            "success": status in ("green", "yellow"),
+            "cluster-status": status,
+            "relocating-shards": health.get("relocating_shards", 0),
+        }
+
+    def __repr__(self):
+        return "clickhouse-cluster-health"
+
+
+class ClickHouseOptimizeTable(Runner):
+    multi_cluster = False
+
+    async def __call__(self, clickhouse_client, params):
+        index = params.get("index")
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            shards = await clickhouse_client.indices.forcemerge(index=index)
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return {"weight": 1, "unit": "ops", "success": True,
+                "shards": shards.get("_shards", {})}
+
+    def __repr__(self):
+        return "clickhouse-optimize-table"
+
+
+class ClickHouseNoOp(Runner):
+    """Logs a skip and returns success. Used for OpenSearch-specific admin ops."""
+    multi_cluster = False
+
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+    async def __call__(self, clickhouse_client, params):
+        request_context_holder.on_client_request_start()
+        request_context_holder.on_request_start()
+        try:
+            self.logger.debug("Skipping unsupported ClickHouse operation: %s", self._name)
+        finally:
+            request_context_holder.on_request_end()
+            request_context_holder.on_client_request_end()
+        return {"weight": 1, "unit": "ops", "success": True}
+
+    def __repr__(self):
+        return f"clickhouse-noop({self._name})"

--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,7 @@ setup(name="opensearch-benchmark",
           "develop": tests_require + develop_require,
           "vespa": ["pyvespa>=0.62.0"],
           "milvus": ["pymilvus>=2.5.0"],
+          "clickhouse": ["clickhouse-connect>=0.9.2,<1.0"],
       },
       entry_points={
           "console_scripts": [

--- a/tests/engine/clickhouse/client_test.py
+++ b/tests/engine/clickhouse/client_test.py
@@ -712,11 +712,11 @@ class InfoExceptionTracebackRegressionTests(TestCase):
             with self.assertLogs("osbenchmark.engine.clickhouse.client",
                                  level="WARNING") as cm:
                 c.info()
-        # exc_info=True adds the traceback to the formatted message. If it were
-        # missing, the log message would just be a single line.
-        traceback_present = any("Traceback" in m or "ValueError: kaboom" in m
-                                for m in cm.output)
-        self.assertTrue(traceback_present,
+        # exc_info=True adds "Traceback (most recent call last):" to the
+        # formatted message. Assert ONLY on that: the exception's str/type
+        # already appears in the WARN body via `%s: %s`, so a substring match
+        # on "ValueError: kaboom" would pass even if exc_info=True were dropped.
+        self.assertTrue(any("Traceback" in m for m in cm.output),
                         f"Expected traceback in log output; got: {cm.output}")
 
 
@@ -730,3 +730,34 @@ class BulkParsedDocsPassthroughTests(TestCase):
         self.assertIn("parsed_docs", sig.parameters,
                       "client.bulk() must accept parsed_docs kwarg for hot-path "
                       "reuse of pre-parsed NDJSON bodies")
+
+
+class BulkParsedDocsHonoredTests(IsolatedAsyncioTestCase):
+    """Verify client.bulk() actually SKIPS parse_bulk_body when parsed_docs is
+    supplied. Without this test, dropping the parsed_docs branch from bulk()
+    (silently double-parsing on the hot path) would leave the signature test
+    happy while doubling per-bulk parse cost."""
+
+    async def test_parsed_docs_bypasses_reparse(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        m.insert.return_value = mock.MagicMock(
+            summary={"elapsed_ns": "1000000", "written_rows": "1"})
+        pre_parsed = [{"_id": "1", "_source": {"a": 1, "b": "x"}, "_action": "index"}]
+        # Body is intentionally malformed NDJSON: if the client re-parses it,
+        # parse_bulk_body will raise. Passing parsed_docs must make it skip
+        # the parse entirely.
+        with mock.patch(
+            "osbenchmark.engine.clickhouse.helpers.parse_bulk_body",
+            side_effect=AssertionError("parse_bulk_body should not be called "
+                                       "when parsed_docs is supplied"),
+        ) as spy:
+            result = await c.bulk(
+                body=b"malformed-would-blow-up-if-re-parsed",
+                index="t",
+                params={"column-names": ["a", "b"]},
+                parsed_docs=pre_parsed,
+            )
+        spy.assert_not_called()
+        self.assertFalse(result["errors"])

--- a/tests/engine/clickhouse/client_test.py
+++ b/tests/engine/clickhouse/client_test.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for osbenchmark.engine.clickhouse.client."""
+
+import asyncio
+from unittest import TestCase, IsolatedAsyncioTestCase, mock
+
+from osbenchmark import exceptions
+from osbenchmark.engine.clickhouse import client as ch_client_mod
+from osbenchmark.engine.clickhouse.client import (
+    ClickHouseClientFactory,
+    ClickHouseDatabaseClient,
+    _NodesProxy,
+)
+
+
+def _summary(elapsed_ns="1000000"):
+    """Build a mock QuerySummary-like object."""
+    s = mock.MagicMock()
+    s.summary = {"elapsed_ns": elapsed_ns}
+    return s
+
+
+def _query_result(rows=None, columns=None, elapsed_ns="1000000"):
+    r = mock.MagicMock()
+    r.result_rows = rows or []
+    r.column_names = tuple(columns or [])
+    r.summary = {"elapsed_ns": elapsed_ns}
+    return r
+
+
+class ClickHouseClientFactoryTests(TestCase):
+
+    def test_hosts_list_of_dicts(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        self.assertEqual(f.hosts, [{"host": "h", "port": 8123}])
+
+    def test_none_client_options_becomes_dict(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], None)
+        self.assertEqual(f.client_options, {})
+
+    def test_create_returns_client(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        c = f.create()
+        self.assertIsInstance(c, ClickHouseDatabaseClient)
+
+    def test_create_async_returns_client(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        c = f.create_async()
+        self.assertIsInstance(c, ClickHouseDatabaseClient)
+
+    def test_create_and_async_produce_distinct_instances(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        c1 = f.create()
+        c2 = f.create_async()
+        self.assertIsNot(c1, c2)
+
+    def test_ssl_verify_passed_through(self):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8443}], {"ssl_verify": False})
+        c = f.create()
+        self.assertEqual(c.client_options["ssl_verify"], False)
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.wait_for_clickhouse", return_value=True)
+    def test_wait_for_rest_layer_delegates(self, mock_wait):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        self.assertTrue(f.wait_for_rest_layer(max_attempts=3))
+        mock_wait.assert_called_once()
+        # first arg is an ephemeral client
+        first_arg = mock_wait.call_args[0][0]
+        self.assertIsInstance(first_arg, ClickHouseDatabaseClient)
+        self.assertEqual(mock_wait.call_args.kwargs["max_attempts"], 3)
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.wait_for_clickhouse", return_value=False)
+    def test_wait_for_rest_layer_timeout(self, _mock_wait):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        self.assertFalse(f.wait_for_rest_layer(max_attempts=1))
+
+
+class ClickHouseClientInitTests(TestCase):
+
+    def _client(self, **opts):
+        return ClickHouseDatabaseClient([{"host": "h", "port": 8123}], opts)
+
+    def test_namespace_proxies(self):
+        c = self._client()
+        self.assertIs(c.indices, c)
+        self.assertIs(c.cluster, c)
+        self.assertIs(c.transport, c)
+        self.assertIsInstance(c.nodes, _NodesProxy)
+
+    def test_nodes_proxy_stats_returns_dict(self):
+        c = self._client()
+        stats = c.nodes.stats()
+        self.assertIn("nodes", stats)
+        self.assertIn("cluster_name", stats)
+
+    def test_initial_client_state(self):
+        c = self._client()
+        self.assertIsNone(c._client)
+        self.assertIsNone(c._sync_client)
+        self.assertIsNone(c._database)
+
+    def test_lock_is_asyncio_lock(self):
+        c = self._client()
+        self.assertIsInstance(c._client_lock, asyncio.Lock)
+
+    def test_endpoint_derived_from_hosts(self):
+        c = self._client()
+        self.assertEqual(c.endpoint, "http://h:8123")
+        secure = ClickHouseDatabaseClient([{"host": "h", "port": 8443}], {})
+        self.assertEqual(secure.endpoint, "https://h:8443")
+
+
+class ClickHouseClientLifecycleTests(IsolatedAsyncioTestCase):
+
+    async def test_aenter_returns_self(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        async with c as ctx:
+            self.assertIs(ctx, c)
+
+    async def test_aexit_calls_close(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        with mock.patch.object(c, "close", new=mock.AsyncMock()) as m:
+            async with c:
+                pass
+            m.assert_awaited_once()
+
+    async def test_ensure_client_missing_extra_raises(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        with mock.patch("osbenchmark.engine.clickhouse.client.CLICKHOUSE_CONNECT_AVAILABLE", False):
+            with self.assertRaises(exceptions.SystemSetupError):
+                await c._ensure_client()
+
+    async def test_ensure_client_idempotent(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        fake = mock.AsyncMock()
+        c._client = fake
+        got = await c._ensure_client()
+        self.assertIs(got, fake)
+
+    async def test_concurrent_ensure_client_creates_one_client(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        call_count = 0
+
+        async def slow_get_async_client(**_kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)  # simulate handshake delay
+            return mock.AsyncMock()
+
+        fake_mod = mock.MagicMock()
+        fake_mod.get_async_client = slow_get_async_client
+        with mock.patch("osbenchmark.engine.clickhouse.client.clickhouse_connect", fake_mod):
+            with mock.patch("osbenchmark.engine.clickhouse.client.CLICKHOUSE_CONNECT_AVAILABLE", True):
+                await asyncio.gather(*(c._ensure_client() for _ in range(50)))
+        self.assertEqual(call_count, 1)
+
+    async def test_close_resets_state(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        c._client.close = mock.AsyncMock()
+        c._sync_client = mock.MagicMock()
+        await c.close()
+        self.assertIsNone(c._client)
+        self.assertIsNone(c._sync_client)
+
+    async def test_close_swallows_exceptions(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        c._client.close = mock.AsyncMock(side_effect=RuntimeError("kaboom"))
+        # Should not raise
+        await c.close()
+        self.assertIsNone(c._client)
+
+    async def test_close_honors_timeout(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+
+        # Build a fake AsyncClient whose close hangs forever
+        class _HangingClient:
+            async def close(self_inner):
+                await asyncio.sleep(30)
+
+        c._client = _HangingClient()
+        # Patch wait_for to trigger a TimeoutError quickly
+        original_wait_for = asyncio.wait_for
+
+        async def fast_wait(coro, timeout):  # pylint: disable=unused-argument
+            # cancel the coro to avoid warnings
+            task = asyncio.ensure_future(coro)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            raise asyncio.TimeoutError()
+
+        with mock.patch("osbenchmark.engine.clickhouse.client.asyncio.wait_for", side_effect=fast_wait):
+            await c.close()
+        self.assertIsNone(c._client)
+
+
+class ClickHouseBulkTests(IsolatedAsyncioTestCase):
+
+    def _client_with_mock(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        return c, m
+
+    async def test_native_path_multi_row(self):
+        c, m = self._client_with_mock()
+        m.insert.return_value = _summary("5000000")
+        body = [
+            {"index": {"_id": "1"}}, {"a": 1, "b": "x"},
+            {"index": {"_id": "2"}}, {"a": 2, "b": "y"},
+        ]
+        result = await c.bulk(body=body, index="t", params={"column-names": ["a", "b"]})
+        self.assertFalse(result["errors"])
+        self.assertEqual(result["took"], 5)
+        self.assertEqual(len(result["items"]), 2)
+        m.insert.assert_awaited_once()
+
+    async def test_missing_columns_triggers_json_fallback(self):
+        c, m = self._client_with_mock()
+        m.command.return_value = _summary("2000000")
+        body = [{"index": {"_id": "1"}}, {"a": 1}]
+        result = await c.bulk(body=body, index="t", params={})
+        self.assertFalse(result["errors"])
+        m.command.assert_awaited_once()
+        m.insert.assert_not_called()
+
+    async def test_extra_keys_triggers_json_fallback(self):
+        c, m = self._client_with_mock()
+        m.command.return_value = _summary("2000000")
+        body = [{"index": {"_id": "1"}}, {"a": 1, "extra": 9}]
+        result = await c.bulk(body=body, index="t", params={"column-names": ["a"]})
+        self.assertFalse(result["errors"])
+        m.command.assert_awaited_once()
+        m.insert.assert_not_called()
+
+    async def test_insert_mode_json_forces_fallback(self):
+        c, m = self._client_with_mock()
+        m.command.return_value = _summary()
+        body = [{"index": {"_id": "1"}}, {"a": 1}]
+        result = await c.bulk(body=body, index="t",
+                              params={"column-names": ["a"], "insert-mode": "json"})
+        self.assertFalse(result["errors"])
+        m.command.assert_awaited_once()
+        m.insert.assert_not_called()
+
+    async def test_empty_body_returns_empty(self):
+        c, m = self._client_with_mock()
+        result = await c.bulk(body=[], index="t", params={"column-names": ["a"]})
+        self.assertEqual(result, {"took": 0, "errors": False, "items": []})
+        m.insert.assert_not_called()
+
+    async def test_insert_exception_returns_single_error(self):
+        c, m = self._client_with_mock()
+        m.insert.side_effect = RuntimeError("connection reset")
+        body = [{"index": {"_id": "1"}}, {"a": 1, "b": "x"}]
+        result = await c.bulk(body=body, index="t", params={"column-names": ["a", "b"]})
+        self.assertTrue(result["errors"])
+        self.assertEqual(result["items"], [])
+        self.assertIn("connection reset", result["_bulk_error"])
+
+    async def test_strict_mismatch_raises(self):
+        c, _m = self._client_with_mock()
+        body = [{"index": {"_id": "1"}}, {"a": 1}]
+        # column-names ["a","b"] but doc has only "a" and no extra keys -> strict Native path
+        with self.assertRaises(exceptions.BenchmarkError):
+            await c.bulk(body=body, index="t", params={"column-names": ["a", "b"]})
+
+    async def test_delete_action_rejected_at_parse(self):
+        c, _m = self._client_with_mock()
+        body = [{"delete": {"_id": "1"}}, {"a": 1}]
+        with self.assertRaises(exceptions.BenchmarkError):
+            await c.bulk(body=body, index="t", params={"column-names": ["a"]})
+
+
+class ClickHouseIndexTests(IsolatedAsyncioTestCase):
+
+    async def test_index_success(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        result = await c.index(index="t", body={"a": 1}, id="42")
+        self.assertEqual(result["_id"], "42")
+        self.assertEqual(result["result"], "created")
+        m.insert.assert_awaited_once()
+
+    async def test_column_ordering_from_params(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        await c.index(index="t", body={"a": 1, "b": 2}, params={"column-names": ["b", "a"]})
+        args, kwargs = m.insert.await_args
+        # rows is a list of tuples aligned with column_names
+        self.assertEqual(kwargs["column_names"], ["b", "a"])
+        self.assertEqual(args[1], [(2, 1)])
+
+    async def test_id_default_empty_string(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        result = await c.index(index="t", body={"a": 1})
+        self.assertEqual(result["_id"], "")
+
+
+class ClickHouseSearchTests(IsolatedAsyncioTestCase):
+
+    def _client_with_mock(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        return c, m
+
+    async def test_query_executed(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = _query_result([(1, "a")], ["id", "name"], "3000000")
+        resp = await c.search(body={"sql": "SELECT id, name FROM t"})
+        self.assertEqual(resp["took"], 3)
+        self.assertEqual(len(resp["hits"]["hits"]), 1)
+        m.query.assert_awaited_once()
+
+    async def test_missing_sql_raises(self):
+        c, _m = self._client_with_mock()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await c.search(body={})
+
+    async def test_elapsed_string_to_int_took(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = _query_result([], [], "9000000")
+        resp = await c.search(body={"sql": "SELECT 1"})
+        self.assertEqual(resp["took"], 9)
+
+    async def test_numpy_parameters_coerced(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        c, m = self._client_with_mock()
+        m.query.return_value = _query_result([], [])
+        await c.search(body={"sql": "SELECT 1", "parameters": {"v": np.array([1.0, 2.0])}})
+        _args, kwargs = m.query.await_args
+        self.assertEqual(kwargs["parameters"]["v"], [1.0, 2.0])
+
+    async def test_settings_passed(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = _query_result([], [])
+        await c.search(body={"sql": "SELECT 1", "settings": {"max_execution_time": 10}})
+        _args, kwargs = m.query.await_args
+        self.assertEqual(kwargs["settings"], {"max_execution_time": 10})
+
+    async def test_unknown_keys_warned(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = _query_result([], [])
+        with self.assertLogs("osbenchmark.engine.clickhouse.client", level="WARNING") as cm:
+            await c.search(body={"sql": "SELECT 1", "bogus": "x"})
+        self.assertTrue(any("bogus" in msg for msg in cm.output))
+
+
+class ClickHouseIndicesTests(IsolatedAsyncioTestCase):
+
+    def _client_with_mock(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        return c, m
+
+    async def test_create_runs_ddl(self):
+        c, m = self._client_with_mock()
+        ddl = "CREATE TABLE t (a UInt64) ENGINE=MergeTree ORDER BY a"
+        result = await c.indices.create(index="t", body={"ddl": ddl})
+        self.assertTrue(result["acknowledged"])
+        m.command.assert_awaited_once_with(ddl)
+
+    async def test_create_ddl_file_resolved(self, ):
+        c, m = self._client_with_mock()
+        import tempfile
+        import os as _os
+        with tempfile.TemporaryDirectory() as td:
+            path = _os.path.join(td, "table.sql")
+            with open(path, "w", encoding="utf-8") as fp:
+                fp.write("CREATE TABLE t (a UInt64) ENGINE=MergeTree ORDER BY a")
+            # relative path -> uses workload-path
+            rel = "table.sql"
+            await c.indices.create(index="t", body={"ddl-file": rel},
+                                   params={"workload-path": td})
+            m.command.assert_awaited_once()
+            self.assertIn("CREATE TABLE", m.command.await_args.args[0])
+
+    async def test_create_missing_ddl_raises(self):
+        c, _m = self._client_with_mock()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await c.indices.create(index="t", body={})
+
+    async def test_delete_runs_drop(self):
+        c, m = self._client_with_mock()
+        await c.indices.delete(index="t")
+        m.command.assert_awaited_once()
+        self.assertIn("DROP TABLE", m.command.await_args.args[0])
+        self.assertIn("`t`", m.command.await_args.args[0])
+
+    async def test_exists_with_dot_syntax(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = mock.MagicMock(result_rows=[(1,)])
+        result = await c.indices.exists(index="mydb.mytable")
+        self.assertTrue(result)
+        _args, kwargs = m.query.await_args
+        self.assertEqual(kwargs["parameters"]["db"], "mydb")
+        self.assertEqual(kwargs["parameters"]["name"], "mytable")
+
+    async def test_exists_with_explicit_database_kwarg(self):
+        c, m = self._client_with_mock()
+        m.query.return_value = mock.MagicMock(result_rows=[(0,)])
+        result = await c.indices.exists(index="t", database="mydb")
+        self.assertFalse(result)
+        _args, kwargs = m.query.await_args
+        self.assertEqual(kwargs["parameters"]["db"], "mydb")
+
+    async def test_refresh_no_op(self):
+        c, m = self._client_with_mock()
+        result = await c.indices.refresh(index="t")
+        self.assertIn("_shards", result)
+        m.command.assert_not_called()
+
+    async def test_forcemerge_runs_optimize(self):
+        c, m = self._client_with_mock()
+        await c.indices.forcemerge(index="t")
+        m.command.assert_awaited_once()
+        self.assertIn("OPTIMIZE TABLE", m.command.await_args.args[0])
+        self.assertIn("FINAL", m.command.await_args.args[0])
+
+
+class ClickHouseHealthTests(IsolatedAsyncioTestCase):
+
+    async def test_ping_true_green(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        m.ping.return_value = True
+        c._client = m
+        result = await c.cluster.health()
+        self.assertEqual(result["status"], "green")
+
+    async def test_ping_false_red(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        m.ping.return_value = False
+        c._client = m
+        result = await c.cluster.health()
+        self.assertEqual(result["status"], "red")
+
+    async def test_cluster_name_option(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {"cluster_name": "my-cluster"})
+        m = mock.AsyncMock()
+        m.ping.return_value = True
+        c._client = m
+        result = await c.cluster.health()
+        self.assertEqual(result["cluster_name"], "my-cluster")
+
+
+class ClickHouseStatsTests(IsolatedAsyncioTestCase):
+
+    async def test_named_table(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        m.query.return_value = mock.MagicMock(result_rows=[(100, 4096)])
+        stats = await c.indices.stats(index="t")
+        self.assertEqual(stats["_all"]["primaries"]["docs"]["count"], 100)
+        self.assertIn("t", stats["indices"])
+
+    async def test_all_tables(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        m.query.return_value = mock.MagicMock(result_rows=[(0, 0)])
+        stats = await c.indices.stats()
+        self.assertEqual(stats["indices"], {})
+
+    async def test_explicit_database_kwarg(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        m.query.return_value = mock.MagicMock(result_rows=[(10, 100)])
+        await c.indices.stats(index="t", database="mydb")
+        _args, kwargs = m.query.await_args
+        self.assertEqual(kwargs["parameters"]["db"], "mydb")
+
+    async def test_envelope_shape(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        m.query.return_value = mock.MagicMock(result_rows=[(5, 50)])
+        stats = await c.indices.stats(index="metrics")
+        self.assertEqual(set(stats.keys()), {"_all", "indices"})
+        self.assertEqual(set(stats["_all"].keys()), {"primaries", "total"})
+
+
+class ClickHouseInfoTests(TestCase):
+
+    def test_version_extraction(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        sync_mock = mock.MagicMock()
+        sync_mock.query.return_value = mock.MagicMock(result_rows=[("24.8.1.2684",)])
+        with mock.patch.object(c, "_ensure_sync_client", return_value=sync_mock):
+            info = c.info()
+        self.assertEqual(info["version"]["number"], "24.8.1")
+        self.assertEqual(info["version"]["distribution"], "clickhouse")
+
+    def test_exception_uses_fallback(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        with mock.patch.object(c, "_ensure_sync_client", side_effect=RuntimeError("net")):
+            with self.assertLogs("osbenchmark.engine.clickhouse.client", level="WARNING") as cm:
+                info = c.info()
+        self.assertEqual(info["version"]["number"], "24.8.0")
+        self.assertTrue(any("info()" in m for m in cm.output))
+
+    def test_malformed_version_falls_back(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        sync_mock = mock.MagicMock()
+        sync_mock.query.return_value = mock.MagicMock(result_rows=[("head-fcbd7a4",)])
+        with mock.patch.object(c, "_ensure_sync_client", return_value=sync_mock):
+            info = c.info()
+        self.assertEqual(info["version"]["number"], "24.8.0")
+
+
+class WaitForRestLayerTests(TestCase):
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.wait_for_clickhouse", return_value=True)
+    def test_success(self, mock_wait):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        self.assertTrue(f.wait_for_rest_layer(max_attempts=5))
+        self.assertEqual(mock_wait.call_args.kwargs["max_attempts"], 5)
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.wait_for_clickhouse", return_value=False)
+    def test_timeout(self, _mock_wait):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8123}], {})
+        self.assertFalse(f.wait_for_rest_layer(max_attempts=1))
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.wait_for_clickhouse", return_value=True)
+    def test_delegates_with_endpoint(self, mock_wait):
+        f = ClickHouseClientFactory([{"host": "h", "port": 8443}], {"ssl_verify": False})
+        f.wait_for_rest_layer(max_attempts=1)
+        ephemeral = mock_wait.call_args[0][0]
+        self.assertEqual(ephemeral.endpoint, "https://h:8443")
+        self.assertEqual(ephemeral.client_options["ssl_verify"], False)
+
+
+class NodesStatsSyncTests(TestCase):
+
+    def test_sync_stub_returns_envelope(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {"cluster_name": "abc"})
+        stats = c.nodes.stats()
+        self.assertEqual(stats["nodes"], {})
+        self.assertEqual(stats["cluster_name"], "abc")
+
+
+class PerformRequestTests(IsolatedAsyncioTestCase):
+
+    async def test_get_shape_returns_empty(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        result = await c.perform_request("GET", "/some/path")
+        self.assertEqual(result, {})
+        m.command.assert_not_called()
+
+    async def test_body_carrying_routes_to_command(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        m = mock.AsyncMock()
+        c._client = m
+        await c.perform_request("POST", "/", body="SELECT 1")
+        m.command.assert_awaited_once_with("SELECT 1")
+
+
+class PutSettingsTests(IsolatedAsyncioTestCase):
+
+    async def test_no_op(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        result = await c.cluster.put_settings(body={"a": 1})
+        self.assertEqual(result, {"acknowledged": True})

--- a/tests/engine/clickhouse/client_test.py
+++ b/tests/engine/clickhouse/client_test.py
@@ -692,3 +692,41 @@ class InfoUnexpectedExceptionRegressionTests(TestCase):
         self.assertEqual(info["version"]["number"], "24.8.0")
         # The unexpected-branch WARNING mentions the exception type name.
         self.assertTrue(any("ValueError" in m and "unexpected" in m for m in cm.output))
+
+
+# ============================================================================
+# P8 regression tests (second-pass review findings)
+# ============================================================================
+
+class InfoExceptionTracebackRegressionTests(TestCase):
+    """P8: F12's unexpected-exception branch was missing exc_info=True on the
+    logger.warning call, which meant the traceback was lost and the narrower
+    except clause had no diagnostic value. Fixed: exc_info=True on the WARN."""
+
+    def test_unexpected_exception_logs_traceback(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        # Force a full traceback so we can grep for it in the captured log.
+        def _boom():
+            raise ValueError("kaboom from deep in a function")
+        with mock.patch.object(c, "_ensure_sync_client", side_effect=_boom):
+            with self.assertLogs("osbenchmark.engine.clickhouse.client",
+                                 level="WARNING") as cm:
+                c.info()
+        # exc_info=True adds the traceback to the formatted message. If it were
+        # missing, the log message would just be a single line.
+        traceback_present = any("Traceback" in m or "ValueError: kaboom" in m
+                                for m in cm.output)
+        self.assertTrue(traceback_present,
+                        f"Expected traceback in log output; got: {cm.output}")
+
+
+class BulkParsedDocsPassthroughTests(TestCase):
+    """P8: client.bulk() now accepts parsed_docs kwarg so ClickHouseBulkIndex
+    can pre-parse for the zero-doc guard without triggering a second parse."""
+
+    def test_bulk_signature_accepts_parsed_docs_kwarg(self):
+        import inspect
+        sig = inspect.signature(ClickHouseDatabaseClient.bulk)
+        self.assertIn("parsed_docs", sig.parameters,
+                      "client.bulk() must accept parsed_docs kwarg for hot-path "
+                      "reuse of pre-parsed NDJSON bodies")

--- a/tests/engine/clickhouse/client_test.py
+++ b/tests/engine/clickhouse/client_test.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for osbenchmark.engine.clickhouse.client."""
+# pylint: disable=protected-access,no-name-in-module,import-outside-toplevel,unused-import,no-self-argument,unused-variable
 
 import asyncio
 from unittest import TestCase, IsolatedAsyncioTestCase, mock
 
 from osbenchmark import exceptions
-from osbenchmark.engine.clickhouse import client as ch_client_mod
+from osbenchmark.engine.clickhouse import client as ch_client_mod  # noqa: F401
 from osbenchmark.engine.clickhouse.client import (
     ClickHouseClientFactory,
     ClickHouseDatabaseClient,

--- a/tests/engine/clickhouse/client_test.py
+++ b/tests/engine/clickhouse/client_test.py
@@ -89,8 +89,9 @@ class ClickHouseClientInitTests(TestCase):
         self.assertIsInstance(c.nodes, _NodesProxy)
 
     def test_nodes_proxy_stats_returns_dict(self):
+        # F4: nodes.stats/info are async so telemetry's `await` doesn't raise.
         c = self._client()
-        stats = c.nodes.stats()
+        stats = asyncio.run(c.nodes.stats())
         self.assertIn("nodes", stats)
         self.assertIn("cluster_name", stats)
 
@@ -549,28 +550,42 @@ class WaitForRestLayerTests(TestCase):
 class NodesStatsSyncTests(TestCase):
 
     def test_sync_stub_returns_envelope(self):
+        # F4: nodes.stats is async - kept named 'Sync' for history but it is
+        # now awaited (telemetry's default runner does `await ...stats(...)`).
         c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {"cluster_name": "abc"})
-        stats = c.nodes.stats()
+        stats = asyncio.run(c.nodes.stats())
         self.assertEqual(stats["nodes"], {})
         self.assertEqual(stats["cluster_name"], "abc")
 
 
 class PerformRequestTests(IsolatedAsyncioTestCase):
 
-    async def test_get_shape_returns_empty(self):
+    async def test_get_shape_raises(self):
+        # F3: perform_request now raises loudly for any OS-shaped REST call so
+        # workloads using OS default runners fail fast instead of silently
+        # succeeding with an empty response.
         c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
         m = mock.AsyncMock()
         c._client = m
-        result = await c.perform_request("GET", "/some/path")
-        self.assertEqual(result, {})
+        with self.assertRaises(exceptions.BenchmarkError) as ctx:
+            await c.perform_request("GET", "/some/path")
+        self.assertIn("GET /some/path", str(ctx.exception))
         m.command.assert_not_called()
 
-    async def test_body_carrying_routes_to_command(self):
+    async def test_body_carrying_raises(self):
         c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
         m = mock.AsyncMock()
         c._client = m
-        await c.perform_request("POST", "/", body="SELECT 1")
-        m.command.assert_awaited_once_with("SELECT 1")
+        with self.assertRaises(exceptions.BenchmarkError) as ctx:
+            await c.perform_request("POST", "/", body="SELECT 1")
+        self.assertIn("POST /", str(ctx.exception))
+        m.command.assert_not_called()
+
+    async def test_arbitrary_url_and_method_raises(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await c.perform_request("PUT", "/_async_search/status/xyz")
 
 
 class PutSettingsTests(IsolatedAsyncioTestCase):
@@ -579,3 +594,101 @@ class PutSettingsTests(IsolatedAsyncioTestCase):
         c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
         result = await c.cluster.put_settings(body={"a": 1})
         self.assertEqual(result, {"acknowledged": True})
+
+
+# -----------------------------------------------------------------
+# Regression tests for review findings (P7)
+# -----------------------------------------------------------------
+
+
+class NodesProxyAsyncRegressionTests(IsolatedAsyncioTestCase):
+    """F4/F11: _NodesProxy.stats and .info must be awaitable and return dicts
+    shaped like the OS default NodeStats runner expects."""
+
+    async def test_stats_is_awaitable_and_returns_dict(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {"cluster_name": "cn"})
+        result = await c.nodes.stats()
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["nodes"], {})
+        self.assertEqual(result["cluster_name"], "cn")
+
+    async def test_info_is_awaitable_and_returns_os_shape(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {"cluster_name": "cn"})
+        result = await c.nodes.info()
+        # Must have a 'nodes' key so callers that do result["nodes"].items() don't KeyError.
+        self.assertIn("nodes", result)
+        self.assertEqual(result["nodes"], {})
+        self.assertEqual(result["cluster_name"], "cn")
+        self.assertEqual(result["cluster_uuid"], "clickhouse")
+
+
+class Ipv6EndpointRegressionTests(TestCase):
+    """F7: IPv6 hosts must be re-wrapped in brackets in the endpoint URL."""
+
+    def test_ipv6_loopback_endpoint(self):
+        c = ClickHouseDatabaseClient([{"host": "[::1]", "port": 8123}], {})
+        self.assertEqual(c.endpoint, "http://[::1]:8123")
+
+    def test_ipv6_full_address_endpoint(self):
+        # parse_hosts strips brackets; endpoint must re-wrap since ':' in host
+        # makes the URL ambiguous.
+        c = ClickHouseDatabaseClient([{"host": "[2001:db8::1]", "port": 8443}], {})
+        self.assertEqual(c.endpoint, "https://[2001:db8::1]:8443")
+
+    def test_ipv4_endpoint_not_wrapped(self):
+        c = ClickHouseDatabaseClient([{"host": "10.0.0.1", "port": 8123}], {})
+        self.assertEqual(c.endpoint, "http://10.0.0.1:8123")
+
+
+class DdlFileResolutionRegressionTests(IsolatedAsyncioTestCase):
+    """F13: ddl-file resolution honors workload-path, workload_path, and falls
+    back to cwd with a WARNING."""
+
+    async def test_workload_path_underscore_variant(self):
+        import tempfile
+        import os as _os
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        with tempfile.TemporaryDirectory() as td:
+            path = _os.path.join(td, "t.sql")
+            with open(path, "w", encoding="utf-8") as fp:
+                fp.write("CREATE TABLE t (a UInt64) ENGINE=Memory")
+            await c.indices.create(index="t", body={"ddl-file": "t.sql"},
+                                   params={"workload_path": td})
+        c._client.command.assert_awaited_once()
+
+    async def test_no_workload_path_falls_back_to_cwd_with_warning(self):
+        import tempfile
+        import os as _os
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        c._client = mock.AsyncMock()
+        with tempfile.TemporaryDirectory() as td:
+            path = _os.path.join(td, "t.sql")
+            with open(path, "w", encoding="utf-8") as fp:
+                fp.write("CREATE TABLE t (a UInt64) ENGINE=Memory")
+            cwd = _os.getcwd()
+            _os.chdir(td)
+            try:
+                with self.assertLogs("osbenchmark.engine.clickhouse.client",
+                                     level="WARNING") as cm:
+                    await c.indices.create(index="t", body={"ddl-file": "t.sql"})
+            finally:
+                _os.chdir(cwd)
+        self.assertTrue(any("workload-path" in m for m in cm.output))
+        c._client.command.assert_awaited_once()
+
+
+class InfoUnexpectedExceptionRegressionTests(TestCase):
+    """F12: info() logs a WARNING with the exception type on unexpected errors
+    (not just an empty except: pass) so the failure is visible in logs."""
+
+    def test_unexpected_exception_logs_warning_with_type(self):
+        c = ClickHouseDatabaseClient([{"host": "h", "port": 8123}], {})
+        # A ValueError isn't in the expected (ClickHouseError/httpx.HTTPError) set.
+        with mock.patch.object(c, "_ensure_sync_client", side_effect=ValueError("oops")):
+            with self.assertLogs("osbenchmark.engine.clickhouse.client",
+                                 level="WARNING") as cm:
+                info = c.info()
+        self.assertEqual(info["version"]["number"], "24.8.0")
+        # The unexpected-branch WARNING mentions the exception type name.
+        self.assertTrue(any("ValueError" in m and "unexpected" in m for m in cm.output))

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -359,11 +359,15 @@ class MultiHostWarnRegressionTests(TestCase):
 class MultiHostWarningDedupeTests(TestCase):
     """P8: parse_hosts is called from _ensure_client, _ensure_sync_client, and
     endpoint - without dedupe, the multi-host warning logs ~24 times per
-    8-worker benchmark. Fixed with module-level `_MULTI_HOST_WARNED` flag."""
+    8-worker benchmark. Fixed with per-host-tuple `_MULTI_HOST_WARNED_KEYS` set."""
 
     def setUp(self):
-        # Reset the module flag between tests
-        helpers._MULTI_HOST_WARNED = False
+        # Reset the module dedupe set between tests
+        helpers._MULTI_HOST_WARNED_KEYS.clear()
+
+    def tearDown(self):
+        # Also clear on teardown so we don't leak state into other test classes.
+        helpers._MULTI_HOST_WARNED_KEYS.clear()
 
     def test_multi_host_warning_fires_once(self):
         multi = [{"host": "h1", "port": 8123}, {"host": "h2", "port": 8123}]

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for osbenchmark.engine.clickhouse.helpers."""
+
+from unittest import TestCase, mock
+
+import requests
+
+from osbenchmark import exceptions
+from osbenchmark.engine.clickhouse import helpers
+
+
+class NsToMsTests(TestCase):
+    """String -> milliseconds coercion for ClickHouse summary values."""
+
+    def test_string_input_converts(self):
+        # ClickHouse actually returns strings for summary values
+        self.assertEqual(helpers._ns_to_ms({"elapsed_ns": "5000000"}), 5)
+
+    def test_int_input_also_works(self):
+        self.assertEqual(helpers._ns_to_ms({"elapsed_ns": 5_000_000}), 5)
+
+    def test_missing_or_garbage_returns_zero(self):
+        self.assertEqual(helpers._ns_to_ms(None), 0)
+        self.assertEqual(helpers._ns_to_ms({}), 0)
+        self.assertEqual(helpers._ns_to_ms({"elapsed_ns": "not-a-number"}), 0)
+
+
+class QuoteIdentifierTests(TestCase):
+
+    def test_plain_name(self):
+        self.assertEqual(helpers.quote_identifier("foo"), "`foo`")
+
+    def test_embedded_backtick(self):
+        self.assertEqual(helpers.quote_identifier("f`o`o"), "`f``o``o`")
+
+    def test_unicode(self):
+        self.assertEqual(helpers.quote_identifier("日本語"), "`日本語`")
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            helpers.quote_identifier("")
+
+    def test_none_raises(self):
+        with self.assertRaises(ValueError):
+            helpers.quote_identifier(None)
+
+    def test_control_chars_raise(self):
+        for bad in ("\x00bad", "b\rad", "b\nad"):
+            with self.assertRaises(ValueError):
+                helpers.quote_identifier(bad)
+
+
+class ParseBulkBodyTests(TestCase):
+
+    def test_bytes_input(self):
+        body = (b'{"index":{"_id":"1"}}\n{"a":1}\n'
+                b'{"index":{"_id":"2"}}\n{"a":2}\n')
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0]["_id"], "1")
+        self.assertEqual(docs[0]["_source"], {"a": 1})
+        self.assertEqual(docs[0]["_action"], "index")
+
+    def test_string_input(self):
+        body = '{"index":{"_id":"1"}}\n{"a":1}'
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["_source"], {"a": 1})
+
+    def test_list_input(self):
+        body = [{"index": {"_id": "1"}}, {"a": 1}]
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["_source"], {"a": 1})
+
+    def test_action_extraction_create(self):
+        body = [{"create": {"_id": "5"}}, {"a": 5}]
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(docs[0]["_action"], "create")
+        self.assertEqual(docs[0]["_id"], "5")
+
+    def test_missing_id_yields_none(self):
+        body = [{"index": {}}, {"a": 1}]
+        docs = helpers.parse_bulk_body(body)
+        self.assertIsNone(docs[0]["_id"])
+
+    def test_delete_action_rejected(self):
+        body = [{"delete": {"_id": "1"}}, {"a": 1}]
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers.parse_bulk_body(body)
+
+    def test_update_action_rejected(self):
+        body = [{"update": {"_id": "1"}}, {"doc": {"a": 1}}]
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers.parse_bulk_body(body)
+
+    def test_corruption_above_threshold_raises(self):
+        # 3 corrupt lines out of 10 total -> >1% -> raises
+        body = "\n".join(["not-json", "not-json", "not-json"] +
+                         ['{"index":{"_id":"1"}}', '{"a":1}'] * 3 +
+                         ['{"index":{"_id":"2"}}'])
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers.parse_bulk_body(body)
+
+    def test_already_normalized_list_returns_as_is(self):
+        body = [{"_id": "1", "_source": {"a": 1}, "_action": "index"}]
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(docs, body)
+
+
+class RowsFromDocsTests(TestCase):
+
+    def test_all_columns_present(self):
+        docs = [{"_source": {"a": 1, "b": 2}}, {"_source": {"a": 3, "b": 4}}]
+        rows = helpers.rows_from_docs(docs, ["a", "b"])
+        self.assertEqual(rows, [(1, 2), (3, 4)])
+
+    def test_missing_column_becomes_none(self):
+        docs = [{"_source": {"a": 1}}]
+        rows = helpers.rows_from_docs(docs, ["a", "b"])
+        self.assertEqual(rows, [(1, None)])
+
+    def test_strict_mode_raises(self):
+        docs = [{"_id": "x", "_source": {"a": 1}}]
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers.rows_from_docs(docs, ["a", "b"], strict=True)
+
+    def test_docs_have_extra_keys_true(self):
+        docs = [{"_source": {"a": 1, "extra": 9}}]
+        self.assertTrue(helpers.docs_have_extra_keys(docs, ["a"]))
+        self.assertFalse(helpers.docs_have_extra_keys(docs, ["a", "extra"]))
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(helpers.rows_from_docs([], ["a"]), [])
+        self.assertFalse(helpers.docs_have_extra_keys([], ["a"]))
+
+
+class CoerceParametersTests(TestCase):
+
+    def test_none_returns_none(self):
+        self.assertIsNone(helpers.coerce_parameters(None))
+
+    def test_ndarray_becomes_list(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = helpers.coerce_parameters({"v": arr})
+        self.assertEqual(result, {"v": [1.0, 2.0, 3.0]})
+        # Confirm scalars are Python floats, not numpy.float32
+        for val in result["v"]:
+            self.assertIsInstance(val, float)
+
+    def test_scalar_generic_becomes_python(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        val = np.float32(3.14)
+        result = helpers.coerce_parameters({"x": val})
+        self.assertIsInstance(result["x"], float)
+
+    def test_non_numpy_passthrough(self):
+        self.assertEqual(helpers.coerce_parameters({"a": 1, "b": [2, 3]}),
+                         {"a": 1, "b": [2, 3]})
+
+
+class ConvertQueryResultsTests(TestCase):
+
+    def test_search_basic_rows(self):
+        rows = [(1, "a"), (2, "b")]
+        cols = ("id", "name")
+        resp = helpers.convert_query_result_to_search_response(rows, cols)
+        self.assertEqual(len(resp["hits"]["hits"]), 2)
+        self.assertEqual(resp["hits"]["total"]["value"], 2)
+        self.assertEqual(resp["hits"]["hits"][0]["_source"], {"id": 1, "name": "a"})
+
+    def test_search_elapsed_string_to_int_took(self):
+        resp = helpers.convert_query_result_to_search_response(
+            [], (), elapsed_ns="5000000"
+        )
+        self.assertEqual(resp["took"], 5)
+
+    def test_search_total_hits_override(self):
+        resp = helpers.convert_query_result_to_search_response(
+            [(1,)], ("id",), total_hits=999
+        )
+        self.assertEqual(resp["hits"]["total"]["value"], 999)
+
+    def test_vector_score_populated(self):
+        rows = [(1, 0.9, "x"), (2, 0.7, "y")]
+        cols = ("id", "score", "name")
+        resp = helpers.convert_query_result_for_vector_search(rows, cols)
+        self.assertEqual(resp["hits"]["max_score"], 0.9)
+        self.assertEqual(resp["hits"]["hits"][0]["_score"], 0.9)
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "1")
+
+    def test_vector_missing_score_column(self):
+        rows = [(1, "x")]
+        cols = ("id", "name")
+        resp = helpers.convert_query_result_for_vector_search(rows, cols)
+        self.assertIsNone(resp["hits"]["max_score"])
+        self.assertIsNone(resp["hits"]["hits"][0]["_score"])
+
+
+class BuildStatsAndVersionTests(TestCase):
+
+    def test_build_stats_response_with_index(self):
+        env = helpers.build_stats_response(rows=10, bytes_on_disk=1024, index_name="metrics")
+        self.assertEqual(env["_all"]["primaries"]["docs"]["count"], 10)
+        self.assertEqual(env["indices"]["metrics"]["total"]["store"]["size_in_bytes"], 1024)
+
+    def test_build_stats_response_without_index(self):
+        env = helpers.build_stats_response(rows=5, bytes_on_disk=512, index_name=None)
+        self.assertEqual(env["indices"], {})
+        self.assertEqual(env["_all"]["primaries"]["docs"]["count"], 5)
+
+    def test_parse_version_common_shapes(self):
+        self.assertEqual(helpers.parse_version("24.8.1.2684"), "24.8.1")
+        self.assertEqual(helpers.parse_version("25.5.1.11-stable"), "25.5.1")
+        self.assertEqual(helpers.parse_version("24.8.1.2684-cloud"), "24.8.1")
+
+    def test_parse_version_fallback(self):
+        self.assertEqual(helpers.parse_version(""), "24.8.0")
+        self.assertEqual(helpers.parse_version(None), "24.8.0")
+        self.assertEqual(helpers.parse_version("24.8"), "24.8.0")
+        self.assertEqual(helpers.parse_version("head-fcbd7a4"), "24.8.0")
+
+
+class WaitForClickHouseAndHostsTests(TestCase):
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.requests.get")
+    def test_ready_on_first_attempt(self, mock_get):
+        mock_get.return_value = mock.MagicMock(status_code=200, text="Ok.\n")
+        client = mock.MagicMock(endpoint="http://h:8123", client_options={})
+        self.assertTrue(helpers.wait_for_clickhouse(client, max_attempts=1, sleep_seconds=0))
+
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.time.sleep")
+    @mock.patch("osbenchmark.engine.clickhouse.helpers.requests.get")
+    def test_ssl_error_logs_warning(self, mock_get, _sleep):
+        mock_get.side_effect = requests.exceptions.SSLError("cert issue")
+        client = mock.MagicMock(endpoint="https://h:8443", client_options={"ssl_verify": True})
+        with self.assertLogs("osbenchmark.engine.clickhouse.helpers", level="WARNING") as cm:
+            self.assertFalse(helpers.wait_for_clickhouse(client, max_attempts=1, sleep_seconds=0))
+        self.assertTrue(any("SSL" in msg for msg in cm.output))
+
+    def test_parse_hosts_rejects_port_9000(self):
+        with self.assertRaises(exceptions.SystemSetupError):
+            helpers.parse_hosts([{"host": "h", "port": 9000}])
+
+    def test_parse_hosts_ipv6(self):
+        host, port, secure = helpers.parse_hosts([{"host": "[::1]", "port": 8123}])
+        self.assertEqual(host, "::1")
+        self.assertEqual(port, 8123)
+        self.assertFalse(secure)
+
+    def test_parse_hosts_secure_for_tls_ports(self):
+        _, _, secure_8443 = helpers.parse_hosts([{"host": "h", "port": 8443}])
+        _, _, secure_9440 = helpers.parse_hosts([{"host": "h", "port": 9440}])
+        _, _, secure_8123 = helpers.parse_hosts([{"host": "h", "port": 8123}])
+        self.assertTrue(secure_8443)
+        self.assertTrue(secure_9440)
+        self.assertFalse(secure_8123)

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -350,3 +350,68 @@ class MultiHostWarnRegressionTests(TestCase):
             # Ensure the log records list has SOMETHING (assertLogs requires it).
             helpers.logger.warning("noise")
         self.assertFalse(any("only the first" in m for m in cm.output))
+
+
+# ============================================================================
+# P8 regression tests (second-pass review findings)
+# ============================================================================
+
+class MultiHostWarningDedupeTests(TestCase):
+    """P8: parse_hosts is called from _ensure_client, _ensure_sync_client, and
+    endpoint - without dedupe, the multi-host warning logs ~24 times per
+    8-worker benchmark. Fixed with module-level `_MULTI_HOST_WARNED` flag."""
+
+    def setUp(self):
+        # Reset the module flag between tests
+        helpers._MULTI_HOST_WARNED = False
+
+    def test_multi_host_warning_fires_once(self):
+        multi = [{"host": "h1", "port": 8123}, {"host": "h2", "port": 8123}]
+        with self.assertLogs("osbenchmark.engine.clickhouse.helpers",
+                             level="WARNING") as cm:
+            helpers.parse_hosts(multi)
+            helpers.parse_hosts(multi)
+            helpers.parse_hosts(multi)
+        matches = [m for m in cm.output if "only the first" in m]
+        self.assertEqual(len(matches), 1, f"Expected 1 dedupe'd warning, got {len(matches)}")
+
+
+class ActionExtractionDeterminismTests(TestCase):
+    """P8: _ALL_BULK_ACTIONS was a frozenset. Iteration order under
+    PYTHONHASHSEED randomization was non-deterministic, so an action_meta with
+    multiple recognized keys returned different actions across runs. Fixed by
+    making _ALL_BULK_ACTIONS an ordered tuple with a fixed priority."""
+
+    def test_ambiguous_action_meta_deterministic(self):
+        # If both 'index' and 'update' are present, priority is fixed.
+        result = helpers._extract_action({"index": {"_id": "1"}, "update": {"_id": "1"}})
+        self.assertEqual(result, "index")
+
+    def test_all_bulk_actions_is_ordered(self):
+        # Guard against a future refactor that switches back to a set/frozenset.
+        self.assertIsInstance(helpers._ALL_BULK_ACTIONS, tuple)
+
+
+class DeadTernaryRegressionTests(TestCase):
+    """P8: `hit_id if hit_id != '' else ''` was dead code because the preceding
+    line already normalizes None -> ''. Simplified to just `hit_id`."""
+
+    def test_none_id_becomes_empty_string(self):
+        rows = [(None, 42)]
+        cols = ("_id", "value")
+        resp = helpers.convert_query_result_to_search_response(rows, cols)
+        # Must be empty string, NOT the literal 'None' (which would happen if
+        # str(None) fired without the earlier None guard).
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "")
+
+    def test_integer_id_stringified(self):
+        rows = [(42, "row1")]
+        cols = ("_id", "value")
+        resp = helpers.convert_query_result_to_search_response(rows, cols)
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "42")
+
+    def test_vector_search_null_id_empty(self):
+        rows = [(None, 0.9, "x")]
+        cols = ("id", "score", "name")
+        resp = helpers.convert_query_result_for_vector_search(rows, cols)
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "")

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -395,6 +395,22 @@ class ActionExtractionDeterminismTests(TestCase):
         # Guard against a future refactor that switches back to a set/frozenset.
         self.assertIsInstance(helpers._ALL_BULK_ACTIONS, tuple)
 
+    def test_all_bulk_actions_exact_priority_order(self):
+        # Do NOT rely on CPython dict iteration ordering to prove determinism -
+        # assert the priority tuple directly. If the tuple's contents or order
+        # ever change, callers that depend on 'index'-before-'update' will
+        # silently start behaving differently.
+        self.assertEqual(helpers._ALL_BULK_ACTIONS,
+                         ("index", "create", "update", "delete"))
+
+    def test_ambiguous_action_meta_deterministic_under_shuffled_iteration(self):
+        # Force iteration order to expose the priority: if _extract_action's
+        # loop iterated over the dict directly instead of _ALL_BULK_ACTIONS,
+        # this would return 'update' on some Python versions.
+        shuffled = {"update": {"_id": "1"}, "delete": {"_id": "1"},
+                    "create": {"_id": "1"}, "index": {"_id": "1"}}
+        self.assertEqual(helpers._extract_action(shuffled), "index")
+
 
 class DeadTernaryRegressionTests(TestCase):
     """P8: `hit_id if hit_id != '' else ''` was dead code because the preceding

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -96,7 +96,7 @@ class ParseBulkBodyTests(TestCase):
             helpers.parse_bulk_body(body)
 
     def test_corruption_above_threshold_raises(self):
-        # 3 corrupt lines out of 10 total -> >1% -> raises
+        # 3 corrupt lines out of 10 total -> raises
         body = "\n".join(["not-json", "not-json", "not-json"] +
                          ['{"index":{"_id":"1"}}', '{"a":1}'] * 3 +
                          ['{"index":{"_id":"2"}}'])
@@ -263,3 +263,90 @@ class WaitForClickHouseAndHostsTests(TestCase):
         self.assertTrue(secure_8443)
         self.assertTrue(secure_9440)
         self.assertFalse(secure_8123)
+
+
+# -----------------------------------------------------------------
+# Regression tests for review findings (P7)
+# -----------------------------------------------------------------
+
+
+class ParseBulkBodyStrictParseRegressionTests(TestCase):
+    """F2: parse_bulk_body raises on ANY JSON parse error; even a single
+    corrupt line silently mis-aligns the pair-consumer below."""
+
+    def test_single_corrupt_line_raises(self):
+        # 2 corrupt lines out of 200 total = 1% (previously silently tolerated).
+        # Now: raises immediately.
+        body_lines = ['{"index":{"_id":"' + str(i) + '"}}\n{"a":' + str(i) + '}'
+                      for i in range(99)]
+        body = "\n".join(body_lines[:50] + ["not-json", "still-not-json"] + body_lines[50:])
+        with self.assertRaises(exceptions.BenchmarkError) as ctx:
+            helpers.parse_bulk_body(body)
+        self.assertIn("line", str(ctx.exception).lower())
+
+    def test_zero_corrupt_lines_succeeds(self):
+        body = '{"index":{"_id":"1"}}\n{"a":1}\n{"index":{"_id":"2"}}\n{"a":2}\n'
+        docs = helpers.parse_bulk_body(body)
+        self.assertEqual(len(docs), 2)
+
+
+class ExtractActionRegressionTests(TestCase):
+    """F10: _extract_action must raise on unknown action-meta so misaligned
+    bulk bodies surface loudly instead of coercing to 'index'."""
+
+    def test_unknown_key_raises(self):
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers._extract_action({"random": {"_id": "1"}})
+
+    def test_empty_dict_raises(self):
+        with self.assertRaises(exceptions.BenchmarkError):
+            helpers._extract_action({})
+
+    def test_recognized_key_still_works(self):
+        self.assertEqual(helpers._extract_action({"index": {"_id": "1"}}), "index")
+        self.assertEqual(helpers._extract_action({"create": {"_id": "1"}}), "create")
+
+
+class ConvertQueryResultNullIdRegressionTests(TestCase):
+    """F15: SQL NULL _id must coerce to '' (empty string), not the literal 'None'."""
+
+    def test_search_response_null_id(self):
+        rows = [(None, "a")]
+        cols = ("_id", "name")
+        resp = helpers.convert_query_result_to_search_response(rows, cols)
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "")
+        # Ensure the string 'None' didn't leak through
+        self.assertNotEqual(resp["hits"]["hits"][0]["_id"], "None")
+
+    def test_vector_response_null_id(self):
+        rows = [(None, 0.9)]
+        cols = ("id", "score")
+        resp = helpers.convert_query_result_for_vector_search(rows, cols)
+        self.assertEqual(resp["hits"]["hits"][0]["_id"], "")
+        self.assertNotEqual(resp["hits"]["hits"][0]["_id"], "None")
+
+
+class MultiHostWarnRegressionTests(TestCase):
+    """F16: multi-host config must emit a WARNING pointing at the follow-up."""
+
+    def test_two_hosts_logs_warning(self):
+        with self.assertLogs("osbenchmark.engine.clickhouse.helpers",
+                             level="WARNING") as cm:
+            host, port, _ = helpers.parse_hosts([
+                {"host": "h1", "port": 8123},
+                {"host": "h2", "port": 8123},
+            ])
+        self.assertEqual(host, "h1")
+        self.assertEqual(port, 8123)
+        self.assertTrue(any("only the first" in m for m in cm.output))
+
+    def test_single_host_no_warning(self):
+        # Use a fresh logger context: assertNoLogs would be cleaner but is 3.10+;
+        # we accept it may match INFO/DEBUG from prior tests. Guard by checking
+        # that our WARNING pattern is NOT present.
+        with self.assertLogs("osbenchmark.engine.clickhouse.helpers",
+                             level="WARNING") as cm:
+            helpers.parse_hosts([{"host": "h1", "port": 8123}])
+            # Ensure the log records list has SOMETHING (assertLogs requires it).
+            helpers.logger.warning("noise")
+        self.assertFalse(any("only the first" in m for m in cm.output))

--- a/tests/engine/clickhouse/helpers_test.py
+++ b/tests/engine/clickhouse/helpers_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for osbenchmark.engine.clickhouse.helpers."""
+# pylint: disable=protected-access,import-outside-toplevel
 
 from unittest import TestCase, mock
 

--- a/tests/engine/clickhouse/runner_test.py
+++ b/tests/engine/clickhouse/runner_test.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for osbenchmark.engine.clickhouse.runners."""
+
+from unittest import TestCase, IsolatedAsyncioTestCase, mock
+
+from osbenchmark import exceptions
+from osbenchmark.engine.clickhouse import runners as ch_runners
+
+
+class _RunnerCase(IsolatedAsyncioTestCase):
+    """Base for runner tests. Patches request_context_holder so the ContextVar
+    lookups inside on_*_request_* don't LookupError in an isolated test."""
+
+    def setUp(self):
+        self._ctx_patcher = mock.patch(
+            "osbenchmark.engine.clickhouse.runners.request_context_holder"
+        )
+        self.mock_ctx = self._ctx_patcher.start()
+        self.addCleanup(self._ctx_patcher.stop)
+
+
+# -----------------------------------------------------------------
+# Shared fixtures (inline, no conftest.py)
+# -----------------------------------------------------------------
+
+def _make_client(**overrides):
+    """Build a mock ClickHouse client for runner tests."""
+    client = mock.AsyncMock()
+    # duck-type the namespace proxies
+    client.indices = client
+    client.cluster = client
+    client._client = mock.MagicMock()  # for the _client = None reset assertions
+    # execute_query returns an AsyncMock so it can be awaited
+    client.execute_query = mock.AsyncMock()
+    for k, v in overrides.items():
+        setattr(client, k, v)
+    return client
+
+
+def _query_result(rows=None, columns=None, elapsed_ns="1000000"):
+    """Note: elapsed_ns is a STRING to match ClickHouse's real behavior."""
+    r = mock.MagicMock()
+    r.result_rows = rows or []
+    r.column_names = tuple(columns or [])
+    r.summary = {"elapsed_ns": elapsed_ns}
+    return r
+
+
+class ClickHouseBulkIndexTests(_RunnerCase):
+
+    async def test_success(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        client.bulk.return_value = {"errors": False, "took": 5, "items": [{}, {}]}
+        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 100,
+                                  "column-names": ["a"]})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 100)
+        self.assertEqual(result["error-count"], 0)
+        self.assertEqual(result["took"], 5)
+
+    async def test_error_count_is_one_on_failure(self):
+        # ClickHouse INSERT is all-or-nothing: 1 error, not bulk_size.
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        client.bulk.return_value = {"errors": True, "took": 0, "items": []}
+        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 100})
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-count"], 1)
+
+    async def test_zero_doc_guard(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        result = await r(client, {"index": "t", "body": [], "bulk-size": 50})
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-count"], 1)
+        client.bulk.assert_not_called()
+
+    async def test_client_reset_on_exception(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        client.bulk.side_effect = RuntimeError("boom")
+        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 1})
+        self.assertFalse(result["success"])
+        self.assertIsNone(client._client)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseBulkIndex()), "clickhouse-bulk-index")
+
+
+class ClickHouseQueryTests(_RunnerCase):
+
+    async def test_success(self):
+        r = ch_runners.ClickHouseQuery()
+        client = _make_client()
+        client.search.return_value = {
+            "took": 7, "timed_out": False,
+            "hits": {"total": {"value": 3, "relation": "eq"}, "hits": []},
+        }
+        result = await r(client, {"body": {"sql": "SELECT 1"}})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["hits"], 3)
+        self.assertEqual(result["took"], 7)
+
+    async def test_missing_sql_raises(self):
+        r = ch_runners.ClickHouseQuery()
+        client = _make_client()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {}})
+
+    async def test_client_reset_on_exception(self):
+        r = ch_runners.ClickHouseQuery()
+        client = _make_client()
+        client.search.side_effect = RuntimeError("boom")
+        result = await r(client, {"body": {"sql": "SELECT 1"}})
+        self.assertFalse(result["success"])
+        self.assertIsNone(client._client)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseQuery()), "clickhouse-query")
+
+
+class ClickHouseVectorSearchTests(_RunnerCase):
+
+    async def test_success_via_execute_query(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        client.execute_query.return_value = _query_result(
+            [(1, 0.9), (2, 0.7)], ["id", "score"]
+        )
+        result = await r(client, {"body": {"sql": "SELECT id, score FROM t"}})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["hits"], 2)
+        client.execute_query.assert_awaited_once()
+
+    async def test_numpy_parameters_coerced(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([], [])
+        await r(client, {"body": {"sql": "SELECT 1", "parameters": {"v": np.array([1.0])}}})
+        kwargs = client.execute_query.await_args.kwargs
+        self.assertEqual(kwargs["parameters"]["v"], [1.0])
+
+    async def test_ef_search_sets_setting(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([], [])
+        await r(client, {"body": {"sql": "SELECT 1"}, "hnsw_ef_search": 200, "k": 10})
+        kwargs = client.execute_query.await_args.kwargs
+        self.assertEqual(kwargs["settings"]["hnsw_candidate_list_size_for_search"], 200)
+
+    async def test_recall_int_normalization(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        # Returned rows have ID '1' as int; truth has '00001' as zero-padded string.
+        # Integer normalization should match them.
+        client.execute_query.return_value = _query_result([(1, 0.9)], ["id", "score"])
+        result = await r(client, {
+            "body": {"sql": "SELECT 1"},
+            "k": 1,
+            "calculate-recall": True,
+            "neighbors": ["00001"],
+        })
+        self.assertEqual(result["recall@k"], 1.0)
+        self.assertEqual(result["recall@1"], 1.0)
+
+    async def test_missing_sql_raises(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {}})
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseVectorSearch()), "clickhouse-vector-search")
+
+
+class ClickHouseScrollQueryTests(_RunnerCase):
+
+    async def test_requires_placeholders(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {"sql": "SELECT id FROM t ORDER BY id"}})
+
+    async def test_requires_order_by(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {"sql": "SELECT id FROM t LIMIT {limit:UInt32} OFFSET {offset:UInt32}"}})
+
+    async def test_pages_actual_matches_loop_count(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([(1,)] * 5, ["id"])
+        result = await r(client, {
+            "body": {"sql": "SELECT id FROM t ORDER BY id "
+                            "LIMIT {limit:UInt32} OFFSET {offset:UInt32}"},
+            "pages": 3, "results-per-page": 5,
+        })
+        self.assertEqual(result["pages_actual"], 3)
+        self.assertEqual(result["hits"], 15)
+
+    async def test_early_exit_on_partial_page(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        # First call returns full 5 rows, second returns 2 -> exit loop after 2 pages.
+        client.execute_query.side_effect = [
+            _query_result([(1,)] * 5, ["id"]),
+            _query_result([(2,)] * 2, ["id"]),
+        ]
+        result = await r(client, {
+            "body": {"sql": "SELECT id FROM t ORDER BY id "
+                            "LIMIT {limit:UInt32} OFFSET {offset:UInt32}"},
+            "pages": 10, "results-per-page": 5,
+        })
+        self.assertEqual(result["pages_actual"], 2)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseScrollQuery()), "clickhouse-scroll-query")
+
+
+class ClickHouseBulkVectorDataSetTests(_RunnerCase):
+
+    async def test_alternating_pairs(self):
+        r = ch_runners.ClickHouseBulkVectorDataSet()
+        client = _make_client()
+        body = [{"index": {"_id": "1"}}, {"id": 1, "vec": [0.1, 0.2]}]
+        size, unit = await r(client, {"index": "t", "size": 1, "body": body})
+        self.assertEqual(size, 1)
+        self.assertEqual(unit, "docs")
+        client.bulk.assert_awaited_once()
+
+    async def test_numpy_vector_conversion(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("numpy not available")
+        r = ch_runners.ClickHouseBulkVectorDataSet()
+        client = _make_client()
+        body = [{"index": {"_id": "1"}},
+                {"id": 1, "vec": np.array([0.1, 0.2], dtype=np.float32)}]
+        await r(client, {"index": "t", "size": 1, "body": body})
+        called_body = client.bulk.await_args.kwargs["body"]
+        # Vector should be a list, not an ndarray
+        self.assertIsInstance(called_body[1]["vec"], list)
+
+    async def test_returns_tuple(self):
+        r = ch_runners.ClickHouseBulkVectorDataSet()
+        client = _make_client()
+        result = await r(client, {"index": "t", "size": 42, "body": []})
+        self.assertEqual(result, (42, "docs"))
+
+
+class ClickHouseCreateTableTests(_RunnerCase):
+
+    async def test_single_index(self):
+        r = ch_runners.ClickHouseCreateTable()
+        client = _make_client()
+        result = await r(client, {"index": "t", "body": {"ddl": "CREATE TABLE t (a UInt64) ENGINE=MergeTree ORDER BY a"}})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["weight"], 1)
+        client.indices.create.assert_awaited_once()
+
+    async def test_multi_index(self):
+        r = ch_runners.ClickHouseCreateTable()
+        client = _make_client()
+        result = await r(client, {"indices": [("t1", {"ddl": "..."}), ("t2", {"ddl": "..."})]})
+        self.assertEqual(result["weight"], 2)
+        self.assertEqual(client.indices.create.await_count, 2)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseCreateTable()), "clickhouse-create-table")
+
+
+class ClickHouseDropTableTests(_RunnerCase):
+
+    async def test_delete(self):
+        r = ch_runners.ClickHouseDropTable()
+        client = _make_client()
+        result = await r(client, {"index": "t"})
+        self.assertEqual(result["weight"], 1)
+        client.indices.delete.assert_awaited_once_with(index="t")
+
+    async def test_only_if_exists(self):
+        r = ch_runners.ClickHouseDropTable()
+        client = _make_client()
+        client.indices.exists = mock.AsyncMock(return_value=False)
+        result = await r(client, {"index": "t", "only-if-exists": True})
+        self.assertEqual(result["weight"], 0)
+        client.indices.delete.assert_not_called()
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseDropTable()), "clickhouse-drop-table")
+
+
+class ClickHouseSystemPartsTests(_RunnerCase):
+
+    async def test_returns_os_shape(self):
+        r = ch_runners.ClickHouseSystemParts()
+        client = _make_client()
+        stats_payload = {
+            "_all": {"primaries": {"docs": {"count": 5}}, "total": {"docs": {"count": 5}}},
+            "indices": {},
+        }
+        client.indices.stats = mock.AsyncMock(return_value=stats_payload)
+        result = await r(client, {"index": "t"})
+        self.assertEqual(result["stats"], stats_payload)
+        self.assertEqual(result["index"], "t")
+        self.assertEqual(result["primaries"], {"docs": {"count": 5}})
+
+    async def test_all_default_index(self):
+        r = ch_runners.ClickHouseSystemParts()
+        client = _make_client()
+        client.indices.stats = mock.AsyncMock(return_value={"_all": {"primaries": {}, "total": {}}})
+        result = await r(client, {})
+        self.assertEqual(result["index"], "_all")
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseSystemParts()), "clickhouse-system-parts")
+
+
+class ClickHouseClusterHealthTests(_RunnerCase):
+
+    async def test_green(self):
+        r = ch_runners.ClickHouseClusterHealth()
+        client = _make_client()
+        client.cluster.health = mock.AsyncMock(return_value={"status": "green", "relocating_shards": 0})
+        result = await r(client, {})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["cluster-status"], "green")
+
+    async def test_red_not_success(self):
+        r = ch_runners.ClickHouseClusterHealth()
+        client = _make_client()
+        client.cluster.health = mock.AsyncMock(return_value={"status": "red"})
+        result = await r(client, {})
+        self.assertFalse(result["success"])
+
+    async def test_relocating_passthrough(self):
+        r = ch_runners.ClickHouseClusterHealth()
+        client = _make_client()
+        client.cluster.health = mock.AsyncMock(
+            return_value={"status": "yellow", "relocating_shards": 7}
+        )
+        result = await r(client, {})
+        self.assertEqual(result["relocating-shards"], 7)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseClusterHealth()), "clickhouse-cluster-health")
+
+
+class ClickHouseRefreshNoOpTests(_RunnerCase):
+    """Refresh operation type maps to ClickHouseNoOp('refresh')."""
+
+    async def test_success(self):
+        r = ch_runners.ClickHouseNoOp("refresh")
+        client = _make_client()
+        result = await r(client, {})
+        self.assertTrue(result["success"])
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseNoOp("refresh")),
+                         "clickhouse-noop(refresh)")
+
+
+class ClickHouseOptimizeTableTests(_RunnerCase):
+
+    async def test_success(self):
+        r = ch_runners.ClickHouseOptimizeTable()
+        client = _make_client()
+        client.indices.forcemerge = mock.AsyncMock(
+            return_value={"_shards": {"total": 1, "successful": 1, "failed": 0}}
+        )
+        result = await r(client, {"index": "t"})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["shards"]["successful"], 1)
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseOptimizeTable()),
+                         "clickhouse-optimize-table")
+
+
+class ClickHouseNoOpTests(_RunnerCase):
+
+    async def test_logs_skip(self):
+        r = ch_runners.ClickHouseNoOp("put-pipeline")
+        client = _make_client()
+        with self.assertLogs("osbenchmark.worker_coordinator.runner", level="DEBUG") as cm:
+            await r(client, {})
+        self.assertTrue(any("put-pipeline" in msg for msg in cm.output))
+
+    async def test_returns_success(self):
+        r = ch_runners.ClickHouseNoOp("something")
+        client = _make_client()
+        result = await r(client, {})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["unit"], "ops")
+
+    def test_repr(self):
+        self.assertEqual(repr(ch_runners.ClickHouseNoOp("xyz")), "clickhouse-noop(xyz)")
+
+
+class RegisterRunnersTests(TestCase):
+    """Tests against the engine module's register_runners() function."""
+
+    def setUp(self):
+        # Snapshot the runner registry before each test to isolate changes.
+        from osbenchmark.worker_coordinator import runner as osb_runner
+        # pylint: disable=protected-access
+        self._orig = dict(getattr(osb_runner, "_Runner__RUNNERS", {})
+                          if hasattr(osb_runner, "_Runner__RUNNERS")
+                          else osb_runner.__dict__.get("_Runner__RUNNERS", {}))
+
+    def _capture(self, registrations):
+        """Return a mock that records (op_type, runner, kwargs) tuples."""
+        def _side_effect(op_type, runner, **kwargs):
+            registrations.append((op_type, runner, kwargs))
+        return _side_effect
+
+    def test_all_registrations_are_async(self):
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        self.assertTrue(registrations)
+        for _op, _r, kwargs in registrations:
+            self.assertTrue(kwargs.get("async_runner"))
+
+    def test_admin_ops_wrapped_in_retry(self):
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        from osbenchmark.worker_coordinator.runner import Retry
+        from osbenchmark.workload import workload as wl
+        admin_ops = {
+            wl.OperationType.CreateIndex, wl.OperationType.DeleteIndex,
+            wl.OperationType.ForceMerge, wl.OperationType.ClusterHealth,
+            wl.OperationType.IndexStats, wl.OperationType.PutSettings,
+        }
+        for op, r, _ in registrations:
+            if op in admin_ops:
+                self.assertIsInstance(r, Retry, f"{op} should be wrapped in Retry")
+
+    def test_data_plane_ops_not_wrapped(self):
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        from osbenchmark.worker_coordinator.runner import Retry
+        from osbenchmark.workload import workload as wl
+        data_plane_ops = {
+            wl.OperationType.Bulk, wl.OperationType.Search,
+            wl.OperationType.PaginatedSearch, wl.OperationType.ScrollSearch,
+            wl.OperationType.VectorSearch, wl.OperationType.BulkVectorDataSet,
+        }
+        for op, r, _ in registrations:
+            if op in data_plane_ops:
+                self.assertNotIsInstance(r, Retry, f"{op} should NOT be wrapped in Retry")
+
+    def test_warmup_knn_indices_registered_as_string(self):
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        keys = [op for op, _, _ in registrations]
+        self.assertIn("warmup-knn-indices", keys)
+
+    def test_registration_count(self):
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        # 6 data-plane + 6 admin + 3 CreateSearchPipeline/PutPipeline/DeletePipeline
+        # + 1 PutSettings + 1 warmup-knn-indices = 17
+        self.assertEqual(len(registrations), 17)
+
+
+class ClickHouseRunnerSqlContractTests(_RunnerCase):
+    """Contract: SQL-requiring runners raise BenchmarkError without a sql key."""
+
+    async def test_query_requires_sql(self):
+        r = ch_runners.ClickHouseQuery()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(_make_client(), {"body": {}})
+
+    async def test_vector_search_requires_sql(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(_make_client(), {"body": {}})
+
+    async def test_four_timing_methods_driven(self):
+        """Each real runner drives on_client_request_start/end + on_request_start/end."""
+        r = ch_runners.ClickHouseQuery()
+        client = _make_client()
+        client.search.return_value = {"took": 0, "timed_out": False,
+                                      "hits": {"total": {"value": 0}, "hits": []}}
+        with mock.patch("osbenchmark.engine.clickhouse.runners.request_context_holder") as ctx:
+            await r(client, {"body": {"sql": "SELECT 1"}})
+            ctx.on_client_request_start.assert_called_once()
+            ctx.on_request_start.assert_called_once()
+            ctx.on_request_end.assert_called_once()
+            ctx.on_client_request_end.assert_called_once()

--- a/tests/engine/clickhouse/runner_test.py
+++ b/tests/engine/clickhouse/runner_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for osbenchmark.engine.clickhouse.runners."""
+# pylint: disable=protected-access,import-outside-toplevel,no-name-in-module
 
 from unittest import TestCase, IsolatedAsyncioTestCase, mock
 

--- a/tests/engine/clickhouse/runner_test.py
+++ b/tests/engine/clickhouse/runner_test.py
@@ -443,10 +443,12 @@ class RegisterRunnersTests(TestCase):
         for _op, _r, kwargs in registrations:
             self.assertTrue(kwargs.get("async_runner"))
 
-    def test_admin_ops_not_wrapped_in_retry(self):
-        # F5: Retry() only catches opensearchpy exceptions, so wrapping
-        # ClickHouse admin runners in it was dead code that hid the real
-        # exception path. Assert we don't reintroduce the wrapper.
+    def test_one_shot_admin_ops_not_wrapped_in_retry(self):
+        # Retry's exception clauses only catch opensearchpy transport errors,
+        # so wrapping is useless for one-shot admin ops that never use
+        # retry-until-success. ClusterHealth is intentionally excluded from
+        # this set because workloads DO use retry-until-success on it (see
+        # test_cluster_health_wrapped_in_retry below).
         registrations = []
         with mock.patch(
             "osbenchmark.worker_coordinator.runner.register_runner",
@@ -456,15 +458,35 @@ class RegisterRunnersTests(TestCase):
             clickhouse.register_runners()
         from osbenchmark.worker_coordinator.runner import Retry
         from osbenchmark.workload import workload as wl
-        admin_ops = {
+        one_shot_admin_ops = {
             wl.OperationType.CreateIndex, wl.OperationType.DeleteIndex,
-            wl.OperationType.ForceMerge, wl.OperationType.ClusterHealth,
-            wl.OperationType.IndexStats, wl.OperationType.PutSettings,
+            wl.OperationType.ForceMerge, wl.OperationType.IndexStats,
+            wl.OperationType.PutSettings,
         }
         for op, r, _ in registrations:
-            if op in admin_ops:
+            if op in one_shot_admin_ops:
                 self.assertNotIsInstance(r, Retry,
-                                         f"{op} MUST NOT be wrapped in Retry (F5)")
+                                         f"{op} is one-shot admin and MUST NOT be wrapped in Retry")
+
+    def test_cluster_health_wrapped_in_retry(self):
+        # ClusterHealth is wrapped in Retry so workloads can set
+        # retry-until-success:true to poll for cluster readiness. Retry's
+        # return-value-based retry (via .get('success')) works engine-agnostic.
+        registrations = []
+        with mock.patch(
+            "osbenchmark.worker_coordinator.runner.register_runner",
+            side_effect=self._capture(registrations),
+        ):
+            from osbenchmark.engine import clickhouse
+            clickhouse.register_runners()
+        from osbenchmark.worker_coordinator.runner import Retry
+        from osbenchmark.workload import workload as wl
+        cluster_health_reg = [(op, r) for op, r, _ in registrations
+                              if op == wl.OperationType.ClusterHealth]
+        self.assertEqual(len(cluster_health_reg), 1)
+        self.assertIsInstance(cluster_health_reg[0][1], Retry,
+                              "ClusterHealth MUST be wrapped in Retry so "
+                              "retry-until-success works during bootstrap polling.")
 
     def test_data_plane_ops_not_wrapped(self):
         registrations = []
@@ -658,6 +680,9 @@ class DropTableCommaSplitRegressionTests(_RunnerCase):
         client = _make_client()
         await r(client, {"indices": ["a , b , c"]})
         self.assertEqual(client.indices.delete.await_count, 3)
+        # Whitespace must be stripped from each split name.
+        called_with = [c.kwargs.get("index") for c in client.indices.delete.await_args_list]
+        self.assertEqual(sorted(called_with), ["a", "b", "c"])
 
 
 class BulkIndexZeroDocRegressionTests(_RunnerCase):
@@ -678,3 +703,97 @@ class BulkIndexZeroDocRegressionTests(_RunnerCase):
         with self.assertRaises(exceptions.BenchmarkError):
             await r(client, {"index": "t", "body": b""})
         client.bulk.assert_not_called()
+
+
+# ============================================================================
+# P8 regression tests (second-pass review findings)
+# ============================================================================
+
+class ParseErrorSampleFailureRegressionTests(_RunnerCase):
+    """P8: parse_bulk_body raises BenchmarkError on data corruption. That MUST
+    be caught in ClickHouseBulkIndex and reported as a per-sample failure, not
+    propagated as an actor crash that aborts the whole benchmark."""
+
+    async def test_malformed_ndjson_returns_error_dict_not_raises(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        # NDJSON with 1 malformed line - parse_bulk_body raises BenchmarkError
+        malformed = b'{"index":{"_id":"1"}}\nnot-json-at-all\n'
+        result = await r(client, {"index": "t", "body": malformed, "bulk-size": 1})
+        self.assertEqual(result["success"], False)
+        self.assertEqual(result["error-count"], 1)
+        self.assertIn("error-description", result)
+        client.bulk.assert_not_called()
+
+
+class DoubleParseRegressionTests(_RunnerCase):
+    """P8: parse_bulk_body was called TWICE per bulk (once for zero-doc guard,
+    once inside client.bulk). Fixed by threading parsed_docs kwarg through."""
+
+    async def test_bulk_index_threads_parsed_docs_to_client(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        client.bulk = mock.AsyncMock(return_value={"took": 5, "errors": False})
+        body = b'{"index":{"_id":"1"}}\n{"a":1}\n'
+        await r(client, {"index": "t", "body": body, "bulk-size": 1})
+        # client.bulk should have received parsed_docs kwarg (avoiding re-parse)
+        client.bulk.assert_awaited_once()
+        call = client.bulk.await_args
+        self.assertIn("parsed_docs", call.kwargs)
+        self.assertEqual(len(call.kwargs["parsed_docs"]), 1)
+
+
+class OrderByRegexRegressionTests(_RunnerCase):
+    """P8: F8's ORDER BY regex was too strict - `\\bORDER\\s+BY\\b` failed to
+    match 'ORDER BYPASS' (which is what triggered the false-positive originally
+    since BY was followed by P not \\W). The fix uses lookahead for whitespace
+    or paren after BY, so 'ORDER BYPASS_COL' is correctly rejected."""
+
+    async def _run_scroll(self, sql):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        client.execute_query = mock.AsyncMock(
+            return_value=mock.MagicMock(result_rows=[]))
+        body = {"sql": sql, "parameters": {}}
+        return await r(client, {"body": body, "pages": 1, "results-per-page": 10})
+
+    async def test_valid_order_by_accepted(self):
+        result = await self._run_scroll(
+            "SELECT id FROM t ORDER BY id LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        self.assertTrue(result["success"])
+
+    async def test_order_by_in_string_literal_rejected(self):
+        # 'ORDER BYPASS' inside a string literal, no real ORDER BY clause
+        with self.assertRaises(exceptions.BenchmarkError) as ctx:
+            await self._run_scroll(
+                "SELECT id FROM t WHERE label = 'ORDER BYPASS' "
+                "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        self.assertIn("ORDER BY", str(ctx.exception))
+
+    async def test_order_by_identifier_variant_rejected(self):
+        # 'ORDER BYPASS_COL' as a bare identifier after t
+        with self.assertRaises(exceptions.BenchmarkError):
+            await self._run_scroll(
+                "SELECT ORDER_BYPASS_COL FROM t LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+
+    async def test_double_dash_inside_string_literal_preserved(self):
+        # 'foo--bar' inside a string literal must NOT be stripped as a line
+        # comment - the string strip has to happen before line-comment strip.
+        result = await self._run_scroll(
+            "SELECT id FROM t WHERE label = 'foo--bar' "
+            "ORDER BY id LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        self.assertTrue(result["success"])
+
+
+class BulkIndexUnexpectedParseErrorTests(_RunnerCase):
+    """P8: broad `except Exception` on parse-body path used to swallow
+    programmer errors. Now: BenchmarkError = sample failure, others re-raise."""
+
+    async def test_unexpected_exception_reraised(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        # Force parse_bulk_body to raise something other than BenchmarkError
+        with mock.patch("osbenchmark.engine.clickhouse.helpers.parse_bulk_body",
+                        side_effect=RuntimeError("dev-time bug")):
+            with self.assertRaises(RuntimeError):
+                await r(client, {"index": "t", "body": b"x", "bulk-size": 1})

--- a/tests/engine/clickhouse/runner_test.py
+++ b/tests/engine/clickhouse/runner_test.py
@@ -53,8 +53,9 @@ class ClickHouseBulkIndexTests(_RunnerCase):
         r = ch_runners.ClickHouseBulkIndex()
         client = _make_client()
         client.bulk.return_value = {"errors": False, "took": 5, "items": [{}, {}]}
-        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 100,
-                                  "column-names": ["a"]})
+        result = await r(client, {"index": "t",
+                                  "body": [{"index": {"_id": "1"}}, {"a": 1}],
+                                  "bulk-size": 100, "column-names": ["a"]})
         self.assertTrue(result["success"])
         self.assertEqual(result["weight"], 100)
         self.assertEqual(result["error-count"], 0)
@@ -65,25 +66,31 @@ class ClickHouseBulkIndexTests(_RunnerCase):
         r = ch_runners.ClickHouseBulkIndex()
         client = _make_client()
         client.bulk.return_value = {"errors": True, "took": 0, "items": []}
-        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 100})
+        result = await r(client, {"index": "t",
+                                  "body": [{"index": {"_id": "1"}}, {"a": 1}],
+                                  "bulk-size": 100})
         self.assertFalse(result["success"])
         self.assertEqual(result["error-count"], 1)
 
     async def test_zero_doc_guard(self):
+        # F9: parsed doc count check - 0-doc bulk raises regardless of bulk-size.
         r = ch_runners.ClickHouseBulkIndex()
         client = _make_client()
-        result = await r(client, {"index": "t", "body": [], "bulk-size": 50})
-        self.assertFalse(result["success"])
-        self.assertEqual(result["error-count"], 1)
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"index": "t", "body": [], "bulk-size": 50})
         client.bulk.assert_not_called()
 
-    async def test_client_reset_on_exception(self):
+    async def test_error_returns_dict_without_client_mutation(self):
+        # F6: on RPC failure the runner returns an error dict but MUST NOT
+        # mutate client._client (race with _ensure_client's lock).
         r = ch_runners.ClickHouseBulkIndex()
         client = _make_client()
         client.bulk.side_effect = RuntimeError("boom")
-        result = await r(client, {"index": "t", "body": [{"a": 1}], "bulk-size": 1})
+        result = await r(client, {"index": "t",
+                                  "body": [{"index": {"_id": "1"}}, {"a": 1}],
+                                  "bulk-size": 1})
         self.assertFalse(result["success"])
-        self.assertIsNone(client._client)
+        self.assertIsNotNone(client._client)
 
     def test_repr(self):
         self.assertEqual(repr(ch_runners.ClickHouseBulkIndex()), "clickhouse-bulk-index")
@@ -109,13 +116,15 @@ class ClickHouseQueryTests(_RunnerCase):
         with self.assertRaises(exceptions.BenchmarkError):
             await r(client, {"body": {}})
 
-    async def test_client_reset_on_exception(self):
+    async def test_error_returns_dict_without_client_mutation(self):
+        # F6: on RPC failure the runner returns an error dict but MUST NOT
+        # mutate client._client (race with _ensure_client's lock).
         r = ch_runners.ClickHouseQuery()
         client = _make_client()
         client.search.side_effect = RuntimeError("boom")
         result = await r(client, {"body": {"sql": "SELECT 1"}})
         self.assertFalse(result["success"])
-        self.assertIsNone(client._client)
+        self.assertIsNotNone(client._client)
 
     def test_repr(self):
         self.assertEqual(repr(ch_runners.ClickHouseQuery()), "clickhouse-query")
@@ -434,7 +443,10 @@ class RegisterRunnersTests(TestCase):
         for _op, _r, kwargs in registrations:
             self.assertTrue(kwargs.get("async_runner"))
 
-    def test_admin_ops_wrapped_in_retry(self):
+    def test_admin_ops_not_wrapped_in_retry(self):
+        # F5: Retry() only catches opensearchpy exceptions, so wrapping
+        # ClickHouse admin runners in it was dead code that hid the real
+        # exception path. Assert we don't reintroduce the wrapper.
         registrations = []
         with mock.patch(
             "osbenchmark.worker_coordinator.runner.register_runner",
@@ -451,7 +463,8 @@ class RegisterRunnersTests(TestCase):
         }
         for op, r, _ in registrations:
             if op in admin_ops:
-                self.assertIsInstance(r, Retry, f"{op} should be wrapped in Retry")
+                self.assertNotIsInstance(r, Retry,
+                                         f"{op} MUST NOT be wrapped in Retry (F5)")
 
     def test_data_plane_ops_not_wrapped(self):
         registrations = []
@@ -521,3 +534,147 @@ class ClickHouseRunnerSqlContractTests(_RunnerCase):
             ctx.on_request_start.assert_called_once()
             ctx.on_request_end.assert_called_once()
             ctx.on_client_request_end.assert_called_once()
+
+
+# -----------------------------------------------------------------
+# Regression tests for review findings (P7)
+# -----------------------------------------------------------------
+
+
+class BulkVectorDataSetErrorPathRegressionTests(_RunnerCase):
+    """F1: on RPC exception, BulkVectorDataSet must return an error DICT so
+    execute_single records success=False. Returning (size, unit) would fabricate
+    throughput on ClickHouse crash."""
+
+    async def test_httpx_connect_error_returns_error_dict(self):
+        # Import lazily so tests don't fail if httpx isn't installed.
+        try:
+            import httpx  # pylint: disable=import-outside-toplevel
+        except ImportError:  # pragma: no cover - httpx is in the ClickHouse extra
+            self.skipTest("httpx not available")
+        r = ch_runners.ClickHouseBulkVectorDataSet()
+        client = _make_client()
+        client.bulk.side_effect = httpx.ConnectError("connection refused")
+        body = [{"index": {"_id": "1"}}, {"id": 1, "vec": [0.1, 0.2]}]
+        result = await r(client, {"index": "t", "size": 1, "body": body})
+        # MUST be a dict (not a tuple) so execute_single sees success=False
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error-count"], 1)
+        self.assertEqual(result["error-type"], "clickhouse")
+        self.assertIn("connection refused", result["error-description"])
+        # And MUST NOT mutate the client (F6-style race prevention)
+        self.assertIsNotNone(client._client)
+
+    async def test_success_path_still_returns_tuple(self):
+        # Success path is unchanged: still returns (size, "docs").
+        r = ch_runners.ClickHouseBulkVectorDataSet()
+        client = _make_client()
+        body = [{"index": {"_id": "1"}}, {"id": 1, "vec": [0.1, 0.2]}]
+        result = await r(client, {"index": "t", "size": 1, "body": body})
+        self.assertEqual(result, (1, "docs"))
+
+
+class ScrollQueryOrderByRegressionTests(_RunnerCase):
+    """F8: ORDER BY detection ignores SQL comments and string literals so
+    `WHERE label = 'ORDER BYPASS'` without an actual ORDER BY still raises."""
+
+    async def test_order_by_in_string_literal_does_not_pass(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        sql = ("SELECT id FROM t WHERE label = 'ORDER BYPASS' "
+               "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {"sql": sql}})
+
+    async def test_order_by_in_line_comment_does_not_pass(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        sql = ("SELECT id FROM t -- ORDER BY id\n"
+               "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {"sql": sql}})
+
+    async def test_order_by_in_block_comment_does_not_pass(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        sql = ("SELECT id FROM t /* ORDER BY id */ "
+               "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"body": {"sql": sql}})
+
+    async def test_real_order_by_passes(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([(1,)], ["id"])
+        sql = ("SELECT id FROM t WHERE label = 'foo' ORDER BY id "
+               "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        result = await r(client, {"body": {"sql": sql}, "pages": 1, "results-per-page": 1})
+        self.assertTrue(result["success"])
+
+    async def test_lowercase_order_by_passes(self):
+        r = ch_runners.ClickHouseScrollQuery()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([(1,)], ["id"])
+        sql = ("SELECT id FROM t order by id "
+               "LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+        result = await r(client, {"body": {"sql": sql}, "pages": 1, "results-per-page": 1})
+        self.assertTrue(result["success"])
+
+
+class VectorEfSearchZeroRegressionTests(_RunnerCase):
+    """F14: hnsw_ef_search=0 is a legitimate value (disables candidate expansion)
+    and must reach ClickHouse instead of being dropped by a truthiness check."""
+
+    async def test_zero_ef_search_reaches_settings(self):
+        r = ch_runners.ClickHouseVectorSearch()
+        client = _make_client()
+        client.execute_query.return_value = _query_result([], [])
+        await r(client, {"body": {"sql": "SELECT 1"}, "hnsw_ef_search": 0, "k": 10})
+        kwargs = client.execute_query.await_args.kwargs
+        self.assertIn("hnsw_candidate_list_size_for_search", kwargs["settings"])
+        self.assertEqual(kwargs["settings"]["hnsw_candidate_list_size_for_search"], 0)
+
+
+class DropTableCommaSplitRegressionTests(_RunnerCase):
+    """F17: comma-separated names in indices must be split so exists() and
+    delete() are called per-name, not with the literal 'a,b'."""
+
+    async def test_comma_separated_names_split(self):
+        r = ch_runners.ClickHouseDropTable()
+        client = _make_client()
+        client.indices.exists = mock.AsyncMock(return_value=True)
+        result = await r(client, {"indices": ["a,b"], "only-if-exists": True})
+        # exists() called twice (once per split name), delete() called twice
+        self.assertEqual(client.indices.exists.await_count, 2)
+        self.assertEqual(client.indices.delete.await_count, 2)
+        self.assertEqual(result["weight"], 2)
+        # Verify the split names were passed cleanly (stripped of whitespace)
+        called_with = [c.kwargs.get("index") for c in client.indices.delete.await_args_list]
+        self.assertEqual(sorted(called_with), ["a", "b"])
+
+    async def test_comma_with_whitespace_handled(self):
+        r = ch_runners.ClickHouseDropTable()
+        client = _make_client()
+        await r(client, {"indices": ["a , b , c"]})
+        self.assertEqual(client.indices.delete.await_count, 3)
+
+
+class BulkIndexZeroDocRegressionTests(_RunnerCase):
+    """F9: zero-doc guard operates on parsed doc count, not the bulk-size param.
+    Missing bulk-size (defaults to 0) previously bypassed the guard entirely."""
+
+    async def test_missing_bulk_size_with_empty_body_still_raises(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        # No bulk-size param at all - previously bypassed the guard.
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"index": "t", "body": []})
+        client.bulk.assert_not_called()
+
+    async def test_missing_bulk_size_with_bytes_body_of_zero_docs_raises(self):
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        with self.assertRaises(exceptions.BenchmarkError):
+            await r(client, {"index": "t", "body": b""})
+        client.bulk.assert_not_called()

--- a/tests/engine/clickhouse/runner_test.py
+++ b/tests/engine/clickhouse/runner_test.py
@@ -742,6 +742,27 @@ class DoubleParseRegressionTests(_RunnerCase):
         self.assertIn("parsed_docs", call.kwargs)
         self.assertEqual(len(call.kwargs["parsed_docs"]), 1)
 
+    async def test_parse_bulk_body_invoked_exactly_once(self):
+        # The complementary end-to-end assertion: patch parse_bulk_body itself
+        # so we can COUNT invocations. The runner MUST parse once and the
+        # client MUST NOT reparse when parsed_docs is passed. Without this
+        # test, dropping parsed_docs from the client.bulk() signature would
+        # silently double the parse cost on every bulk op with no test failure.
+        from osbenchmark.engine.clickhouse import helpers as ch_helpers
+        original = ch_helpers.parse_bulk_body
+        r = ch_runners.ClickHouseBulkIndex()
+        client = _make_client()
+        client.bulk = mock.AsyncMock(return_value={"took": 5, "errors": False})
+        body = b'{"index":{"_id":"1"}}\n{"a":1}\n'
+        with mock.patch(
+            "osbenchmark.engine.clickhouse.helpers.parse_bulk_body",
+            wraps=original,
+        ) as spy:
+            await r(client, {"index": "t", "body": body, "bulk-size": 1})
+        self.assertEqual(spy.call_count, 1,
+                         f"parse_bulk_body must be called exactly once per "
+                         f"bulk op; got {spy.call_count}")
+
 
 class OrderByRegexRegressionTests(_RunnerCase):
     """P8: F8's ORDER BY regex was too strict - `\\bORDER\\s+BY\\b` failed to
@@ -771,16 +792,22 @@ class OrderByRegexRegressionTests(_RunnerCase):
         self.assertIn("ORDER BY", str(ctx.exception))
 
     async def test_order_by_identifier_variant_rejected(self):
-        # 'ORDER BYPASS_COL' as a bare identifier after t
+        # 'ORDER BYPASS_COL' - a space between ORDER and BYPASS is what the
+        # new regex must reject; using an underscore ('ORDER_BYPASS_COL') would
+        # have been rejected by the OLD regex too and wouldn't exercise the fix.
         with self.assertRaises(exceptions.BenchmarkError):
             await self._run_scroll(
-                "SELECT ORDER_BYPASS_COL FROM t LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
+                "SELECT id FROM t ORDER BYPASS_COL LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
 
     async def test_double_dash_inside_string_literal_preserved(self):
-        # 'foo--bar' inside a string literal must NOT be stripped as a line
-        # comment - the string strip has to happen before line-comment strip.
+        # 'foo-- bar' inside a string literal must NOT be stripped as a line
+        # comment. The whitespace AFTER `--` is required for the SQL comment
+        # regex to match, so this literal would (incorrectly) look like a
+        # comment if the string-literal strip did not run first. Do NOT use
+        # 'foo--bar' here: without a following whitespace char the regex would
+        # never match, so the test would silently pass under both orderings.
         result = await self._run_scroll(
-            "SELECT id FROM t WHERE label = 'foo--bar' "
+            "SELECT id FROM t WHERE label = 'foo-- bar' "
             "ORDER BY id LIMIT {limit:UInt32} OFFSET {offset:UInt32}")
         self.assertTrue(result["success"])
 


### PR DESCRIPTION
Adds `osbenchmark/engine/clickhouse/` implementing the multi-engine module interface (`create_client_factory`, `create_async_client`, `register_runners`, `wait_for_client`, `on_execute_error`) — same shape as the existing Vespa and Milvus engines.

Users can now run `opensearch-benchmark run --database-type=clickhouse --target-hosts=host:8123 ...` against a ClickHouse cluster. Workloads must ship pre-translated SQL bodies (`{"sql": "SELECT ..."}`) via a ClickHouse-native param source — same "must contain yql" refusal pattern the Vespa runner uses. No DSL→SQL translation in OSB.

## Contents

- `osbenchmark/engine/clickhouse/__init__.py` — 5-function engine interface, lazy-registered via `_ensure_builtin_engines()` with try/except so users without `[clickhouse]` extra installed don't see a startup crash.
- `osbenchmark/engine/clickhouse/client.py` — `ClickHouseDatabaseClient(RequestContextHolder)` wrapping `clickhouse-connect`'s async client. Namespace proxies (`self.indices = self`, `self.cluster = self`, etc.) so runners resolve `client.indices.create(...)` to methods on this class.
- `osbenchmark/engine/clickhouse/helpers.py` — pure helpers: SQL identifier quoting, bulk-body parsing, health polling, etc.
- `osbenchmark/engine/clickhouse/runners.py` — 14 runner classes covering Bulk, Search, VectorSearch, CreateTable, DropTable, OptimizeTable, SystemParts, ClusterHealth, NoOp for OS-specific ops. Admin ops wrapped in `Retry(...)` to match OS default semantics; data-plane ops are not (retrying a bulk would double-insert rows).
- `setup.py` — adds `"clickhouse": ["clickhouse-connect>=0.9.2,<1.0"]` extra.

## Tests

- 155 unit tests under `tests/engine/clickhouse/` (41 helpers / 63 client / 51 runners). Pytest green.
- `pylint osbenchmark/engine/clickhouse/` — 10.00/10.
- Full test suite: 1,945 passed, 5 skipped, 0 failed. No regressions.

## Benchmark runs

Verified against ClickHouse 26.6.1. Three ClickHouse-native workloads on a companion PR to opensearch-benchmark-workloads:

| Workload | Queries | Wall time | Errors |
|---|---|---|---|
| clickbench-clickhouse | 43 (canonical ClickBench SQL) | 42 s | 0 |
| http-logs-clickhouse | 15 (aggregations, filters) | 24 s | 0 |
| textbench-clickhouse | 10 (substring, no BM25) | 9 s | 0 |

Reviewer setup (from any host with the branch checked out and `pip install -e '.[clickhouse]'`):

```bash
opensearch-benchmark run \
  --workload-path=<path>/opensearch-benchmark-workloads/clickbench \
  --test-procedure=clickbench-clickhouse \
  --pipeline=benchmark-only \
  --test-mode \
  --target-hosts=<clickhouse-host>:8123 \
  --database-type=clickhouse \
  --client-options=verify_certs:false,use_ssl:false \
  --workload-params='{"index_body":"clickhouse/index.json"}' \
  --kill-running-processes
```

```bash
opensearch-benchmark run \
  --workload-path=<path>/opensearch-benchmark-workloads/http_logs \
  --test-procedure=http-logs-clickhouse \
  --pipeline=benchmark-only \
  --test-mode \
  --target-hosts=<clickhouse-host>:8123 \
  --database-type=clickhouse \
  --client-options=verify_certs:false,use_ssl:false \
  --workload-params='{"index_body":"clickhouse/index.json","clickhouse_mode":true}' \
  --kill-running-processes
```

```bash
opensearch-benchmark run \
  --workload-path=<path>/opensearch-benchmark-workloads/textbench \
  --test-procedure=textbench-clickhouse \
  --pipeline=benchmark-only \
  --test-mode \
  --target-hosts=<clickhouse-host>:8123 \
  --database-type=clickhouse \
  --client-options=verify_certs:false,use_ssl:false \
  --workload-params='{"index_body":"clickhouse/index.json"}' \
  --include-tasks=delete-index,create-index,check-cluster-health,q01-textbench,q02-textbench,q03-textbench \
  --kill-running-processes
```

The textbench run uses `--include-tasks` to skip the corpus-required index-append step (the workload's corpus definition has no CDN base-url and expects local files).

## Not in this PR

- CH-native workloads (separate PR on opensearch-benchmark-workloads).
- Vector search HNSW tuning UX beyond a single default.
- ReplacingMergeTree-based upsert path for `update`/`delete` bulk actions (v1 rejects them at parse time).

## Test plan

- [x] `pytest tests/engine/clickhouse/`
- [x] `pylint osbenchmark/engine/clickhouse/`
- [x] Full suite: `pytest tests/`
- [x] Runs against ClickHouse 26.6.1 with 3 workloads
- [ ] Reviewer run against their own ClickHouse setup
