### PR TITLE
Add per-query radial search threshold support

### DIFF
--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -27,6 +27,10 @@ class Context(Enum):
     RADIAL_NEIGHBORS = 4
     PARENTS = 6
     ATTRIBUTES = 7
+    FAISS_MAX_DISTANCE = 8
+    FAISS_MIN_SCORE = 9
+    LUCENE_MAX_DISTANCE = 10
+    LUCENE_MIN_SCORE = 11
 
 
 class DataSet(ABC):
@@ -152,6 +156,18 @@ class HDF5DataSet(DataSet):
 
         if context == Context.ATTRIBUTES:
             return "attributes"
+
+        if context == Context.FAISS_MAX_DISTANCE:
+            return "faiss_max_distance"
+
+        if context == Context.FAISS_MIN_SCORE:
+            return "faiss_min_score"
+
+        if context == Context.LUCENE_MAX_DISTANCE:
+            return "lucene_max_distance"
+
+        if context == Context.LUCENE_MIN_SCORE:
+            return "lucene_min_score"
 
         raise Exception("Unsupported context")
 

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1164,11 +1164,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.space_type = params.get(self.PARAMS_NAME_SPACE_TYPE, "l2")
 
         if self.radial_search_type:
-            index_body = params.get("target_index_body", "")
-            if "lucene" in index_body.lower():
-                self.radial_engine = "lucene"
-            else:
-                self.radial_engine = "faiss"
+            self.radial_engine = params.get("radial_engine", "faiss")
 
 
         if self.PARAMS_NAME_FILTER in params:

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1124,6 +1124,18 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self._validate_neighbors_data_set(self.neighbors_data_set_path, self.neighbors_data_set_corpus)
         self.neighbors_data_set = None
         self.radial_search_type = params.get(self.PARAMS_NAME_RADIAL_SEARCH_TYPE)
+        if self.PARAMS_NAME_RADIAL_SEARCH_TYPE in params:
+            self.radial_search_type = parse_string_parameter(self.PARAMS_NAME_RADIAL_SEARCH_TYPE, params)
+            if self.radial_search_type not in (self.PARAMS_NAME_MAX_DISTANCE, self.PARAMS_NAME_MIN_SCORE):
+                raise exceptions.InvalidSyntax(
+                    "'radial_search_type' must be either 'max_distance' or 'min_score'.")
+            if self.k is None:
+                raise exceptions.InvalidSyntax(
+                    "'k' must be provided when using 'radial_search_type'.")
+            if (self.PARAMS_NAME_MAX_DISTANCE in params or self.PARAMS_NAME_MIN_SCORE in params
+                    or self.PARAMS_NAME_MAX_DISTANCE in query_params or self.PARAMS_NAME_MIN_SCORE in query_params):
+                raise exceptions.InvalidSyntax(
+                    "'radial_search_type' cannot be combined with 'max_distance' or 'min_score'.")
         self.threshold_data_set = None
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1102,6 +1102,14 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
     PARAMS_NAME_SPACE_TYPE = "space_type"
     PARAMS_NAME_MAX_DISTANCE = "max_distance"
     PARAMS_NAME_MIN_SCORE = "min_score"
+    PARAMS_NAME_RADIAL_SEARCH_TYPE = "radial_search_type"
+
+    RADIAL_THRESHOLD_CONTEXTS = {
+        ("faiss", "max_distance"): Context.FAISS_MAX_DISTANCE,
+        ("faiss", "min_score"): Context.FAISS_MIN_SCORE,
+        ("lucene", "max_distance"): Context.LUCENE_MAX_DISTANCE,
+        ("lucene", "min_score"): Context.LUCENE_MIN_SCORE,
+    }
 
     def __init__(self, workloads, params, query_params, **kwargs):
         super().__init__(workloads, params, Context.QUERY, **kwargs)
@@ -1115,11 +1123,14 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.neighbors_data_set_corpus = params.get(self.PARAMS_NAME_NEIGHBORS_DATA_SET_CORPUS)
         self._validate_neighbors_data_set(self.neighbors_data_set_path, self.neighbors_data_set_corpus)
         self.neighbors_data_set = None
+        self.radial_search_type = params.get(self.PARAMS_NAME_RADIAL_SEARCH_TYPE)
+        self.threshold_data_set = None
         operation_type = parse_string_parameter(self.PARAMS_NAME_OPERATION_TYPE, params,
                                                 self.PARAMS_VALUE_VECTOR_SEARCH)
         self.oversample_factor = params.get(self.PARAMS_NAME_OVERSAMPLE_FACTOR)
         has_radial = (self.PARAMS_NAME_MAX_DISTANCE in params or self.PARAMS_NAME_MIN_SCORE in params
-                      or self.PARAMS_NAME_MAX_DISTANCE in query_params or self.PARAMS_NAME_MIN_SCORE in query_params)
+                      or self.PARAMS_NAME_MAX_DISTANCE in query_params or self.PARAMS_NAME_MIN_SCORE in query_params
+                      or self.radial_search_type is not None)
         if self.oversample_factor and has_radial:
             raise exceptions.InvalidSyntax(
                 "'oversample_factor' cannot be used with 'max_distance' or 'min_score'. "
@@ -1129,7 +1140,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             self.PARAMS_NAME_OPERATION_TYPE: operation_type,
             self.PARAMS_NAME_ID_FIELD_NAME: params.get(self.PARAMS_NAME_ID_FIELD_NAME),
         })
-        if self.k is not None:
+        if self.k is not None and self.radial_search_type is None:
             self.query_params[self.PARAMS_NAME_K] = self.k
         if self.PARAMS_NAME_MAX_DISTANCE in params:
             self.query_params[self.PARAMS_NAME_MAX_DISTANCE] = params[self.PARAMS_NAME_MAX_DISTANCE]
@@ -1139,6 +1150,13 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
         self.space_type = params.get(self.PARAMS_NAME_SPACE_TYPE, "l2")
+
+        if self.radial_search_type:
+            index_body = params.get("target_index_body", "")
+            if "lucene" in index_body.lower():
+                self.radial_engine = "lucene"
+            else:
+                self.radial_engine = "faiss"
 
 
         if self.PARAMS_NAME_FILTER in params:
@@ -1200,7 +1218,9 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         if not self.neighbors_data_set_path:
             self.neighbors_data_set_path = self.data_set_path
         # add neighbor instance to partition
-        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params or self.PARAMS_NAME_MIN_SCORE in self.query_params:
+        if self.radial_search_type:
+            neighbors_context = Context.NEIGHBORS
+        elif self.PARAMS_NAME_MAX_DISTANCE in self.query_params or self.PARAMS_NAME_MIN_SCORE in self.query_params:
             neighbors_context = Context.RADIAL_NEIGHBORS
         else:
             neighbors_context = Context.NEIGHBORS
@@ -1208,6 +1228,14 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         partition.neighbors_data_set = get_data_set(
             self.neighbors_data_set_format, self.neighbors_data_set_path, neighbors_context)
         partition.neighbors_data_set.seek(partition.offset)
+
+        if self.radial_search_type:
+            threshold_context = self.RADIAL_THRESHOLD_CONTEXTS[
+                (self.radial_engine, self.radial_search_type)]
+            partition.threshold_data_set = get_data_set(
+                self.neighbors_data_set_format, self.neighbors_data_set_path, threshold_context)
+            partition.threshold_data_set.seek(partition.offset)
+
         return partition
 
     def params(self):
@@ -1219,16 +1247,25 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         if is_dataset_exhausted and self.current_rep < self.repetitions:
             self.data_set.seek(self.offset)
             self.neighbors_data_set.seek(self.offset)
+            if self.threshold_data_set:
+                self.threshold_data_set.seek(self.offset)
             self.current = self.offset
             self.current_rep += 1
         elif is_dataset_exhausted:
             raise StopIteration
         vector = self.data_set.read(1)[0]
         neighbor = self.neighbors_data_set.read(1)[0]
-        if self.k is not None:
+
+        if self.radial_search_type:
+            true_neighbors = list(map(str, neighbor[:self.k].astype(int)))
+            threshold_row = self.threshold_data_set.read(1)[0]
+            threshold_value = float(threshold_row[self.k - 1])
+            self.query_params[self.radial_search_type] = threshold_value
+        elif self.k is not None:
             true_neighbors = list(map(str, neighbor[:self.k].astype(int)))
         else:
             true_neighbors = list(map(str, neighbor[neighbor >= 0].astype(int)))
+
         self.query_params.update({
             "neighbors": true_neighbors,
         })
@@ -1239,11 +1276,13 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         return self.query_params
 
     def _add_search_threshold(self, query):
-        if self.k is not None:
+        if self.radial_search_type:
+            query[self.radial_search_type] = self.query_params[self.radial_search_type]
+        elif self.k is not None:
             query["k"] = self.k
-        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params:
+        if self.PARAMS_NAME_MAX_DISTANCE in self.query_params and not self.radial_search_type:
             query[self.PARAMS_NAME_MAX_DISTANCE] = self.query_params[self.PARAMS_NAME_MAX_DISTANCE]
-        if self.PARAMS_NAME_MIN_SCORE in self.query_params:
+        if self.PARAMS_NAME_MIN_SCORE in self.query_params and not self.radial_search_type:
             query[self.PARAMS_NAME_MIN_SCORE] = self.query_params[self.PARAMS_NAME_MIN_SCORE]
 
     def _build_vector_search_query_body(self, vector, efficient_filter=None, filter_type=None, filter_body=None) -> dict:

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3484,6 +3484,134 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
         self.assertNotIn("-1.0", neighbors)
         self.assertEqual(neighbors, ["0", "1", "2", "3", "4"])
 
+    def test_radial_search_type_max_distance_faiss(self):
+        k = 5
+        num_vectors = 10
+        data_set_path = create_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+        threshold_data = np.arange(num_vectors * self.DEFAULT_DIMENSION, dtype=np.float32).reshape(
+            num_vectors, self.DEFAULT_DIMENSION)
+        with h5py.File(data_set_path, 'a') as hf:
+            hf.create_dataset("faiss_max_distance", data=threshold_data)
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k,
+            "radial_search_type": "max_distance",
+            "target_index_body": "indices/faiss-index.json",
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertNotIn("k", query)
+        self.assertIn("max_distance", query)
+        self.assertEqual(query["max_distance"], float(threshold_data[0][k - 1]))
+        self.assertEqual(body["size"], k)
+        neighbors = params.get("neighbors")
+        self.assertEqual(len(neighbors), k)
+
+    def test_radial_search_type_min_score_lucene(self):
+        k = 3
+        num_vectors = 10
+        data_set_path = create_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+        threshold_data = np.arange(num_vectors * self.DEFAULT_DIMENSION, dtype=np.float32).reshape(
+            num_vectors, self.DEFAULT_DIMENSION)
+        with h5py.File(data_set_path, 'a') as hf:
+            hf.create_dataset("lucene_min_score", data=threshold_data)
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k,
+            "radial_search_type": "min_score",
+            "target_index_body": "indices/lucene-index.json",
+        }
+        query_param_source = VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+        query_param_source_partition = query_param_source.partition(0, 1)
+        params = query_param_source_partition.params()
+
+        body = params.get("body")
+        query = body["query"]["knn"][self.DEFAULT_FIELD_NAME]
+        self.assertNotIn("k", query)
+        self.assertNotIn("max_distance", query)
+        self.assertIn("min_score", query)
+        self.assertEqual(query["min_score"], float(threshold_data[0][k - 1]))
+        self.assertEqual(body["size"], k)
+        neighbors = params.get("neighbors")
+        self.assertEqual(len(neighbors), k)
+
+    def test_radial_search_type_oversample_raises_error(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+
+        test_param_source_params = {
+            "field": self.DEFAULT_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": 100,
+            "radial_search_type": "max_distance",
+            "target_index_body": "indices/faiss-index.json",
+            "oversample_factor": 5.0,
+        }
+        with self.assertRaises(exceptions.InvalidSyntax):
+            VectorSearchPartitionParamSource(
+                workload.Workload(name="unit-test"),
+                test_param_source_params, {
+                    "index": self.DEFAULT_INDEX_NAME,
+                    "request-params": {},
+                }
+            )
+
     def _check_params(
             self,
             actual_params: dict,

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3513,7 +3513,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": k,
             "radial_search_type": "max_distance",
-            "target_index_body": "indices/faiss-index.json",
+            "radial_engine": "faiss",
         }
         query_param_source = VectorSearchPartitionParamSource(
             workload.Workload(name="unit-test"),
@@ -3563,7 +3563,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": k,
             "radial_search_type": "min_score",
-            "target_index_body": "indices/lucene-index.json",
+            "radial_engine": "lucene",
         }
         query_param_source = VectorSearchPartitionParamSource(
             workload.Workload(name="unit-test"),
@@ -3600,7 +3600,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": 100,
             "radial_search_type": "max_distance",
-            "target_index_body": "indices/faiss-index.json",
+            "radial_engine": "faiss",
             "oversample_factor": 5.0,
         }
         with self.assertRaises(exceptions.InvalidSyntax):


### PR DESCRIPTION
### Description
- Adds `radial_search_type` parameter that enables per-query radial thresholds read from an enriched HDF5 dataset
- Each query gets its own `max_distance` or `min_score` value from a pre-computed threshold dataset, instead of using a fixed value for all queries
- Uses explicit `radial_engine` param ("faiss" or "lucene") to select the correct threshold dataset
- Coexists with existing fixed-threshold radial search (no breaking changes)

### Testing
- [x] All 35 existing vector search unit tests pass
- [x] 3 new unit tests pass
- [x] Faiss HNSW benchmark: recall=0.96, p50=9.6ms (k=100, cohere-10M)
- [x] Lucene HNSW benchmark: recall=0.85, p50=18ms (k=100, cohere-10M)
- [x] Faiss varying k: k=200 (0.95), k=500 (0.92), k=1000 (0.88)
- [x] Manual 10K-query validation — Faiss: 0.9599 (matches OSB 0.96)
- [x] Manual 10K-query validation — Lucene: 0.8447 (matches OSB 0.85)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
