### PR TITLE
Fix aggregate reading a TestRun attribute that does not exist

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -166,7 +166,7 @@ class Aggregator:
         self.config.add(config.Scope.applicationOverride, "test_run", "pipeline", test_run.pipeline)
         self.config.add(config.Scope.applicationOverride, "workload", "params", test_run.workload_params)
         self.config.add(config.Scope.applicationOverride, "builder",
-                        "cluster_config.params", test_run.cluster_config_instance_params)
+                        "cluster_config.params", test_run.cluster_config_params)
         self.config.add(config.Scope.applicationOverride, "builder", "plugin.params", test_run.plugin_params)
         self.config.add(config.Scope.applicationOverride, "workload", "latency.percentiles", test_run.latency_percentiles)
         self.config.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", test_run.throughput_percentiles)

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 import pytest
 from osbenchmark import config
+from osbenchmark import metrics
 from osbenchmark.aggregator import Aggregator, AggregatedResults
 
 @pytest.fixture
@@ -119,6 +120,21 @@ def test_calculate_weighted_average(aggregator):
     assert result["throughput"] == 160  # (100*2 + 200*3) / (2+3)
     assert result["latency"]["avg"] == 16  # (10*2 + 20*3) / (2+3)
     assert result["latency"]["unit"] == "ms"
+
+def test_update_config_object_reads_attributes_that_test_runs_actually_have(aggregator):
+    # a real TestRun, not a Mock: a Mock creates whatever attribute is asked of it, so it cannot
+    # tell us whether update_config_object reads attributes that a test run really carries
+    test_run = metrics.TestRun(
+        benchmark_version="1.0.0", benchmark_revision="abc123", environment_name="unit-test",
+        test_run_id="test1", test_run_timestamp="20250101T000000Z", pipeline="benchmark-only",
+        user_tags={}, workload="workload1", workload_params={}, test_procedure="test_proc1",
+        cluster_config=["external"], cluster_config_params={"heap_size": "6g"}, plugin_params={},
+        meta_data={})
+
+    aggregator.update_config_object(test_run)
+
+    aggregator.config.add.assert_any_call(config.Scope.applicationOverride, "builder",
+                                          "cluster_config.params", {"heap_size": "6g"})
 
 def test_calculate_rsd(aggregator):
     values = [1, 2, 3, 4, 5]


### PR DESCRIPTION
### Description

`update_config_object` read `test_run.cluster_config_instance_params`, which no test run has, so `aggregate` failed on every invocation:

```
[ERROR] ❌ Cannot aggregate. 'TestRun' object has no attribute 'cluster_config_instance_params'.
```

`TestRun` defines `cluster_config_params` (`osbenchmark/metrics.py:1343`), and the name being read occurs nowhere else in the repository — nothing assigns it. #882 (`2c85d505`) renamed the attribute on `TestRun` to `cluster_config_params` but renamed this read site to `cluster_config_instance_params`; #939 (`e10342d1`) later corrected the *config key* on that same line, from `cluster_config_instance.params` to `cluster_config.params`, and left the attribute name as it was. This one-word change reads the name `TestRun` actually defines.

Unlike the null-metrics crash (#1093), this does not depend on the data — it is on the plain `aggregate` → `build_aggregated_results` → `update_config_object` path. As far as I can tell it means `aggregate` cannot currently succeed for anyone on `main`.

A side effect of the fix: because the read never succeeded, the cluster-config params never reached the aggregated result. They now do.

### Issues Resolved

Resolves #1094

### Testing
- [x] New functionality includes testing

- One new test, `test_update_config_object_reads_attributes_that_test_runs_actually_have`, which constructs a **real** `metrics.TestRun` and asserts the `cluster_config.params` value reaches `config.add`.
- Verified red without the fix: with `main`'s `aggregator.py` restored under the new test it fails with `AttributeError: 'TestRun' object has no attribute 'cluster_config_instance_params'`; with the fix it passes.
- Full suite: `1423 passed, 5 skipped` (baseline on `main` is 1422). `pylint` clean.
- End-to-end through the real CLI: `aggregate` reports `✅ SUCCESS` and the aggregated result now carries `cluster-config-instance-params: {'heap_size': '6g'}`, which was being silently lost.

The reason the existing suite doesn't catch this is worth flagging on its own: `tests/aggregator_test.py` never constructs a real `TestRun` — every test passes a bare `Mock()`, and a `Mock` returns a fresh `Mock` for any attribute name asked of it, so a wrong name reads fine. `main` sits at 1422 passed while `aggregate` cannot complete once. `Mock(spec=TestRun)` does not fix it either, because `spec` inspects the class, which knows nothing about attributes assigned in `__init__`; it raises on `cluster_config` first and points at the wrong line. A real `TestRun` is the only thing that catches it, which is why the new test builds one.

### Notes

Found while using Apache solr-orbit, a Python port of OSB whose `aggregator.py` is byte-identical to this one apart from the import module name, to run a multi-configuration benchmark campaign. The same fix is proposed there as apache/solr-orbit#59.

This was the second of three defects blocking `aggregate`; it only became visible after the null-metrics crash was fixed, because that one happens earlier on the same path.
