### PR TITLE
Fix aggregate crashing on operations that report null metrics

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -213,7 +213,6 @@ class Aggregator:
         # Get iterations for each test run
         iterations_per_run = [self.accumulated_iterations[test_id][task_name]
                                     for test_id in self.test_runs.keys()]
-        total_iterations = sum(iterations_per_run)
 
         for metric, values in task_metrics.items():
             if isinstance(values[0], dict):
@@ -222,23 +221,44 @@ class Aggregator:
                     if metric_field == 'unit':
                         weighted_metrics[metric][metric_field] = values[0][metric_field]
                     elif metric_field == 'min':
-                        weighted_metrics[metric]['overall_min'] = min(value.get(metric_field, 0) for value in values)
+                        item_values = [value.get(metric_field) for value in values]
+                        weighted_metrics[metric]['overall_min'] = min(
+                            (value for value in item_values if value is not None), default=None)
                     elif metric_field == 'max':
-                        weighted_metrics[metric]['overall_max'] = max(value.get(metric_field, 0) for value in values)
+                        item_values = [value.get(metric_field) for value in values]
+                        weighted_metrics[metric]['overall_max'] = max(
+                            (value for value in item_values if value is not None), default=None)
                     else:
                         # for items like median or containing percentile values
-                        item_values = [value.get(metric_field, 0) for value in values]
-                        weighted_sum = sum(value * iterations for value, iterations in zip(item_values, iterations_per_run))
-                        weighted_metrics[metric][metric_field] = weighted_sum / total_iterations
+                        item_values = [value.get(metric_field) for value in values]
+                        weighted_metrics[metric][metric_field] = self.weighted_mean(item_values, iterations_per_run)
             else:
-                weighted_sum = sum(value * iterations for value, iterations in zip(values, iterations_per_run))
-                weighted_metrics[metric] = weighted_sum / total_iterations
+                weighted_metrics[metric] = self.weighted_mean(values, iterations_per_run)
 
         return weighted_metrics
+
+    @staticmethod
+    def weighted_mean(values: List[Any], iterations_per_run: List[int]) -> Any:
+        """
+        Weights each test run's value by that run's iteration count.
+        Operations that produced no valid samples report their metrics as None; those are left out
+        of both the sum and the divisor, and the result is None when no run contributed a value,
+        so that "not measured" stays distinct from a measured zero
+        """
+        contributions = [(value, iterations) for value, iterations in zip(values, iterations_per_run)
+                         if value is not None]
+        total_iterations = sum(iterations for _, iterations in contributions)
+        if not total_iterations:
+            return None
+        return sum(value * iterations for value, iterations in contributions) / total_iterations
 
     def calculate_rsd(self, values: List[Union[int, float]], metric_name: str) -> Union[float, str]:
         if not values:
             raise ValueError(f"Cannot calculate RSD for metric '{metric_name}': empty list of values")
+        # operations that produced no valid samples report None, which cannot contribute to a deviation
+        values = [value for value in values if value is not None]
+        if not values:
+            return "NA"  # no test run measured this metric
         if len(values) == 1:
             return "NA"  # RSD is not applicable for a single value
         mean = statistics.mean(values)

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -136,6 +136,47 @@ def test_update_config_object_reads_attributes_that_test_runs_actually_have(aggr
     aggregator.config.add.assert_any_call(config.Scope.applicationOverride, "builder",
                                           "cluster_config.params", {"heap_size": "6g"})
 
+def test_calculate_weighted_average_with_null_metric_fields(aggregator):
+    # An operation that produced no valid samples reports null metric fields, e.g. `optimize`
+    # in the geonames workload, which reports error_rate 1.0 and a fully null throughput.
+    task_metrics = {
+        "throughput": [
+            {"min": None, "mean": None, "median": None, "max": None, "unit": "ops/s"},
+            {"min": None, "mean": None, "median": None, "max": None, "unit": "ops/s"}
+        ]
+    }
+    aggregator.accumulated_iterations = {"test1": {"op1": 1}, "test2": {"op1": 1}}
+    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+
+    result = aggregator.calculate_weighted_average(task_metrics, "op1")
+
+    # null is carried through rather than replaced by 0, which would read as a real
+    # measurement of zero throughput
+    assert result["throughput"]["overall_min"] is None
+    assert result["throughput"]["overall_max"] is None
+    assert result["throughput"]["mean"] is None
+    assert result["throughput"]["median"] is None
+    assert result["throughput"]["unit"] == "ops/s"
+
+def test_calculate_weighted_average_with_partially_null_metric_fields(aggregator):
+    # A metric that has samples in one test run but not another: the valid values are
+    # still aggregated, weighted only by the runs that contributed them.
+    task_metrics = {
+        "throughput": [
+            {"min": 10, "mean": 20, "median": 20, "max": 30, "unit": "ops/s"},
+            {"min": None, "mean": None, "median": None, "max": None, "unit": "ops/s"}
+        ]
+    }
+    aggregator.accumulated_iterations = {"test1": {"op1": 2}, "test2": {"op1": 3}}
+    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+
+    result = aggregator.calculate_weighted_average(task_metrics, "op1")
+
+    assert result["throughput"]["overall_min"] == 10
+    assert result["throughput"]["overall_max"] == 30
+    assert result["throughput"]["mean"] == 20
+    assert result["throughput"]["unit"] == "ops/s"
+
 def test_calculate_rsd(aggregator):
     values = [1, 2, 3, 4, 5]
     rsd = aggregator.calculate_rsd(values, "test_metric")


### PR DESCRIPTION
### Description

`calculate_weighted_average` reduced `min`/`max` with `value.get(metric_field, 0)`. That default only applies when the key is *absent*, so a key present with value `None` reached `min()`/`max()` and raised `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'`. The percentile/median branch just below had the same flaw in a different shape — `value * iterations` on `None`.

`calculate_rsd` is a second, independent site, reached from `build_aggregated_results_dict` with the per-run mean values (`TypeError: can't convert type 'NoneType' to numerator/denominator`). Fixing only the first one moves the crash rather than removing it — that is how I found the second, by running against real data after unit tests for the first were already green.

The change:

- extracts the weighted mean into a `weighted_mean` helper. The divisor now depends on which runs contributed a value, so it can no longer be one total summed up front, and the dict and scalar branches were computing it two different ways;
- leaves nulls out of both the weighted sum and its divisor, so a run that measured nothing does not drag the mean toward zero;
- propagates `None` when no run contributed a value, rather than substituting `0`. `0` would read as "throughput was zero", which is a different claim from "not measured". This matches how `aggregate_json_by_key` in the same file already treats nulls;
- returns `NA` from `calculate_rsd` when no values remain, as it already does for the single-value case.

### Issues Resolved

Resolves #1093

### Testing
- [x] New functionality includes testing

- Two new tests in `tests/aggregator_test.py`: all-null metric fields, and partially null — a metric with samples in one run but not another, where the valid values must still aggregate, weighted only by the runs that contributed them.
- Both verified red without the fix, by restoring `main`'s `aggregator.py` under the new tests rather than by inspection.
- Full suite: `1424 passed, 5 skipped` (baseline on `main` is 1422). `pylint` clean.
- End-to-end through the real CLI, on test-run files written by OSB's own `TestRun.as_dict()`: `aggregate` goes from `❌ FAILURE` to `✅ SUCCESS`, and the output is correct rather than merely non-crashing — a healthy operation aggregates to `overall_min 40000.0, mean 42250.0, median 42150.0, overall_max 44500.0` with `mean_rsd 0.8368`, while the null operation reports `null` throughput and `mean_rsd "NA"`.

The `calculate_rsd` site has no dedicated unit test here; it is covered by the end-to-end run, where it was the crash that surfaced once the first site was fixed. I can add a direct one if you'd prefer it in the suite.

### Notes

Found while using Apache solr-orbit, a Python port of OSB whose `aggregator.py` is byte-identical to this one apart from the import module name, to run a multi-configuration benchmark campaign. The same fix is proposed there as apache/solr-orbit#58. Reported here because the defect is upstream, not port-specific.
