### PR TITLE
Use release-approval environment in 1.x release workflow (fixes 1.19.0 publish)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Publish Release to GitHub
+name: Release Workflow
 
 on:
   push:
@@ -6,26 +6,15 @@ on:
       - "*"
 
 jobs:
-  publish-release:
+  release-to-pypi:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
-      issues: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - id: get_approvers
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@fa642940caf8412403569b28b2db4a1df08a83a3 # v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_approvers.outputs.approvers }}
-          minimum-approvals: 1
-          issue-title: 'Release opensearch-benchmark'
-          issue-body: "Please approve or deny the release of opensearch-benchmark. **Tag**: ${{ github.ref_name }}  **Commit**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
 
       - name: Set up Python 3
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -33,16 +22,13 @@ jobs:
           python-version: '3.x'
 
       - name: Build project for distribution
-        run: |
-          make build
-          tar zcvf artifacts.tar.gz dist
+        run: make build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
-      - name: Publish release
+      - name: Release on Github
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          draft: true
+          draft: false
           generate_release_notes: true
-          files: artifacts.tar.gz


### PR DESCRIPTION
### Description

Backports #1067 to `1.x`. Fixes the 1.19.0 release, which **failed at the PyPI publish step** with:

```
Trusted publishing exchange failure:
* `invalid-publisher`: valid token, but no corresponding publisher (Publisher with matching claims was not found)
...
* `environment`: `MISSING`
```

**Root cause:** PyPI trusted publishing for `opensearch-benchmark` requires the release job to run in the `release-approval` GitHub environment. `main`'s workflow sets `environment: release-approval` (added in #1067), but the `1.x` workflow still used the old `trstringer/manual-approval` issue-based gate and set **no** environment — so the OIDC token carried `environment: MISSING` and PyPI rejected it. The 2.4.0 release (off `main`) published cleanly for exactly this reason.

This PR replaces the `1.x` `publish-release.yml` with the environment-based version from `main` (already SHA-pinned). The `release-approval` environment provides the approval gate, replacing the manual-approval issue.

### Issues Resolved

Unblocks the 1.19.0 release. Backport of #1067 to `1.x`.

### Testing

- `make build` target exists on `1.x` (`Makefile:58`).
- YAML validated.
- After merge, re-tagging `1.19.0` will re-trigger the workflow, which will pause for approval in the `release-approval` environment and then publish to PyPI.

### Check List
- [x] Workflow-only change.
- [x] Commit is signed off (DCO).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
