### PR TITLE
Let aggregate load a workload from --workload-path

### DIFF
--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -292,7 +292,10 @@ class Aggregator:
         if self.test_run_compatibility_check():
             self.test_run = self.test_store.find_by_test_run_id(list(self.test_runs.keys())[0])
             self.test_procedure_name = self.test_run.test_procedure
-            self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
+            # a workload given as a path is already configured; naming a repository too would send the
+            # loader looking for the workload in that repository instead
+            if not self.args.workload_path:
+                self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
             self.config.add(config.Scope.applicationOverride, "workload", "workload.name", self.test_run.workload)
             self.loaded_workload = workload.load_workload(self.config)
             for id in self.test_runs.keys():

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -321,10 +321,7 @@ def create_arg_parser():
         "--results-file",
         help="Write the aggregated results to the provided file.",
         default="")
-    aggregate_parser.add_argument(
-        "--workload-repository",
-        help="Define the repository from where OSB will load workloads (default: default).",
-        default="default")
+    add_workload_source(aggregate_parser)
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
     download_parser.add_argument(
@@ -1184,6 +1181,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "reporting", "percentiles", args.percentiles)
             publisher.compare(cfg, args.baseline, args.contender)
         elif sub_command == "aggregate":
+            configure_workload_params(arg_parser, args, cfg, command_requires_workload=False)
             test_runs_dict = prepare_test_runs_dict(args, cfg)
             aggregator_instance = aggregator.Aggregator(cfg, test_runs_dict, args)
             aggregator_instance.aggregate()

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import pytest
 from osbenchmark import config
 from osbenchmark import metrics
@@ -22,7 +22,8 @@ def mock_args():
     return Mock(
         results_file="",
         test_run_id="",
-        workload_repository="default"
+        workload_repository="default",
+        workload_path=None
     )
 
 @pytest.fixture
@@ -176,6 +177,34 @@ def test_calculate_weighted_average_with_partially_null_metric_fields(aggregator
     assert result["throughput"]["overall_max"] == 30
     assert result["throughput"]["mean"] == 20
     assert result["throughput"]["unit"] == "ops/s"
+def _stub_run_for_aggregate(aggregator):
+    aggregator.test_store.find_by_test_run_id.side_effect = None
+    aggregator.test_store.find_by_test_run_id.return_value = Mock(
+        results={}, workload="workload1", test_procedure="test_proc1")
+
+def test_aggregate_names_the_workload_repository(aggregator):
+    _stub_run_for_aggregate(aggregator)
+
+    with patch("osbenchmark.workload.load_workload"), patch.object(aggregator, "build_aggregated_results"), \
+            patch("osbenchmark.aggregator.FileTestRunStore"):
+        aggregator.aggregate()
+
+    aggregator.config.add.assert_any_call(config.Scope.applicationOverride, "workload",
+                                          "repository.name", "default")
+
+def test_aggregate_leaves_a_workload_path_alone(aggregator):
+    # a workload passed as a path is already configured; also naming a repository would send the
+    # loader hunting for the workload inside that repository instead
+    aggregator.args.workload_path = "/path/to/my/workload"
+    _stub_run_for_aggregate(aggregator)
+
+    with patch("osbenchmark.workload.load_workload"), patch.object(aggregator, "build_aggregated_results"), \
+            patch("osbenchmark.aggregator.FileTestRunStore"):
+        aggregator.aggregate()
+
+    repository_calls = [c for c in aggregator.config.add.call_args_list
+                        if c.args[1:3] == ("workload", "repository.name")]
+    assert repository_calls == []
 
 def test_calculate_rsd(aggregator):
     values = [1, 2, 3, 4, 5]


### PR DESCRIPTION
### Description

`add_workload_source()` offers a workload either as a repository or as a local path, and `run`, `list` and `info` all use it. `aggregate` defined only its own `--workload-repository`, so a test run made against a workload on disk could not be aggregated afterwards — the aggregator loads the workload to read its schedule, and a repository lookup fails for a workload that only exists as a path:

```
$ opensearch-benchmark aggregate --test-runs=<id1>,<id2> --workload-path=/path/to/workload
opensearch-benchmark: error: unrecognized arguments: --workload-path=/path/to/workload
```

The aggregate parser now uses the same `add_workload_source` helper as `run`, so the two options stay mutually exclusive and `--workload-revision` comes along with them. Dispatch calls `configure_workload_params` with `command_requires_workload=False`, matching how `list` already handles a command that takes a workload source but no `--workload` — `aggregate` gets the workload name from the stored test run.

One behavioural detail: a path sets `workload.path`, which is what makes the loader choose `SimpleWorkloadRepository`. So when a path was given, `aggregate()` no longer names a repository — doing both would send the loader looking for the workload inside that repository instead. That guard is load-bearing, since argparse's default for `--workload-repository` is the string `"default"` rather than `None`.

### Issues Resolved

Resolves #1095

### Testing
- [x] New functionality includes testing

- Two new tests: `test_aggregate_names_the_workload_repository` (unchanged behaviour when a repository is used) and `test_aggregate_leaves_a_workload_path_alone` (no `repository.name` is configured when a path is given).
- The shared `mock_args` fixture previously supplied no `workload_path`, so the aggregator saw a `Mock` attribute that happens to be truthy. It is now explicit — that fixture change is what makes the first test meaningful rather than accidentally passing.
- CLI verified by hand: `aggregate --workload-path=<dir>` is accepted where it previously errored, aggregation succeeds end to end, and combining it with `--workload-revision` is correctly rejected.
- Full suite: `1424 passed, 5 skipped` (baseline on `main` is 1422). `pylint` clean.

### Notes

Found while using Apache solr-orbit, a Python port of OSB with the same argparse structure, to run a multi-configuration benchmark campaign. The same change is proposed there as apache/solr-orbit#60. Third of three `aggregate` gaps I hit, and the only one that is a parity gap rather than a bug.

There is a case for going further — a test run already records the workload it used, so `aggregate` could resolve the spec from the stored run and need no workload-source argument at all. I've gone with the parity fix because it is the smaller change and matches the existing pattern, but I'm open to the other shape if you'd rather have it.
