### PR TITLE
Use target_index_body for engine detection instead of radial_engine

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1164,7 +1164,11 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.space_type = params.get(self.PARAMS_NAME_SPACE_TYPE, "l2")
 
         if self.radial_search_type:
-            self.radial_engine = params.get("radial_engine", "faiss")
+            index_body = params.get("target_index_body", "")
+            if "lucene" in index_body.lower():
+                self.radial_engine = "lucene"
+            else:
+                self.radial_engine = "faiss"
 
 
         if self.PARAMS_NAME_FILTER in params:

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -3513,7 +3513,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": k,
             "radial_search_type": "max_distance",
-            "radial_engine": "faiss",
+            "target_index_body": "indices/faiss-index.json",
         }
         query_param_source = VectorSearchPartitionParamSource(
             workload.Workload(name="unit-test"),
@@ -3563,7 +3563,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": k,
             "radial_search_type": "min_score",
-            "radial_engine": "lucene",
+            "target_index_body": "indices/lucene-index.json",
         }
         query_param_source = VectorSearchPartitionParamSource(
             workload.Workload(name="unit-test"),
@@ -3600,7 +3600,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
             "data_set_path": data_set_path,
             "k": 100,
             "radial_search_type": "max_distance",
-            "radial_engine": "faiss",
+            "target_index_body": "indices/faiss-index.json",
             "oversample_factor": 5.0,
         }
         with self.assertRaises(exceptions.InvalidSyntax):


### PR DESCRIPTION
### Description
Use target_index_body for engine detection instead of radial_engine param.

### Testing
Validated via unit tests. Template passthrough follows same pattern as radial_search_type which is already working in production.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
