### PR TITLE
Revert to execute-test / test_execution terminology (3.0)

### DIFF
--- a/CREATE_WORKLOAD_GUIDE.md
+++ b/CREATE_WORKLOAD_GUIDE.md
@@ -53,7 +53,7 @@ By default, workloads created will come with the following operations run in the
 
 To invoke the newly created workload, run the following:
 ```
-$ opensearch-benchmark run \
+$ opensearch-benchmark execute-test \
 --pipeline="benchmark-only" \
 --workload-path="<PATH OUTPUTTED IN THE OUTPUT OF THE CREATE-WORKLOAD COMMAND>" \
 --target-host="<CLUSTER ENDPOINT>" \

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -160,7 +160,7 @@ Now, you have a local cluster running! You can connect to this and run the workl
 
 Here's a sample run of the geonames benchmark which can be found from the [workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) repo.
 ```
-opensearch-benchmark run --pipeline=benchmark-only --workload=geonames --target-host=127.0.0.1:9200 --test-mode --workload-params '{"number_of_shards":"1","number_of_replicas":"0"}'
+opensearch-benchmark execute-test --pipeline=benchmark-only --workload=geonames --target-host=127.0.0.1:9200 --test-mode --workload-params '{"number_of_shards":"1","number_of_replicas":"0"}'
 ```
 
 And we're done! You should be seeing the performance metrics soon enough!

--- a/PYTHON_SUPPORT_GUIDE.md
+++ b/PYTHON_SUPPORT_GUIDE.md
@@ -40,17 +40,17 @@ For an example, please see the reference the following:
 
 **Basic OpenSearch Benchmark command with distribution version and test mode**
 ```
-opensearch-benchmark run --distribution-version=1.0.0 --workload=geonames --test-mode
+opensearch-benchmark execute-test --distribution-version=1.0.0 --workload=geonames --test-mode
 ```
 
 **OpenSearch Benchmark command running test on target-host in test mode**
 ```
-opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
+opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'" --test-mode"
 ```
 
 **OpenSearch-Benchmark command running test on target-host without test mode**
 ```
-opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 To ensure that users are using the correct python versions, install the repository with `python3 -m pip install -e .` and run `which opensearch-benchmark` to get the path. Pre-append this path to each of the three commands above and re-run them in the command line.
@@ -59,12 +59,12 @@ Keep in mind the file path outputted differs for each operating system and might
 
 - For example: When running `which opensearch-benchmark` on an Ubuntu environment, the commad line outputs `/home/ubuntu/.pyenv/shims/opensearch-benchmark`. On closer inspection, the path points to a shell script. Thus, to invoke OpenSearch Benchmark, pre-=append the OpenSearch Benchmark command with `bash` and the path outputted earlier:
 ```
-bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+bash -x /home/ubuntu/.pyenv/shims/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 - Another example: When running `which opensearch-benchmark` on an Amazon Linux 2 environment, the command line outputs `~/.local/bin/opensearch-benchmark`. On closer inspection, the path points to a Python script. Thus, to invoke OpenSearch Benchmark, pre-append the OpenSearch Benchmark command with `python3` and the path outputted earlier:
 ```
-python3 ~/.local/bin/opensearch-benchmark run --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
+python3 ~/.local/bin/opensearch-benchmark execute-test --workload=geonames --pipeline=benchmark-only --target-host="<OPENSEARCH CLUSTER ENDPOINT>" --client-options="basic_auth_user:'<USERNAME>',basic_auth_password:'<PASSWORD>'"
 ```
 
 ### Creating a Pull Request After Adding Changes and Testing Them Out

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -72,7 +72,7 @@ Add backport labels to PRs and commits so that changes can be added to `main` br
     3. Run `opensearch-benchmark --version` to ensure that it is the correct version
     4. Run `opensearch-benchmark --help`
     5. Run `opensearch-benchmark list workloads`
-    6. Run a basic workload on Linux and MacOS:  `opensearch-benchmark run --workload pmc --test-mode`
+    6. Run a basic workload on Linux and MacOS:  `opensearch-benchmark execute-test --workload pmc --test-mode`
     7. If you are fastidious, you can check the installed source files at `` `python3 -m site --user-site`/osbenchmark `` to verify that a recent change is indeed present.
 
 8. Verify Docker Hub Staging OSB Image Works:

--- a/docs/api/run-test.md
+++ b/docs/api/run-test.md
@@ -1,17 +1,17 @@
 ---
 layout: default
-title: Run Test
+title: Execute Test
 parent: OSB API
 nav_order: 10
 ---
 
-The `run` command of OpenSearch Benchmark runs tests against your OpenSearch cluster.
+The `execute-test` command of OpenSearch Benchmark runs tests against your OpenSearch cluster.
 
 
 ## Syntax
 
 ```bash
-opensearch-benchmark run <arguments>
+opensearch-benchmark execute-test <arguments>
 ```
 
 
@@ -28,13 +28,14 @@ Argument | Description | Required
 `pipeline` | Steps required to run a test, including provisioning an OpenSearch from source code or a specified distribution. Defaults to `from-sources` which provisions an OpenSearch cluster from source code. | No
 `distribution-version` | The OpenSearch version to use for a given test. Defining a version can be useful when using a `pipeline` that includes provisioning. When using a `pipeline` without provisioning, OSB will automatically determine the version | No
 `target-hosts` | The OpenSearch endpoint(s) to run a test against. This should only be specified with  `--pipeline=benchmark-only`  | No
+`database-type` | The target database engine to benchmark. Accepted values are `opensearch`, `vespa`, `milvus`, and `clickhouse` (default: `opensearch`). | No
 `test-mode` | Run a single iteration of each operation in the test procedure. The test provides a quick way for sanity checking a testing configuration. Therefore, do not use `test-mode` for actual benchmarking. | No
 `kill-running-processes` | Kill any running OpenSearch Benchmark processes on the local machine before the test runs. | No
 
 *Example 1*
 
 ```
-opensearch-benchmark run --workload eventdata --test-mode
+opensearch-benchmark execute-test --workload eventdata --test-mode
 ```
 
 Provision an OpenSearch node on the local machine based on the latest source code in Github and run the `eventdata` workload in test mode.
@@ -42,7 +43,7 @@ Provision an OpenSearch node on the local machine based on the latest source cod
 *Example 2*
 
 ```
-opensearch-benchmark run --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
+opensearch-benchmark execute-test --workload http_logs --pipeline benchmark-only --target-hosts <endpoint> --workload-params "bulk_indexing_clients:1,ingest_percentage:10"
 ```
 
 Run the `http_logs` workload against an existing OpenSearch cluster but only use one client for indexing and only ingest 10% of the total data corpus.
@@ -50,7 +51,7 @@ Run the `http_logs` workload against an existing OpenSearch cluster but only use
 *Example 3*
 
 ```
-opensearch-benchmark run --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
+opensearch-benchmark execute-test --workload nyc_taxis --pipeline benchmark-only --target-hosts <endpoint> --client-options "verify_certs:false,use_ssl:true,basic_auth_user:admin,basic_auth_password:admin"
 ```
 
 Run the `nyc_taxis` workload against an existing OpenSearch cluster with the security plugin enabled.
@@ -64,7 +65,7 @@ Argument | Description | Required
 `cluster-config-path` | Define the path to the cluster-configs and plugin configurations to use. | No
 `cluster-config-repository` | Define repository from where OSB will load cluster-configs (default: `default`). | No
 `cluster-config-revision` | Define a specific revision in the cluster-config repository that OSB should use. | No
-`test-run-id` | Define a unique id for this test_run. | No
+`test-execution-id` | Define a unique id for this test_execution. | No
 `pipeline` | Select the pipeline to run. | No
 `revision` | Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is, 'latest' fetches the latest version on main. It is also possible to specify a commit id or an ISO timestamp. The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, e.g. "@2013-07-27T10:37:00Z" (default: `current`). | No
 `workload-repository` | Define the repository from where OSB will load workloads (default: `default`). | No
@@ -81,6 +82,7 @@ Argument | Description | Required
 `target-hosts` | Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' (default: `localhost:9200`). | No
 `worker-ips` | Define a comma-separated list of hosts which should generate load (default: `localhost`). | No
 `client-options` | Define a comma-separated list of client options to use. The options will be passed to the OpenSearch Python client (default: `timeout:60`). | No
+`database-type` | Define the target database engine. Supported engines are `opensearch`, `vespa`, `milvus`, and `clickhouse` (default: `opensearch`). | No
 `on-error` | Controls how OSB behaves on response errors. Options are `continue` and `abort` (default: `continue`). | No
 `telemetry` | Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices with `opensearch-benchmark list telemetry`. | No
 `telemetry-params` | Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters. | No

--- a/docs/grpc-support.md
+++ b/docs/grpc-support.md
@@ -28,7 +28,7 @@ OpenSearch Benchmark supports benchmarking OpenSearch clusters via gRPC transpor
 To benchmark with gRPC, specify both REST and gRPC endpoints:
 
 ```bash
-opensearch-benchmark run \
+opensearch-benchmark execute-test \
     --target-hosts=localhost:9200 \
     --grpc-target-hosts=localhost:9401 \
     --workload=http_logs \

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -85,8 +85,8 @@ def osbenchmark_command_line_for(cfg, command_line):
 
 def osbenchmark(cfg, command_line):
     """
-    This method should be used for benchmark invocations of the all commands besides test_run.
-    These commands may have different CLI options than test_run.
+    This method should be used for benchmark invocations of all commands besides execute-test.
+    These commands may have different CLI options than execute-test.
     """
     cmd = osbenchmark_command_line_for(cfg, command_line)
     print(f'\n{datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")} Invoking OSB: {cmd}')
@@ -98,8 +98,19 @@ def osbenchmark(cfg, command_line):
 
 def run_test(cfg, command_line):
     """
-    This method should be used for benchmark invocations of the test_run command.
-    It sets up some defaults for how the integration tests expect to run test_runs.
+    This method should be used for benchmark invocations of the execute-test command.
+    It sets up some defaults for how the integration tests expect to run tests.
+    Uses the primary `execute-test` subcommand; the deprecated `run` alias is
+    covered separately by run_test_with_deprecated_alias.
+    """
+    return osbenchmark(cfg, f"execute-test {command_line} --kill-running-processes --on-error='abort'")
+
+
+def run_test_with_deprecated_alias(cfg, command_line):
+    """
+    Same as run_test but invokes the deprecated `run` subcommand alias instead of
+    the primary `execute-test`. Keeps alias coverage so the deprecated path
+    (promised in the 3.x terminology revert) stays exercised end-to-end.
     """
     return osbenchmark(cfg, f"run {command_line} --kill-running-processes --on-error='abort'")
 
@@ -186,8 +197,9 @@ class TestCluster:
         except BaseException as e:
             raise AssertionError("Failed to install OpenSearch {}.".format(distribution_version), e)
 
-    def start(self, test_run_id):
-        cmd = "start --runtime-jdk=\"bundled\" --installation-id={} --test-run-id={}".format(self.installation_id, test_run_id)
+    def start(self, test_execution_id):
+        cmd = "start --runtime-jdk=\"bundled\" --installation-id={} --test-execution-id={}".format(
+            self.installation_id, test_execution_id)
         if osbenchmark(self.cfg, cmd) != 0:
             raise AssertionError("Failed to start OpenSearch test cluster.")
         opensearch = client.OsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
@@ -213,7 +225,7 @@ class OsMetricsStore:
                              node_name="metrics-store",
                              cluster_config="defaults",
                              http_port=10200)
-        self.cluster.start(test_run_id="metrics-store")
+        self.cluster.start(test_execution_id="metrics-store")
 
     def stop(self):
         self.cluster.stop()

--- a/it/list_test.py
+++ b/it/list_test.py
@@ -26,7 +26,13 @@ import it
 
 
 @it.all_benchmark_configs
-def test_list_test_runs(cfg):
+def test_list_test_executions(cfg):
+    assert it.osbenchmark(cfg, "list test-executions") == 0
+
+
+@it.all_benchmark_configs
+def test_list_test_runs_deprecated_alias(cfg):
+    # the pre-3.x positional `test-runs` must remain accepted (deprecated).
     assert it.osbenchmark(cfg, "list test-runs") == 0
 
 

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -34,5 +34,9 @@ def test_sources(cfg):
                         f"--opensearch-plugins=analysis-icu") == 0
 
     it.wait_until_port_is_free(port_number=port)
-    assert it.run_test(cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
-                        f"--test-procedure=append-no-conflicts-index-only --cluster-config=\"4gheap,ea\"") == 0
+    # Exercise the deprecated `run` subcommand alias end-to-end so the alias path
+    # (kept working by the 3.x terminology revert) stays covered alongside the
+    # primary `execute-test` invocation above.
+    assert it.run_test_with_deprecated_alias(
+        cfg, f"--pipeline=from-sources --workload=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+        f"--test-procedure=append-no-conflicts-index-only --cluster-config=\"4gheap,ea\"") == 0

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -35,11 +35,11 @@ def test_cluster():
     # test with a recent distribution
     dist = it.DISTRIBUTIONS[-1]
     port = 19200
-    test_run_id = str(uuid.uuid4())
+    test_execution_id = str(uuid.uuid4())
 
     it.wait_until_port_is_free(port_number=port)
     cluster.install(distribution_version=dist, node_name="benchmark-node", cluster_config="4gheap", http_port=port)
-    cluster.start(test_run_id=test_run_id)
+    cluster.start(test_execution_id=test_execution_id)
     yield cluster
     cluster.stop()
 

--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -138,11 +138,10 @@ class Aggregator:
                 if isinstance(aggregated_task_metrics[metric], dict):
                     # Calculate RSD for the mean values across all test runs
                     # We use mean here as it's more sensitive to outliers, which is desirable for assessing variability
-                    # Use .get('mean') and drop missing/None entries: a stored op_metric may lack 'mean'
-                    # (older/partial results), which would otherwise raise KeyError here. Matches the
-                    # defensive .get(field, 0) in calculate_weighted_average.
-                    mean_values = [v['mean'] for v in task_metrics[metric]
-                                   if isinstance(v, dict) and v.get('mean') is not None]
+                    # Use .get('mean'): a stored op_metric may lack 'mean' (older/partial results) or carry
+                    # None (an op that produced no valid samples, e.g. index-only throughput). We pass those
+                    # through to calculate_rsd, which tolerates None/empty and returns "NA" rather than raising.
+                    mean_values = [v.get('mean') for v in task_metrics[metric] if isinstance(v, dict)]
                     rsd = self.calculate_rsd(mean_values, f"{task}.{metric}.mean")
                     op_metric[metric]['mean_rsd'] = rsd
 
@@ -273,12 +272,12 @@ class Aggregator:
         return sum(value * iterations for value, iterations in contributions) / total_iterations
 
     def calculate_rsd(self, values: List[Union[int, float]], metric_name: str) -> Union[float, str]:
-        if not values:
-            raise ValueError(f"Cannot calculate RSD for metric '{metric_name}': empty list of values")
         # operations that produced no valid samples report None, which cannot contribute to a deviation
         values = [value for value in values if value is not None]
         if not values:
-            return "NA"  # no test run measured this metric
+            # No test run measured this metric (all None, or nothing collected).
+            # RSD is undefined; report "NA" rather than crashing the whole aggregation.
+            return "NA"
         if len(values) == 1:
             return "NA"  # RSD is not applicable for a single value
         mean = statistics.mean(values)

--- a/osbenchmark/aggregator.py
+++ b/osbenchmark/aggregator.py
@@ -3,39 +3,39 @@ import statistics
 from typing import Any, Dict, List, Union
 import uuid
 
-from osbenchmark.metrics import FileTestRunStore, TestRun
-from osbenchmark import metrics, workload, config
+from osbenchmark.metrics import FileTestExecutionStore, TestExecution
+from osbenchmark import metrics, workload, config, exceptions
 from osbenchmark.utils import io as rio
 
 class Aggregator:
-    def __init__(self, cfg, test_runs_dict, args) -> None:
+    def __init__(self, cfg, test_executions_dict, args) -> None:
         self.config = cfg
         self.args = args
-        self.test_runs = test_runs_dict
+        self.test_executions = test_executions_dict
         self.accumulated_results: Dict[str, Dict[str, List[Any]]] = {}
         self.accumulated_iterations: Dict[str, Dict[str, int]] = {}
         self.metrics = ["throughput", "latency", "service_time", "client_processing_time", "processing_time", "error_rate", "duration"]
-        self.test_store = metrics.test_run_store(self.config)
+        self.test_store = metrics.test_execution_store(self.config)
         self.cwd = cfg.opts("node", "benchmark.cwd")
-        self.test_run = None
+        self.test_execution = None
         self.test_procedure_name = None
         self.loaded_workload = None
 
-    def count_iterations_for_each_op(self, test_run: TestRun) -> None:
+    def count_iterations_for_each_op(self, test_execution: TestExecution) -> None:
         """Count iterations for each operation in the test run"""
-        workload_params = test_run.workload_params if test_run.workload_params else {}
-        test_run_id = test_run.test_run_id
-        self.accumulated_iterations[test_run_id] = {}
+        workload_params = test_execution.workload_params if test_execution.workload_params else {}
+        test_execution_id = test_execution.test_execution_id
+        self.accumulated_iterations[test_execution_id] = {}
 
         for task in self.loaded_workload.find_test_procedure_or_default(self.test_procedure_name).schedule:
             task_name = task.name
             task_name_iterations = f"{task_name}_iterations"
             iterations = int(workload_params.get(task_name_iterations, task.iterations or 1))
-            self.accumulated_iterations[test_run_id][task_name] = iterations
+            self.accumulated_iterations[test_execution_id][task_name] = iterations
 
-    def accumulate_results(self, test_run: TestRun) -> None:
+    def accumulate_results(self, test_execution: TestExecution) -> None:
         """Accumulate results from a single test run"""
-        for operation_metric in test_run.results.get("op_metrics", []):
+        for operation_metric in test_execution.results.get("op_metrics", []):
             task = operation_metric.get("task", "")
             self.accumulated_results.setdefault(task, {})
             for metric in self.metrics:
@@ -47,7 +47,7 @@ class Aggregator:
         Aggregates JSON results across multiple test runs using a specified key path.
         Handles nested dictionary structures and calculates averages for numeric values
         """
-        all_json_results = [self.test_store.find_by_test_run_id(id).results for id in self.test_runs.keys()]
+        all_json_results = [self.test_store.find_by_test_execution_id(id).results for id in self.test_executions.keys()]
 
         def get_nested_value(json_data: Dict[str, Any], path: List[str]) -> Any:
             """
@@ -138,7 +138,11 @@ class Aggregator:
                 if isinstance(aggregated_task_metrics[metric], dict):
                     # Calculate RSD for the mean values across all test runs
                     # We use mean here as it's more sensitive to outliers, which is desirable for assessing variability
-                    mean_values = [v['mean'] for v in task_metrics[metric]]
+                    # Use .get('mean') and drop missing/None entries: a stored op_metric may lack 'mean'
+                    # (older/partial results), which would otherwise raise KeyError here. Matches the
+                    # defensive .get(field, 0) in calculate_weighted_average.
+                    mean_values = [v['mean'] for v in task_metrics[metric]
+                                   if isinstance(v, dict) and v.get('mean') is not None]
                     rsd = self.calculate_rsd(mean_values, f"{task}.{metric}.mean")
                     op_metric[metric]['mean_rsd'] = rsd
 
@@ -152,67 +156,83 @@ class Aggregator:
 
         return aggregated_results
 
-    def update_config_object(self, test_run: TestRun) -> None:
+    def update_config_object(self, test_execution: TestExecution) -> None:
         """
         Updates the configuration object with values from a test run.
         Uses the first test run as reference since configurations should be identical
         """
         current_timestamp = self.config.opts("system", "time.start")
         self.config.add(config.Scope.applicationOverride, "builder",
-                        "cluster_config.names", test_run.cluster_config)
+                        "cluster_config.names", test_execution.cluster_config)
         self.config.add(config.Scope.applicationOverride, "system",
-                        "env.name", test_run.environment_name)
+                        "env.name", test_execution.environment_name)
         self.config.add(config.Scope.applicationOverride, "system", "time.start", current_timestamp)
-        self.config.add(config.Scope.applicationOverride, "test_run", "pipeline", test_run.pipeline)
-        self.config.add(config.Scope.applicationOverride, "workload", "params", test_run.workload_params)
+        self.config.add(config.Scope.applicationOverride, "test_execution", "pipeline", test_execution.pipeline)
+        self.config.add(config.Scope.applicationOverride, "workload", "params", test_execution.workload_params)
         self.config.add(config.Scope.applicationOverride, "builder",
-                        "cluster_config.params", test_run.cluster_config_params)
-        self.config.add(config.Scope.applicationOverride, "builder", "plugin.params", test_run.plugin_params)
-        self.config.add(config.Scope.applicationOverride, "workload", "latency.percentiles", test_run.latency_percentiles)
-        self.config.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", test_run.throughput_percentiles)
+                        "cluster_config.params", test_execution.cluster_config_params)
+        self.config.add(config.Scope.applicationOverride, "builder", "plugin.params", test_execution.plugin_params)
+        self.config.add(config.Scope.applicationOverride, "workload", "latency.percentiles", test_execution.latency_percentiles)
+        self.config.add(config.Scope.applicationOverride, "workload", "throughput.percentiles", test_execution.throughput_percentiles)
 
-    def build_aggregated_results(self) -> TestRun:
-        test_run = self.test_store.find_by_test_run_id(list(self.test_runs.keys())[0])
+    def build_aggregated_results(self) -> TestExecution:
+        test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
         aggregated_results = self.build_aggregated_results_dict()
 
         if hasattr(self.args, 'results_file') and self.args.results_file != "":
             normalized_results_file = rio.normalize_path(self.args.results_file, self.cwd)
             # ensure that the parent folder already exists when we try to write the file...
             rio.ensure_dir(rio.dirname(normalized_results_file))
-            test_run_id = os.path.basename(normalized_results_file)
-            self.config.add(config.Scope.applicationOverride, "system", "test_run.id", normalized_results_file)
-        elif hasattr(self.args, 'test_run_id') and self.args.test_run_id:
-            test_run_id = f"aggregate_results_{test_run.workload}_{self.args.test_run_id}"
-            self.config.add(config.Scope.applicationOverride, "system", "test_run.id", test_run_id)
+            test_execution_id = os.path.basename(normalized_results_file)
+            self.config.add(config.Scope.applicationOverride, "system", "test_execution.id", normalized_results_file)
+        elif getattr(self.args, 'test_execution_id', None) or getattr(self.args, 'test_run_id', None):
+            # back-compat: the CLI dest becomes test_execution_id, but the deprecated
+            # --test-run-id alias may still populate test_run_id until the CLI flip lands.
+            arg_test_execution_id = getattr(self.args, 'test_execution_id', None) \
+                or getattr(self.args, 'test_run_id', None)
+            test_execution_id = f"aggregate_results_{test_execution.workload}_{arg_test_execution_id}"
+            self.config.add(config.Scope.applicationOverride, "system", "test_execution.id", test_execution_id)
         else:
-            test_run_id = f"aggregate_results_{test_run.workload}_{str(uuid.uuid4())}"
-            self.config.add(config.Scope.applicationOverride, "system", "test_run.id", test_run_id)
+            test_execution_id = f"aggregate_results_{test_execution.workload}_{str(uuid.uuid4())}"
+            self.config.add(config.Scope.applicationOverride, "system", "test_execution.id", test_execution_id)
 
-        print("Aggregate test run ID: ", test_run_id)
+        print("Aggregate test execution ID: ", test_execution_id)
 
-        self.update_config_object(test_run)
+        self.update_config_object(test_execution)
 
         loaded_workload = workload.load_workload(self.config)
         test_procedure_object = loaded_workload.find_test_procedure_or_default(self.test_procedure_name)
 
-        test_run = metrics.create_test_run(self.config, loaded_workload, test_procedure_object, test_run.workload_revision)
-        test_run.user_tags = {
-            "aggregation-of-runs": list(self.test_runs.keys())
+        test_execution = metrics.create_test_execution(self.config, loaded_workload, test_procedure_object, test_execution.workload_revision)
+        test_execution.user_tags = {
+            "aggregation-of-runs": list(self.test_executions.keys())
         }
-        test_run.add_results(AggregatedResults(aggregated_results))
-        test_run.distribution_version = test_run.distribution_version
-        test_run.revision = test_run.revision
-        test_run.distribution_flavor = test_run.distribution_flavor
-        test_run.cluster_config_revision = test_run.cluster_config_revision
+        test_execution.add_results(AggregatedResults(aggregated_results))
+        test_execution.distribution_version = test_execution.distribution_version
+        test_execution.revision = test_execution.revision
+        test_execution.distribution_flavor = test_execution.distribution_flavor
+        test_execution.cluster_config_revision = test_execution.cluster_config_revision
 
-        return test_run
+        return test_execution
 
     def calculate_weighted_average(self, task_metrics: Dict[str, List[Any]], task_name: str) -> Dict[str, Any]:
         weighted_metrics = {}
 
-        # Get iterations for each test run
-        iterations_per_run = [self.accumulated_iterations[test_id][task_name]
-                                    for test_id in self.test_runs.keys()]
+        # Get iterations for each test run. accumulated_iterations is keyed by
+        # the tasks in the currently-loaded workload schedule, while task_name
+        # comes from the stored op_metrics; if a workload was edited (op renamed
+        # or removed) the two can drift. Guard with .get() and raise a clear
+        # error naming the mismatched task instead of a bare KeyError.
+        iterations_per_run = []
+        for test_id in self.test_executions.keys():
+            run_iterations = self.accumulated_iterations.get(test_id, {})
+            if task_name not in run_iterations:
+                raise exceptions.SystemSetupError(
+                    f"Task '{task_name}' is present in the stored results of test execution "
+                    f"'{test_id}' but not in the loaded workload's schedule. The workload "
+                    f"definition likely changed since the run; aggregate results generated "
+                    f"with the same workload version used for the original runs.")
+            iterations_per_run.append(run_iterations[task_name])
 
         for metric, values in task_metrics.items():
             if isinstance(values[0], dict):
@@ -265,21 +285,21 @@ class Aggregator:
         std_dev = statistics.stdev(values)
         return (std_dev / mean) * 100 if mean != 0 else float('inf')
 
-    def test_run_compatibility_check(self) -> None:
-        first_test_run = self.test_store.find_by_test_run_id(list(self.test_runs.keys())[0])
-        workload = first_test_run.workload
-        test_procedure = first_test_run.test_procedure
-        for id in self.test_runs.keys():
-            test_run = self.test_store.find_by_test_run_id(id)
-            if test_run:
-                if test_run.workload != workload:
+    def test_execution_compatibility_check(self) -> None:
+        first_test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
+        workload = first_test_execution.workload
+        test_procedure = first_test_execution.test_procedure
+        for id in self.test_executions.keys():
+            test_execution = self.test_store.find_by_test_execution_id(id)
+            if test_execution:
+                if test_execution.workload != workload:
                     raise ValueError(
-                        f"Incompatible workload: test {id} has workload '{test_run.workload}' instead of '{workload}'. "
+                        f"Incompatible workload: test {id} has workload '{test_execution.workload}' instead of '{workload}'. "
                         f"Ensure that all test IDs have the same workload."
                     )
-                if test_run.test_procedure != test_procedure:
+                if test_execution.test_procedure != test_procedure:
                     raise ValueError(
-                        f"Incompatible test procedure: test {id} has test procedure '{test_run.test_procedure}' "
+                        f"Incompatible test procedure: test {id} has test procedure '{test_execution.test_procedure}' "
                         f"instead of '{test_procedure}'. Ensure that all test IDs have the same test procedure from the same workload."
                     )
             else:
@@ -289,24 +309,24 @@ class Aggregator:
         return True
 
     def aggregate(self) -> None:
-        if self.test_run_compatibility_check():
-            self.test_run = self.test_store.find_by_test_run_id(list(self.test_runs.keys())[0])
-            self.test_procedure_name = self.test_run.test_procedure
+        if self.test_execution_compatibility_check():
+            self.test_execution = self.test_store.find_by_test_execution_id(list(self.test_executions.keys())[0])
+            self.test_procedure_name = self.test_execution.test_procedure
             # a workload given as a path is already configured; naming a repository too would send the
             # loader looking for the workload in that repository instead
             if not self.args.workload_path:
                 self.config.add(config.Scope.applicationOverride, "workload", "repository.name", self.args.workload_repository)
-            self.config.add(config.Scope.applicationOverride, "workload", "workload.name", self.test_run.workload)
+            self.config.add(config.Scope.applicationOverride, "workload", "workload.name", self.test_execution.workload)
             self.loaded_workload = workload.load_workload(self.config)
-            for id in self.test_runs.keys():
-                test_run = self.test_store.find_by_test_run_id(id)
-                if test_run:
-                    self.count_iterations_for_each_op(test_run)
-                    self.accumulate_results(test_run)
+            for id in self.test_executions.keys():
+                test_execution = self.test_store.find_by_test_execution_id(id)
+                if test_execution:
+                    self.count_iterations_for_each_op(test_execution)
+                    self.accumulate_results(test_execution)
 
             aggregated_results = self.build_aggregated_results()
-            file_test_run_store = FileTestRunStore(self.config)
-            file_test_run_store.store_aggregated_run(aggregated_results)
+            file_test_execution_store = FileTestExecutionStore(self.config)
+            file_test_execution_store.store_aggregated_test_execution(aggregated_results)
         else:
             raise ValueError("Incompatible test run results")
 

--- a/osbenchmark/benchmark.py
+++ b/osbenchmark/benchmark.py
@@ -36,14 +36,14 @@ import thespian.actors
 
 from osbenchmark import PROGRAM_NAME, BANNER, FORUM_LINK, SKULL, check_python_version, doc_link, telemetry
 from osbenchmark import version, actor, config, paths, \
-    test_run_orchestrator, publisher, \
+    test_execution_orchestrator, publisher, \
         metrics, workload, exceptions, log
 from osbenchmark.builder import cluster_config, builder
 from osbenchmark.synthetic_data_generator import synthetic_data_generator_orchestrator
 from osbenchmark.workload_generator import workload_generator
 from osbenchmark.utils import io, convert, process, console, net, opts, versions
 from osbenchmark import aggregator
-from osbenchmark.database.registry import DatabaseType
+
 
 def create_arg_parser():
     def positive_number(v):
@@ -70,7 +70,14 @@ def create_arg_parser():
     def supported_os_version(v):
         if v:
             min_os_version = versions.Version.from_string(version.minimum_os_version())
-            specified_version = versions.Version.from_string(v)
+            try:
+                specified_version = versions.Version.from_string(v)
+            except exceptions.InvalidSyntax:
+                # Convert to ArgumentTypeError so argparse prints a clean
+                # "error: argument --distribution-version: ..." and exits,
+                # instead of letting InvalidSyntax escape as a raw traceback.
+                raise argparse.ArgumentTypeError(
+                    f"must be a valid version string (e.g. 1.2.3) but was {v!r}")
             if specified_version < min_os_version:
                 raise argparse.ArgumentTypeError(f"must be at least {min_os_version} but was {v}")
         return v
@@ -114,19 +121,19 @@ def create_arg_parser():
         dest="subcommand",
         help="")
 
-    test_run_parser = subparsers.add_parser("run", help="Run a benchmark")
+    test_execution_parser = subparsers.add_parser("execute-test", aliases=["run", "execute"], help="Run a benchmark")
     # change in favor of "list telemetry", "list workloads", "list pipelines"
     list_parser = subparsers.add_parser("list", help="List configuration options")
     list_parser.add_argument(
         "configuration",
         metavar="configuration",
         help="The configuration for which OSB should show the available options. "
-             "Possible values are: telemetry, workloads, pipelines, test-runs, cluster-configs, opensearch-plugins",
-        choices=["telemetry", "workloads", "pipelines", "test-runs", "aggregated-results",
+             "Possible values are: telemetry, workloads, pipelines, test-executions, cluster-configs, opensearch-plugins",
+        choices=["telemetry", "workloads", "pipelines", "test-executions", "test-runs", "aggregated-results",
                  "cluster-configs", "opensearch-plugins"])
     list_parser.add_argument(
         "--limit",
-        help="Limit the number of search results for recent test-runs (default: 10).",
+        help="Limit the number of search results for recent test-executions (default: 10).",
         default=10,
     )
     add_workload_source(list_parser)
@@ -258,17 +265,17 @@ def create_arg_parser():
         "Ensure that index name also exists in --indices parameter. " +
         "To specify several indices and doc counts, use format: <index1>:<sample-frequency-1> <index2>:<sample-frequency-2> ...")
 
-    compare_parser = subparsers.add_parser("compare", help="Compare two test_runs")
+    compare_parser = subparsers.add_parser("compare", help="Compare two test_executions")
     compare_parser.add_argument(
         "--baseline",
         "-b",
         required=True,
-        help=f"TestRun ID of the baseline (see {PROGRAM_NAME} list test-runs).")
+        help=f"TestExecution ID of the baseline (see {PROGRAM_NAME} list test-executions).")
     compare_parser.add_argument(
         "--contender",
         "-c",
         required=True,
-        help=f"TestRun ID of the contender (see {PROGRAM_NAME} list test-runs).")
+        help=f"TestExecution ID of the contender (see {PROGRAM_NAME} list test-executions).")
     compare_parser.add_argument(
         "--percentiles",
         help=f"A comma-separated list of percentiles to report latency and service time."
@@ -293,29 +300,34 @@ def create_arg_parser():
         help="Whether to include the comparison in the results file.",
         default=True)
 
-    visualize_parser = subparsers.add_parser("visualize", help="Generate HTML visualization for a test run")
+    visualize_parser = subparsers.add_parser("visualize", help="Generate HTML visualization for a test execution")
     visualize_parser.add_argument(
+        "--test-execution-id",
         "--test-run-id",
         "-tid",
-        dest="test_run_id",
+        dest="test_execution_id",
         required=True,
-        help=f"TestRun ID to visualize (see {PROGRAM_NAME} list test_runs).")
+        help=f"TestExecution ID to visualize (see {PROGRAM_NAME} list test-executions).")
     visualize_parser.add_argument(
         "--output-path",
         dest="output_path",
-        help="Path where the HTML report should be saved. If not specified, it will be saved in the test run directory, where test_run.json can be found.",
+        help="Path where the HTML report should be saved. If not specified, it will be saved in the test execution directory, where test_execution.json can be found.",
         default=None)
 
-    aggregate_parser = subparsers.add_parser("aggregate", help="Aggregate multiple test-runs")
+    aggregate_parser = subparsers.add_parser("aggregate", help="Aggregate multiple test-executions")
     aggregate_parser.add_argument(
+        "--test-executions",
         "--test-runs",
+        dest="test_executions",
         type=non_empty_list,
         required=True,
-        help="Comma-separated list of TestRun IDs to aggregate")
+        help="Comma-separated list of TestExecution IDs to aggregate")
     aggregate_parser.add_argument(
+        "--test-executions-id",
         "--test-runs-id",
         "-tid",
-        help="Define a unique id for this aggregated test-run.",
+        dest="test_execution_id",
+        help="Define a unique id for this aggregated test-execution.",
         default="")
     aggregate_parser.add_argument(
         "--results-file",
@@ -457,14 +469,16 @@ def create_arg_parser():
         required=True,
         help="The id of the installation to start",
         # the default will be dynamically derived by
-        # test_run_orchestrator based on the
+        # test_execution_orchestrator based on the
         # presence / absence of other command line options
         default="")
     start_parser.add_argument(
+        "--test-execution-id",
         "--test-run-id",
         "-tid",
+        dest="test_execution_id",
         required=True,
-        help="Define a unique id for this test_run.",
+        help="Define a unique id for this test_execution.",
         default="")
     start_parser.add_argument(
         "--runtime-jdk",
@@ -488,7 +502,7 @@ def create_arg_parser():
         required=True,
         help="The id of the installation to stop",
         # the default will be dynamically derived by
-        # test_run_orchestrator based on the
+        # test_execution_orchestrator based on the
         # presence / absence of other command line options
         default="")
     stop_parser.add_argument(
@@ -497,7 +511,7 @@ def create_arg_parser():
         default=preserve_install,
         action="store_true")
 
-    for p in [list_parser, test_run_parser]:
+    for p in [list_parser, test_execution_parser]:
         p.add_argument(
             "--distribution-version",
             type=supported_os_version,
@@ -516,227 +530,222 @@ def create_arg_parser():
             help="Define a specific revision in the cluster-config repository that OSB should use.",
             default=None)
 
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
+        "--test-execution-id",
         "--test-run-id",
         "-tid",
-        help="Define a unique id for this test-run.",
+        dest="test_execution_id",
+        help="Define a unique id for this test-execution.",
         default=str(uuid.uuid4()))
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--pipeline",
         help="Select the pipeline to run.",
         # the default will be dynamically derived by
-        # test_run_orchestrator based on the
+        # test_execution_orchestrator based on the
         # presence / absence of other command line options
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--revision",
         help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
              " 'latest' fetches the latest version on main. It is also possible to specify a commit id or a timestamp."
              " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
              "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
         default="current")  # optimized for local usage, don't fetch sources
-    add_workload_source(test_run_parser)
-    test_run_parser.add_argument(
+    add_workload_source(test_execution_parser)
+    test_execution_parser.add_argument(
         "--workload",
         "-w",
         help=f"Define the workload to use. List possible workloads with `{PROGRAM_NAME} list workloads`."
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--workload-params",
         "-wp",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the workload as variables.",
         default=""
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--test-procedure",
         help=f"Define the test_procedure to use. List possible test_procedures for workloads with `{PROGRAM_NAME} list workloads`.")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--cluster-config",
         help=f"Define the cluster-config to use. List possible "
         f"cluster-configs with `{PROGRAM_NAME} list "
         f"cluster-configs` (default: defaults).",
         default="defaults")  # optimized for local usage
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--cluster-config-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the cluster-config.",
         default=""
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--runtime-jdk",
         type=runtime_jdk,
         help="The major version of the runtime JDK to use.",
         default=None)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--opensearch-plugins",
         help="Define the OpenSearch plugins to install. (default: install no plugins).",
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--plugin-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to all plugins as variables.",
         default=""
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--target-hosts",
         "-t",
         help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
              "(default: localhost:9200).",
         default="")  # actually the default is pipeline specific and it is set later
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--worker-ips",
         help="Define a comma-separated list of hosts which should generate load (default: localhost).",
         default="localhost")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--grpc-target-hosts",
         help="Define a comma-separated list of host:port pairs for gRPC endpoints "
              "(default: localhost:9400).",
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--client-options",
         "-c",
         help=f"Define a comma-separated list of client options to use. The options will be passed to the OpenSearch "
              f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
-    test_run_parser.add_argument(
-        "--database-type",
-        help="Target database backend. Selects the DatabaseClient adapter used to run "
-             "the workload (default: opensearch). Choices are populated from the "
-             "registered DatabaseType enum.",
-        choices=[d.value for d in DatabaseType],
-        default=DatabaseType.OPENSEARCH.value)
-    test_run_parser.add_argument("--on-error",
+    test_execution_parser.add_argument("--on-error",
                              choices=["continue", "abort"],
                              help="Controls how OSB behaves on response errors (default: continue).",
                              default="continue")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--telemetry",
         help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
              f"devices with `{PROGRAM_NAME} list telemetry`.",
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--telemetry-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters.",
         default=""
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--distribution-repository",
         help="Define the repository from where the OpenSearch distribution should be downloaded (default: release).",
         default="release")
 
-    task_filter_group = test_run_parser.add_mutually_exclusive_group()
+    task_filter_group = test_execution_parser.add_mutually_exclusive_group()
     task_filter_group.add_argument(
         "--include-tasks",
         help="Defines a comma-separated list of tasks to run. By default all tasks of a test_procedure are run.")
     task_filter_group.add_argument(
         "--exclude-tasks",
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a test_procedure are run.")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--user-tag",
         help="Define a user-specific key-value pair (separated by ':'). It is added to each metric record as meta info. "
              "Example: intention:baseline-ticket-12345",
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--results-format",
         help="Define the output format for the command line results (default: markdown).",
         choices=["markdown", "csv"],
         default="markdown")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--results-numbers-align",
         help="Define the output column number alignment for the command line results (default: right).",
         choices=["right", "center", "left", "decimal"],
         default="right")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--show-in-results",
         help="Define which values are shown in the summary results published (default: available).",
         choices=["available", "all-percentiles", "all"],
         default="available")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--results-file",
         help="Write the command line results also to the provided file.",
         default="")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--preserve-install",
         help=f"Keep the benchmark candidate and its index. (default: {str(preserve_install).lower()}).",
         default=preserve_install,
         action="store_true")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--test-mode",
         help="Runs the given workload in 'test mode'. Meant to check a workload for errors but not for real benchmarks (default: false).",
         default=False,
         action="store_true")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--enable-worker-coordinator-profiling",
         help="Enables a profiler for analyzing the performance of calls in OSB's worker coordinator (default: false).",
         default=False,
         action="store_true")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--enable-assertions",
         help="Enables assertion checks for tasks (default: false).",
         default=False,
         action="store_true")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--kill-running-processes",
         "-k",
         action="store_true",
         default=False,
         help="If any processes is running, it is going to kill them and allow OSB to continue to run."
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--latency-percentiles",
         help=f"A comma-separated list of percentiles to report for latency "
              f"(default: {metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES}).",
         default=metrics.GlobalStatsCalculator.DEFAULT_LATENCY_PERCENTILES
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--throughput-percentiles",
         help=f"A comma-separated list of percentiles to report for throughput, in addition to mean/median/max/min "
              f"(default: {metrics.GlobalStatsCalculator.DEFAULT_THROUGHPUT_PERCENTILES}).",
         default=metrics.GlobalStatsCalculator.DEFAULT_THROUGHPUT_PERCENTILES
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--randomization-enabled",
         help="Runs the given workload with query randomization enabled (default: false).",
         default=False,
         action="store_true")
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--randomization-repeat-frequency",
         help=f"The repeat_frequency for query randomization. Ignored if randomization is off"
              f"(default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_RF)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--randomization-n",
         help=f"The number of standard values to generate for each field for query randomization."
              f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_N)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--randomization-alpha",
         help=f"The alpha parameter used for the Zipf distribution for query randomization. Low values spread the distribution out, "
              f"high values favor the most common queries. "
              f"Ignored if randomization is off (default: {workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA}).",
         default=workload.loader.QueryRandomizerWorkloadProcessor.DEFAULT_ALPHA)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--test-iterations",
         help="The number of times to run the workload (default: 1).",
         default=1)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--aggregate",
         type=lambda x: (str(x).lower() in ['true', '1', 'yes', 'y']),
-        help="Aggregate the results of multiple test runs (default: true).",
+        help="Aggregate the results of multiple test executions (default: true).",
         default=True)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--sleep-timer",
-        help="Sleep for the specified number of seconds before starting the next test run (default: 5).",
+        help="Sleep for the specified number of seconds before starting the next test execution (default: 5).",
         default=5)
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--cancel-on-error",
         action="store_true",
         help="Stop running tests if an error occurs in one of the test iterations (default: false).",
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--load-test-qps",
         help="Run a load test on your cluster, up to a certain QPS value (default: 0)",
         default=0
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-test",
         help="Run a redline test on your cluster, up to a certain QPS value (default: 1000)",
         nargs='?',
@@ -744,57 +753,57 @@ def create_arg_parser():
         default=0,  # Value to use when flag is not present
         type=int
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-scale-step",
         type=int,
         help="How many clients to add while scaling up during redline testing (default: 5).",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-scaledown-percentage",
         type=float,
         help="What percentage of clients to remove when errors occur (default: 10%%).",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-post-scaledown-sleep",
         type=int,
         help="How many seconds to wait before scaling up again after a scale down (default: 30).",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-max-clients",
         type=int,
         help="Maximum number of clients to allow during redline testing. If not set, will default to clients defined in the test procedure.",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-max-cpu-usage",
         type=int,
         help="Maximum CPU utilization before scaling back client numbers. Used to activate CPU-based feedback in OSB.",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-cpu-window-seconds",
         type=int,
         help="How many seconds the window for average CPU load should be in seconds during CPU-based redline testing. (Default: 30)",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--redline-cpu-check-interval",
         type=int,
         help="How many seconds between CPU checks there should be during CPU-based redline testing. (Default: 30)",
         default=None
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--visualize",
-        help="Generate HTML visualizations for benchmark results. Stored in the test runs directory by default",
+        help="Generate HTML visualizations for benchmark results. Stored in the test executions directory by default",
         action="store_true",
         default=False
     )
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
     "--visualize-output-path",
-    help="Path where the HTML visualization should be saved when --visualize is enabled. If not specified, it will be saved in the test run directory.",
+    help="Path where the HTML visualization should be saved when --visualize is enabled. If not specified, it will be saved in the test execution directory.",
     default=None
     )
 
@@ -805,19 +814,19 @@ def create_arg_parser():
     ###############################################################################
     # This option is intended to tell OSB to assume a different start date than 'now'. This is effectively just useful for things like
     # backtesting or a benchmark run across environments (think: comparison of EC2 and bare metal) but never for the typical user.
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--effective-start-date",
         help=argparse.SUPPRESS,
         type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
         default=None)
     # Skips checking that the REST API is available before proceeding with the benchmark
-    test_run_parser.add_argument(
+    test_execution_parser.add_argument(
         "--skip-rest-api-check",
         help=argparse.SUPPRESS,
         action="store_true",
         default=False)
 
-    for p in [list_parser, test_run_parser, compare_parser, aggregate_parser,
+    for p in [list_parser, test_execution_parser, compare_parser, aggregate_parser,
               download_parser, install_parser, start_parser, stop_parser, info_parser,
               synthetic_data_generator_parser, create_workload_parser, visualize_parser]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
@@ -846,9 +855,9 @@ def dispatch_list(cfg):
     elif what == "workloads":
         workload.list_workloads(cfg)
     elif what == "pipelines":
-        test_run_orchestrator.list_pipelines()
-    elif what == "test-runs":
-        metrics.list_test_runs(cfg)
+        test_execution_orchestrator.list_pipelines()
+    elif what in ("test-executions", "test-runs"):
+        metrics.list_test_executions(cfg)
     elif what == "aggregated-results":
         metrics.list_aggregated_results(cfg)
     elif what == "cluster-configs":
@@ -859,18 +868,18 @@ def dispatch_list(cfg):
         raise exceptions.SystemSetupError("Cannot list unknown configuration option [%s]" % what)
 
 def dispatch_visualize(cfg):
-    test_run_id = cfg.opts("system", "test_run.id")
+    test_execution_id = cfg.opts("system", "test_execution.id")
     output_path = cfg.opts("visualize", "output.path", mandatory=False, default_value=None)
-    store = metrics.test_run_store(cfg)
+    store = metrics.test_execution_store(cfg)
 
     try:
-        # load the run
-        te = store.find_by_test_run_id(test_run_id)
+        # load the test execution
+        te = store.find_by_test_execution_id(test_execution_id)
 
         # render, write, and open the HTML
         html_path = (
             store.file_store.store_html_results(te)
-            if isinstance(store, metrics.CompositeTestRunStore)
+            if isinstance(store, metrics.CompositeTestExecutionStore)
             else store.store_html_results(te)
         )
 
@@ -882,9 +891,9 @@ def dispatch_visualize(cfg):
             console.info(f"HTML report copied to: {dest}")
 
     except exceptions.NotFound:
-        raise exceptions.SystemSetupError(f"No test run with id [{test_run_id}]")
+        raise exceptions.SystemSetupError(f"No test execution with id [{test_execution_id}]")
     except Exception as e:
-        raise exceptions.SystemSetupError(f"Error visualizing test run: {e}")
+        raise exceptions.SystemSetupError(f"Error visualizing test execution: {e}")
 
 def print_help_on_errors():
     heading = "Getting further help:"
@@ -934,7 +943,7 @@ def run_test(cfg, kill_running_processes=False):
         finally:
             store.close()
 
-    with_actor_system(test_run_orchestrator.run, cfg)
+    with_actor_system(test_execution_orchestrator.run, cfg)
 
 
 def with_actor_system(runnable, cfg):
@@ -995,7 +1004,7 @@ def with_actor_system(runnable, cfg):
                 console.println("")
                 console.warn("Terminating now at the risk of leaving child processes behind.")
                 console.println("")
-                console.warn("The next test_run may fail due to an unclean shutdown.")
+                console.warn("The next test_execution may fail due to an unclean shutdown.")
                 console.println("")
                 console.println(SKULL)
                 console.println("")
@@ -1085,10 +1094,6 @@ def configure_connection_params(arg_parser, args, cfg):
     grpc_target_hosts = opts.TargetHosts(args.grpc_target_hosts) if hasattr(args, "grpc_target_hosts") and args.grpc_target_hosts else None
     cfg.add(config.Scope.applicationOverride, "client", "grpc_hosts", grpc_target_hosts)
 
-    # Configure database backend; worker_coordinator reads cfg.opts("database", "type")
-    # to pick the DatabaseClient factory via the database/ registry.
-    database_type = getattr(args, "database_type", "opensearch")
-    cfg.add(config.Scope.applicationOverride, "database", "type", database_type)
     if "timeout" not in client_options.default:
         console.info("You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.")
     if list(target_hosts.all_hosts) != list(client_options.all_client_options):
@@ -1101,29 +1106,29 @@ def configure_reporting_params(args, cfg):
     cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.results_file)
     cfg.add(config.Scope.applicationOverride, "reporting", "numbers.align", args.results_numbers_align)
 
-def prepare_test_runs_dict(args, cfg):
+def prepare_test_executions_dict(args, cfg):
     cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.results_file)
-    test_runs_dict = {}
-    if args.test_runs:
-        for run in args.test_runs:
+    test_executions_dict = {}
+    if args.test_executions:
+        for run in args.test_executions:
             run = run.strip()
             if run:
-                test_runs_dict[run] = None
-    return test_runs_dict
+                test_executions_dict[run] = None
+    return test_executions_dict
 
 def configure_test(arg_parser, args, cfg):
-    # As the run command is doing more work than necessary at the moment, we duplicate several parameters
+    # As the execute-test command is doing more work than necessary at the moment, we duplicate several parameters
     # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
-    # these duplicated parameters will vanish as we move towards dedicated subcommands and use "run" only
+    # these duplicated parameters will vanish as we move towards dedicated subcommands and use "execute-test" only
     # to run the actual benchmark (i.e. generating load).
-    print_test_run_id(args)
+    print_test_execution_id(args)
     if args.effective_start_date:
         cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)
-    cfg.add(config.Scope.applicationOverride, "system", "test_run.id", args.test_run_id)
-    # use the test-run id implicitly also as the install id.
-    cfg.add(config.Scope.applicationOverride, "system", "install.id", args.test_run_id)
-    cfg.add(config.Scope.applicationOverride, "test_run", "pipeline", args.pipeline)
-    cfg.add(config.Scope.applicationOverride, "test_run", "user.tag", args.user_tag)
+    cfg.add(config.Scope.applicationOverride, "system", "test_execution.id", args.test_execution_id)
+    # use the test-execution id implicitly also as the install id.
+    cfg.add(config.Scope.applicationOverride, "system", "install.id", args.test_execution_id)
+    cfg.add(config.Scope.applicationOverride, "test_execution", "pipeline", args.pipeline)
+    cfg.add(config.Scope.applicationOverride, "test_execution", "user.tag", args.user_tag)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "profiling", args.enable_worker_coordinator_profiling)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "assertions", args.enable_assertions)
     cfg.add(config.Scope.applicationOverride, "worker_coordinator", "on.error", args.on_error)
@@ -1166,8 +1171,8 @@ def configure_test(arg_parser, args, cfg):
 
     configure_reporting_params(args, cfg)
 
-def print_test_run_id(args):
-    console.info(f"[Test Run ID]: {args.test_run_id}")
+def print_test_execution_id(args):
+    console.info(f"[Test Execution ID]: {args.test_execution_id}")
 
 def dispatch_sub_command(arg_parser, args, cfg):
     sub_command = args.subcommand
@@ -1182,12 +1187,12 @@ def dispatch_sub_command(arg_parser, args, cfg):
             publisher.compare(cfg, args.baseline, args.contender)
         elif sub_command == "aggregate":
             configure_workload_params(arg_parser, args, cfg, command_requires_workload=False)
-            test_runs_dict = prepare_test_runs_dict(args, cfg)
-            aggregator_instance = aggregator.Aggregator(cfg, test_runs_dict, args)
+            test_executions_dict = prepare_test_executions_dict(args, cfg)
+            aggregator_instance = aggregator.Aggregator(cfg, test_executions_dict, args)
             aggregator_instance.aggregate()
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "list.test_runs.max_results", args.limit)
+            cfg.add(config.Scope.applicationOverride, "system", "list.test_executions.max_results", args.limit)
             configure_builder_params(args, cfg, command_requires_cluster_config=False)
             configure_workload_params(arg_parser, args, cfg, command_requires_workload=False)
             dispatch_list(cfg)
@@ -1213,8 +1218,8 @@ def dispatch_sub_command(arg_parser, args, cfg):
             configure_builder_params(args, cfg)
             builder.install(cfg)
         elif sub_command == "start":
-            print_test_run_id(args)
-            cfg.add(config.Scope.applicationOverride, "system", "test_run.id", args.test_run_id)
+            print_test_execution_id(args)
+            cfg.add(config.Scope.applicationOverride, "system", "test_execution.id", args.test_execution_id)
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             cfg.add(config.Scope.applicationOverride, "builder", "runtime.jdk", args.runtime_jdk)
             configure_telemetry_params(args, cfg)
@@ -1223,27 +1228,27 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "builder", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             builder.stop(cfg)
-        elif sub_command == "run":
+        elif sub_command in ("execute-test", "run", "execute"):
             iterations = int(args.test_iterations)
             if iterations > 1:
-                test_runs = []
+                test_executions = []
                 for _ in range(iterations):
                     try:
                         configure_test(arg_parser, args, cfg)
                         run_test(cfg, args.kill_running_processes)
                         time.sleep(int(args.sleep_timer))
-                        test_runs.append(args.test_run_id)
-                        args.test_run_id = str(uuid.uuid4())
+                        test_executions.append(args.test_execution_id)
+                        args.test_execution_id = str(uuid.uuid4())
                     except Exception as e:
-                        console.error(f"Error occurred during test run {_+1}: {str(e)}")
+                        console.error(f"Error occurred during test execution {_+1}: {str(e)}")
                         if args.cancel_on_error:
-                            console.info("Cancelling remaining test runs.")
+                            console.info("Cancelling remaining test executions.")
                             break
 
                 if args.aggregate:
-                    args.test_runs = test_runs
-                    test_runs_dict = prepare_test_runs_dict(args, cfg)
-                    aggregator_instance = aggregator.Aggregator(cfg, test_runs_dict, args)
+                    args.test_executions = test_executions
+                    test_executions_dict = prepare_test_executions_dict(args, cfg)
+                    aggregator_instance = aggregator.Aggregator(cfg, test_executions_dict, args)
                     aggregator_instance.aggregate()
             elif args.test_iterations == 1:
                 configure_test(arg_parser, args, cfg)
@@ -1272,7 +1277,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
             workload_generator.create_workload(cfg)
         elif sub_command == "visualize":
-            cfg.add(config.Scope.applicationOverride, "system", "test_run.id", args.test_run_id)
+            cfg.add(config.Scope.applicationOverride, "system", "test_execution.id", args.test_execution_id)
             cfg.add(config.Scope.applicationOverride, "visualize", "output.path", args.output_path)
             # Always set visualize to true for the visualize command
             cfg.add(config.Scope.applicationOverride, "workload", "visualize", True)
@@ -1309,15 +1314,17 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
 def handle_command_suggestions():
     """
-    Check for common command mistakes and provide helpful suggestions
-    Returns True if suggestion was provided, False otherwise
+    Warn when a deprecated subcommand alias is used, but let the command run.
+    'execute-test' is the primary subcommand; 'run' and 'execute' remain accepted
+    as deprecated aliases (see create_arg_parser). Returns True if a deprecation
+    warning was emitted, False otherwise.
     """
     # check-deprecated-terms-disable-1x
-    DEPRECATED_SUBCOMMANDS = ["execute-test", "execute"]
+    DEPRECATED_SUBCOMMANDS = ["run", "execute"]
     if len(sys.argv) > 1 and sys.argv[1] in DEPRECATED_SUBCOMMANDS:
-        console.info("Did you mean 'run'?")
-        console.info("Example: opensearch-benchmark run --workload=geonames --test-mode")
-        console.info("For more information, run: opensearch-benchmark run --help")
+        console.warn(f"The '{sys.argv[1]}' subcommand is deprecated; use 'execute-test' instead.")
+        console.info("Example: opensearch-benchmark execute-test --workload=geonames --test-mode")
+        console.info("For more information, run: opensearch-benchmark execute-test --help")
         return True
     return False
 
@@ -1332,9 +1339,9 @@ def main():
     # Early init of console output so we start to show everything consistently.
     console.init(quiet=False)
 
-    # Handle command suggestions before argument parsing
-    if handle_command_suggestions():
-        sys.exit(1)
+    # Emit a deprecation warning for deprecated subcommand aliases (run/execute),
+    # but still allow the command to run via the argparse aliases.
+    handle_command_suggestions()
 
     arg_parser = create_arg_parser()
     args = arg_parser.parse_args()

--- a/osbenchmark/builder/builder.py
+++ b/osbenchmark/builder/builder.py
@@ -98,7 +98,8 @@ def install(cfg):
 
 def start(cfg):
     root_path = paths.install_root(cfg)
-    test_run_id = cfg.opts("system", "test_run.id")
+    test_execution_id = cfg.opts("system", "test_execution.id", mandatory=False) \
+        or cfg.opts("system", "test_run.id")
     # avoid double-launching - we expect that the node file is absent
     with contextlib.suppress(FileNotFoundError):
         _load_node_file(root_path)
@@ -115,7 +116,7 @@ def start(cfg):
     else:
         raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
     nodes = node_launcher.start([node_config])
-    _store_node_file(root_path, (nodes, test_run_id))
+    _store_node_file(root_path, (nodes, test_execution_id))
 
 
 def stop(cfg):
@@ -128,35 +129,35 @@ def stop(cfg):
     else:
         raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
 
-    nodes, test_run_id = _load_node_file(root_path)
+    nodes, test_execution_id = _load_node_file(root_path)
 
     cls = metrics.metrics_store_class(cfg)
     metrics_store = cls(cfg)
 
-    test_run_store = metrics.test_run_store(cfg)
+    test_execution_store = metrics.test_execution_store(cfg)
     try:
-        current_test_run = test_run_store.find_by_test_run_id(test_run_id)
+        current_test_execution = test_execution_store.find_by_test_execution_id(test_execution_id)
         metrics_store.open(
-            test_run_id=current_test_run.test_run_id,
-            test_run_timestamp=current_test_run.test_run_timestamp,
-            workload_name=current_test_run.workload_name,
-            test_procedure_name=current_test_run.test_procedure_name
+            test_execution_id=current_test_execution.test_execution_id,
+            test_execution_timestamp=current_test_execution.test_execution_timestamp,
+            workload_name=current_test_execution.workload_name,
+            test_procedure_name=current_test_execution.test_procedure_name
         )
     except exceptions.NotFound:
-        logging.getLogger(__name__).info("Could not find test_run [%s] and will thus not persist system metrics.", test_run_id)
-        # Don't persist system metrics if we can't retrieve the test_run as we cannot derive the required meta-data.
-        current_test_run = None
+        logging.getLogger(__name__).info("Could not find test_execution [%s] and will thus not persist system metrics.", test_execution_id)
+        # Don't persist system metrics if we can't retrieve the test_execution as we cannot derive the required meta-data.
+        current_test_execution = None
         metrics_store = None
 
     node_launcher.stop(nodes, metrics_store)
     _delete_node_file(root_path)
 
-    if current_test_run:
+    if current_test_execution:
         metrics_store.flush(refresh=True)
         for node in nodes:
             results = metrics.calculate_system_results(metrics_store, node.node_name)
-            current_test_run.add_results(results)
-            metrics.results_store(cfg).store_results(current_test_run)
+            current_test_execution.add_results(results)
+            metrics.results_store(cfg).store_results(current_test_execution)
 
         metrics_store.close()
 
@@ -342,7 +343,7 @@ class BuilderActor(actor.BenchmarkActor):
     def __init__(self):
         super().__init__()
         self.cfg = None
-        self.test_run_orchestrator = None
+        self.test_execution_orchestrator = None
         self.cluster_launcher = None
         self.cluster = None
         self.cluster_config = None
@@ -358,7 +359,7 @@ class BuilderActor(actor.BenchmarkActor):
             return
         failmsg = "Child actor exited with [%s] while in status [%s]." % (msg, self.status)
         self.logger.error(failmsg)
-        self.send(self.test_run_orchestrator, actor.BenchmarkFailure(failmsg))
+        self.send(self.test_execution_orchestrator, actor.BenchmarkFailure(failmsg))
 
     def receiveMsg_PoisonMessage(self, msg, sender):
         self.logger.info("BuilderActor#receiveMessage poison(msg = [%s] sender = [%s])", str(msg.poisonMessage), str(sender))
@@ -368,12 +369,12 @@ class BuilderActor(actor.BenchmarkActor):
         else:
             failmsg = msg.details
         self.logger.error(failmsg)
-        self.send(self.test_run_orchestrator, actor.BenchmarkFailure(failmsg))
+        self.send(self.test_execution_orchestrator, actor.BenchmarkFailure(failmsg))
 
     @actor.no_retry("builder")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StartEngine(self, msg, sender):
         self.logger.info("Received signal from test run orchestrator to start engine.")
-        self.test_run_orchestrator = sender
+        self.test_execution_orchestrator = sender
         self.cfg = msg.cfg
         self.cluster_config, _ = load_cluster_config(self.cfg, msg.external)
         # TODO: This is implicitly set by #load_cluster_config() - can we gather this elsewhere?
@@ -428,7 +429,7 @@ class BuilderActor(actor.BenchmarkActor):
             raise exceptions.BenchmarkAssertionError("Unknown wakeup reason [{}]".format(msg.payload))
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
-        self.send(self.test_run_orchestrator, msg)
+        self.send(self.test_execution_orchestrator, msg)
 
     @actor.no_retry("builder")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StopEngine(self, msg, sender):
@@ -444,14 +445,14 @@ class BuilderActor(actor.BenchmarkActor):
         self.transition_when_all_children_responded(sender, msg, "cluster_stopping", "cluster_stopped", self.on_all_nodes_stopped)
 
     def on_all_nodes_started(self):
-        self.send(self.test_run_orchestrator, EngineStarted(self.cluster_config_revision))
+        self.send(self.test_execution_orchestrator, EngineStarted(self.cluster_config_revision))
 
     def reset_relative_time(self):
         for m in self.children:
             self.send(m, ResetRelativeTime(0))
 
     def on_all_nodes_stopped(self):
-        self.send(self.test_run_orchestrator, EngineStopped())
+        self.send(self.test_execution_orchestrator, EngineStopped())
         # clear all state as the builder might get reused later
         for m in self.children:
             self.send(m, thespian.actors.ActorExitRequest())
@@ -568,7 +569,9 @@ class NodeBuilderActor(actor.BenchmarkActor):
             cfg = config.auto_load_local_config(msg.cfg, additional_sections=[
                 # only copy the relevant bits
                 "workload", "builder", "client", "telemetry",
-                # allow metrics store to extract test_run meta-data
+                # allow metrics store to extract test_execution meta-data
+                # (copy both the reverted and pre-revert sections during migration)
+                "test_execution",
                 "test_run",
                 "source"
             ])
@@ -647,7 +650,7 @@ def load_cluster_config(cfg, external):
 
 def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_ids, sources=False, distribution=False,
            external=False, docker=False):
-    test_run_root_path = paths.test_run_root(cfg)
+    test_execution_root_path = paths.test_execution_root(cfg)
     node_ids = cfg.opts("provisioning", "node.ids", mandatory=False)
     node_name_prefix = cfg.opts("provisioning", "node.name.prefix")
     cluster_config, plugins = load_cluster_config(cfg, external)
@@ -660,7 +663,7 @@ def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_i
             node_name = "%s-%s" % (node_name_prefix, node_id)
             p.append(
                 provisioner.local(cfg, cluster_config, plugins, node_ip, node_http_port, all_node_ips,
-                                  all_node_names, test_run_root_path, node_name))
+                                  all_node_names, test_execution_root_path, node_name))
         l = launcher.ProcessLauncher(cfg)
     elif external:
         raise exceptions.BenchmarkAssertionError("Externally provisioned clusters should not need to be managed by OSB's builder")
@@ -672,7 +675,7 @@ def create(cfg, metrics_store, node_ip, node_http_port, all_node_ips, all_node_i
         p = []
         for node_id in node_ids:
             node_name = "%s-%s" % (node_name_prefix, node_id)
-            p.append(provisioner.docker(cfg, cluster_config, node_ip, node_http_port, test_run_root_path, node_name))
+            p.append(provisioner.docker(cfg, cluster_config, node_ip, node_http_port, test_execution_root_path, node_name))
         l = launcher.DockerLauncher(cfg)
     else:
         # It is a programmer error (and not a user error) if this function is called with wrong parameters
@@ -719,9 +722,9 @@ class Builder:
         self.launcher.stop(self.nodes, self.metrics_store)
         self.flush_metrics(refresh=True)
         try:
-            current_test_run = self._current_test_run()
+            current_test_execution = self._current_test_execution()
             for node in self.nodes:
-                self._add_results(current_test_run, node)
+                self._add_results(current_test_execution, node)
         except exceptions.NotFound as e:
             self.logger.warning("Cannot store system metrics: %s.", str(e))
 
@@ -733,11 +736,12 @@ class Builder:
                                 data_paths=node_config.data_paths)
         self.node_configs = []
 
-    def _current_test_run(self):
-        test_run_id = self.cfg.opts("system", "test_run.id")
-        return metrics.test_run_store(self.cfg).find_by_test_run_id(test_run_id)
+    def _current_test_execution(self):
+        test_execution_id = self.cfg.opts("system", "test_execution.id", mandatory=False) \
+            or self.cfg.opts("system", "test_run.id")
+        return metrics.test_execution_store(self.cfg).find_by_test_execution_id(test_execution_id)
 
-    def _add_results(self, current_test_run, node):
+    def _add_results(self, current_test_execution, node):
         results = metrics.calculate_system_results(self.metrics_store, node.node_name)
-        current_test_run.add_results(results)
-        metrics.results_store(self.cfg).store_results(current_test_run)
+        current_test_execution.add_results(results)
+        metrics.results_store(self.cfg).store_results(current_test_execution)

--- a/osbenchmark/builder/installers/docker_installer.py
+++ b/osbenchmark/builder/installers/docker_installer.py
@@ -31,7 +31,7 @@ class DockerInstaller(Installer):
     def _create_node(self):
         node_name = str(uuid.uuid4())
         node_port = int(self.cluster_config.variables["node"]["port"])
-        node_root_dir = os.path.join(self.cluster_config.variables["test_run_root"], node_name)
+        node_root_dir = os.path.join(self.cluster_config.variables["test_execution_root"], node_name)
         node_data_paths = [os.path.join(node_root_dir, "data", str(uuid.uuid4()))]
         node_binary_path = os.path.join(node_root_dir, "install")
         node_log_dir = os.path.join(node_root_dir, "logs", "server")

--- a/osbenchmark/builder/installers/preparers/opensearch_preparer.py
+++ b/osbenchmark/builder/installers/preparers/opensearch_preparer.py
@@ -29,7 +29,7 @@ class OpenSearchPreparer(Preparer):
     def _create_node(self):
         node_name = str(uuid.uuid4())
         node_port = int(self.cluster_config.variables["node"]["port"])
-        node_root_dir = os.path.join(self.cluster_config.variables["test_run_root"], node_name)
+        node_root_dir = os.path.join(self.cluster_config.variables["test_execution_root"], node_name)
         node_binary_path = os.path.join(node_root_dir, "install")
         node_log_dir = os.path.join(node_root_dir, "logs", "server")
         node_heap_dump_dir = os.path.join(node_root_dir, "heapdump")

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -30,10 +30,6 @@ import opensearchpy
 import urllib3
 from urllib3.util.ssl_ import is_ipaddress
 
-import grpc
-from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub
-from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub
-
 from osbenchmark.kafka_client import KafkaMessageProducer
 from osbenchmark import exceptions, doc_link, async_connection
 from osbenchmark.context import RequestContextHolder
@@ -303,6 +299,14 @@ class GrpcClientFactory:
         Create gRPC service stubs.
         Returns a dict of {cluster_name: {service_name: stub}} structure.
         """
+        # Import grpc and protobuf stubs lazily — loading the grpc C extension
+        # initializes background threads. If that happens in the main process
+        # before Thespian forks actor children, the forked processes inherit
+        # broken gRPC thread state and may deadlock.
+        import grpc  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.document_service_pb2_grpc import DocumentServiceStub  # pylint: disable=import-outside-toplevel
+        from opensearch.protobufs.services.search_service_pb2_grpc import SearchServiceStub  # pylint: disable=import-outside-toplevel
+
         stubs = {}
 
         if len(self.grpc_hosts.all_hosts.items()) > 1:

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -1481,13 +1481,19 @@ class TestExecution:
         test_execution_id = d["test-execution-id"] if "test-execution-id" in d else d["test-run-id"]
         test_execution_timestamp = d["test-execution-timestamp"] if "test-execution-timestamp" in d \
             else d["test-run-timestamp"]
+        # back-compat: accept the pre-2.x provision-config-* field names (1.x vocab) as
+        # fallbacks for the reverted cluster-config-* names. Explicit "in" on the required
+        # config-instance field so a doc missing BOTH still raises KeyError (matches id/timestamp).
+        cluster_config = d["cluster-config-instance"] if "cluster-config-instance" in d \
+            else d["provision-config-instance"]
+        cluster_config_params = d.get("cluster-config-instance-params", d.get("provision-config-instance-params"))
         return TestExecution(d["benchmark-version"], d.get("benchmark-revision"), d["environment"], test_execution_id,
                     time.from_is8601(test_execution_timestamp),
                     d["pipeline"], user_tags, d["workload"], d.get("workload-params"),
-                    d.get("test_procedure"), d["cluster-config-instance"],
-                    d.get("cluster-config-instance-params"), d.get("plugin-params"),
+                    d.get("test_procedure"), cluster_config,
+                    cluster_config_params, d.get("plugin-params"),
                     workload_revision=d.get("workload-revision"),
-                    cluster_config_revision=cluster.get("cluster-config-revision"),
+                    cluster_config_revision=cluster.get("cluster-config-revision", cluster.get("provision-config-revision")),
                     distribution_version=cluster.get("distribution-version"),
                     distribution_flavor=cluster.get("distribution-flavor"),
                     revision=cluster.get("revision"), results=d.get("results"), meta_data=d.get("meta", {}))
@@ -1619,12 +1625,23 @@ class FileTestExecutionStore(TestExecutionStore):
         else:
             return os.path.join(root_dir, "test-runs", glob_id, "test_run.json")
 
+    def _legacy_1x_test_execution_file(self, test_execution_id=None, is_aggregated=False):
+        # back-compat read-only helper for the 1.x on-disk layout
+        # (test_executions/ UNDERSCORE dir + test_execution.json). Only the
+        # individual-run directory name differs from the reverted layout; 1.x
+        # aggregated results already match the canonical aggregated_test_execution.json
+        # path, so no aggregated branch is added here. Nothing writes to this path.
+        root_dir = self.cfg.opts("node", "root.dir")
+        glob_id = test_execution_id if test_execution_id else "*"
+        return os.path.join(root_dir, "test_executions", glob_id, "test_execution.json")
+
     def list(self):
-        # back-compat: glob BOTH the reverted (test-executions/*/test_execution.json)
-        # and the pre-revert (test-runs/*/test_run.json) layouts so historical
-        # runs stay listable.
+        # back-compat: glob the reverted (test-executions/*/test_execution.json), the
+        # pre-revert 2.x (test-runs/*/test_run.json), and the 1.x underscore
+        # (test_executions/*/test_execution.json) layouts so historical runs stay listable.
         results = glob.glob(self._test_execution_file(test_execution_id="*")) + \
-            glob.glob(self._legacy_test_run_file(test_execution_id="*"))
+            glob.glob(self._legacy_test_run_file(test_execution_id="*")) + \
+            glob.glob(self._legacy_1x_test_execution_file(test_execution_id="*"))
         all_test_executions = self._to_test_executions(results)
         return all_test_executions[:self._max_results()]
 
@@ -1639,7 +1656,8 @@ class FileTestExecutionStore(TestExecutionStore):
         # back-compat: look up the reverted layout first, then fall back to the
         # pre-revert on-disk file so historical runs remain retrievable.
         for candidate in (self._test_execution_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated),
-                          self._legacy_test_run_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated)):
+                          self._legacy_test_run_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated),
+                          self._legacy_1x_test_execution_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated)):
             if io.exists(candidate):
                 test_executions = self._to_test_executions([candidate])
                 if test_executions:

--- a/osbenchmark/metrics.py
+++ b/osbenchmark/metrics.py
@@ -247,8 +247,8 @@ class IndexTemplateProvider:
     def metrics_template(self):
         return self._read("metrics-template")
 
-    def test_runs_template(self):
-        return self._read("test-runs-template")
+    def test_executions_template(self):
+        return self._read("test-executions-template")
 
     def results_template(self):
         return self._read("results-template")
@@ -283,13 +283,13 @@ class MetaInfoScope(Enum):
     """
 
 
-def calculate_results(store, test_run):
+def calculate_results(store, test_execution):
     calc = GlobalStatsCalculator(
         store,
-        test_run.workload,
-        test_run.test_procedure,
-        latency_percentiles=test_run.latency_percentiles,
-        throughput_percentiles=test_run.throughput_percentiles
+        test_execution.workload,
+        test_execution.test_procedure,
+        latency_percentiles=test_execution.latency_percentiles,
+        throughput_percentiles=test_execution.throughput_percentiles
         )
     return calc()
 
@@ -311,13 +311,16 @@ def metrics_store(cfg, read_only=True, workload=None, test_procedure=None, clust
     store = cls(cfg=cfg, meta_info=meta_info)
     logging.getLogger(__name__).info("Creating %s", str(store))
 
-    test_run_id = cfg.opts("system", "test_run.id")
-    test_run_timestamp = cfg.opts("system", "time.start")
+    # Phase B: prefer the reverted internal cfg key, fall back to the pre-revert
+    # key so the tree stays runnable until the CLI producer flips.
+    test_execution_id = cfg.opts("system", "test_execution.id", mandatory=False) \
+        or cfg.opts("system", "test_run.id")
+    test_execution_timestamp = cfg.opts("system", "time.start")
     selected_cluster_config = cfg.opts("builder", "cluster_config.names") \
         if cluster_config is None else cluster_config
 
     store.open(
-        test_run_id, test_run_timestamp,
+        test_execution_id, test_execution_timestamp,
         workload, test_procedure, selected_cluster_config,
         create=not read_only)
     return store
@@ -337,7 +340,10 @@ def extract_user_tags_from_config(cfg):
     :param cfg: The current configuration object.
     :return: A dict containing user tags. If no user tags are given, an empty dict is returned.
     """
-    user_tags = cfg.opts("test_run", "user.tag", mandatory=False)
+    # Phase B: prefer the reverted config section, fall back to the pre-revert
+    # section so the tree stays runnable until the CLI producer flips.
+    user_tags = cfg.opts("test_execution", "user.tag", mandatory=False) \
+        or cfg.opts("test_run", "user.tag", mandatory=False)
     return extract_user_tags_from_string(user_tags)
 
 
@@ -380,8 +386,8 @@ class MetricsStore:
         :param meta_info: This parameter is optional and intended for creating a metrics store with a previously serialized meta-info.
         """
         self._config = cfg
-        self._test_run_id = None
-        self._test_run_timestamp = None
+        self._test_execution_id = None
+        self._test_execution_timestamp = None
         self._workload = None
         self._workload_params = cfg.opts("workload", "params", default_value={}, mandatory=False)
         self._test_procedure = None
@@ -402,14 +408,14 @@ class MetricsStore:
         self._stop_watch = self._clock.stop_watch()
         self.logger = logging.getLogger(__name__)
 
-    def open(self, test_run_id=None, test_run_timestamp=None, workload_name=None,\
+    def open(self, test_execution_id=None, test_execution_timestamp=None, workload_name=None,\
          test_procedure_name=None, cluster_config_name=None, ctx=None,\
          create=False):
         """
-        Opens a metrics store for a specific test_run, workload, test_procedure and cluster_config.
+        Opens a metrics store for a specific test_execution, workload, test_procedure and cluster_config.
 
-        :param test_run_id: The test run id. This attribute is sufficient to uniquely identify a test_run.
-        :param test_run_timestamp: The test run timestamp as a datetime.
+        :param test_execution_id: The test execution id. This attribute is sufficient to uniquely identify a test_execution.
+        :param test_execution_timestamp: The test execution timestamp as a datetime.
         :param workload_name: Workload name.
         :param test_procedure_name: TestProcedure name.
         :param cluster_config_name: ClusterConfigInstance name.
@@ -418,19 +424,21 @@ class MetricsStore:
         False when it is just opened for reading (as we can assume all necessary indices exist at this point).
         """
         if ctx:
-            self._test_run_id = ctx["test-run-id"]
-            self._test_run_timestamp = ctx["test-run-timestamp"]
+            # back-compat: accept both 3.x test-execution-id and pre-3.x test-run-id.
+            self._test_execution_id = ctx["test-execution-id"] if "test-execution-id" in ctx else ctx["test-run-id"]
+            self._test_execution_timestamp = ctx["test-execution-timestamp"] if "test-execution-timestamp" in ctx \
+                else ctx["test-run-timestamp"]
             self._workload = ctx["workload"]
             self._test_procedure = ctx["test_procedure"]
             self._cluster_config = ctx["cluster-config-instance"]
         else:
-            self._test_run_id = test_run_id
-            self._test_run_timestamp = time.to_iso8601(test_run_timestamp)
+            self._test_execution_id = test_execution_id
+            self._test_execution_timestamp = time.to_iso8601(test_execution_timestamp)
             self._workload = workload_name
             self._test_procedure = test_procedure_name
             self._cluster_config = cluster_config_name
-        assert self._test_run_id is not None, "Attempting to open metrics store without a test run id"
-        assert self._test_run_timestamp is not None, "Attempting to open metrics store without a test run timestamp"
+        assert self._test_execution_id is not None, "Attempting to open metrics store without a test run id"
+        assert self._test_execution_timestamp is not None, "Attempting to open metrics store without a test run timestamp"
 
         self._cluster_config_name = "+".join(self._cluster_config) \
             if isinstance(self._cluster_config, list) \
@@ -438,7 +446,7 @@ class MetricsStore:
 
         self.logger.info("Opening metrics store for test run timestamp=[%s], workload=[%s],"
         "test_procedure=[%s], cluster_config=[%s]",
-                         self._test_run_timestamp, self._workload, self._test_procedure, self._cluster_config)
+                         self._test_execution_timestamp, self._workload, self._test_procedure, self._cluster_config)
 
         user_tags = extract_user_tags_from_config(self._config)
         for k, v in user_tags.items():
@@ -503,8 +511,8 @@ class MetricsStore:
     @property
     def open_context(self):
         return {
-            "test-run-id": self._test_run_id,
-            "test-run-timestamp": self._test_run_timestamp,
+            "test-execution-id": self._test_execution_id,
+            "test-execution-timestamp": self._test_execution_timestamp,
             "workload": self._workload,
             "test_procedure": self._test_procedure,
             "cluster-config-instance": self._cluster_config
@@ -574,8 +582,8 @@ class MetricsStore:
         doc = {
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time-ms": convert.seconds_to_ms(relative_time),
-            "test-run-id": self._test_run_id,
-            "test-run-timestamp": self._test_run_timestamp,
+            "test-execution-id": self._test_execution_id,
+            "test-execution-timestamp": self._test_execution_timestamp,
             "environment": self._environment_name,
             "workload": self._workload,
             "test_procedure": self._test_procedure,
@@ -631,8 +639,8 @@ class MetricsStore:
         doc.update({
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time-ms": convert.seconds_to_ms(relative_time),
-            "test-run-id": self._test_run_id,
-            "test-run-timestamp": self._test_run_timestamp,
+            "test-execution-id": self._test_execution_id,
+            "test-execution-timestamp": self._test_execution_timestamp,
             "environment": self._environment_name,
             "workload": self._workload,
             "test_procedure": self._test_procedure,
@@ -823,12 +831,12 @@ class OsMetricsStore(MetricsStore):
         self._index_template_provider = index_template_provider_class(cfg)
         self._docs = None
 
-    def open(self, test_run_id=None, test_run_timestamp=None, workload_name=None, \
+    def open(self, test_execution_id=None, test_execution_timestamp=None, workload_name=None, \
         test_procedure_name=None, cluster_config_name=None, ctx=None, \
         create=False):
         self._docs = []
         MetricsStore.open(
-            self, test_run_id, test_run_timestamp,
+            self, test_execution_id, test_execution_timestamp,
             workload_name, test_procedure_name,
             cluster_config_name, ctx, create)
         self._index = self.index_name()
@@ -850,7 +858,7 @@ class OsMetricsStore(MetricsStore):
         self._client.refresh(index=self._index)
 
     def index_name(self):
-        ts = time.from_is8601(self._test_run_timestamp)
+        ts = time.from_is8601(self._test_execution_timestamp)
         return "benchmark-metrics-%04d-%02d" % (ts.year, ts.month)
 
     def _migrated_index_name(self, original_name):
@@ -867,7 +875,7 @@ class OsMetricsStore(MetricsStore):
             sw.stop()
             self.logger.info("Successfully added %d metrics documents for test run timestamp=[%s], workload=[%s], "
                              "test_procedure=[%s], cluster_config=[%s] in [%f] seconds.",
-                             len(self._docs), self._test_run_timestamp,
+                             len(self._docs), self._test_execution_timestamp,
                              self._workload, self._test_procedure, self._cluster_config, sw.total_time())
         self._docs = []
         # ensure we can search immediately after flushing
@@ -997,8 +1005,14 @@ class OsMetricsStore(MetricsStore):
             "bool": {
                 "filter": [
                     {
-                        "term": {
-                            "test-run-id": self._test_run_id
+                        # back-compat: match docs written with either 3.x test-execution-id
+                        # or pre-3.x test-run-id (fields cannot be aliased without reindex).
+                        "bool": {
+                            "should": [
+                                {"term": {"test-execution-id": self._test_execution_id}},
+                                {"term": {"test-run-id": self._test_execution_id}}
+                            ],
+                            "minimum_should_match": 1
                         }
                     },
                     {
@@ -1044,8 +1058,8 @@ class OsMetricsStore(MetricsStore):
         return self._index
 
     @property
-    def test_run_id(self) -> str:
-        return self._test_run_id
+    def test_execution_id(self) -> str:
+        return self._test_execution_id
 
     def __str__(self):
         return "OpenSearch metrics store"
@@ -1204,26 +1218,26 @@ class InMemoryMetricsStore(MetricsStore):
         return "in-memory metrics store"
 
 
-def test_run_store(cfg):
+def test_execution_store(cfg):
     """
-    Creates a proper test_run store based on the current configuration.
+    Creates a proper test_execution store based on the current configuration.
     :param cfg: Config object. Mandatory.
-    :return: A test_run store implementation.
+    :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
     if cfg.opts("reporting", "datastore.type") == "opensearch":
-        logger.info("Creating OS test run store")
-        return CompositeTestRunStore(OsTestRunStore(cfg), FileTestRunStore(cfg))
+        logger.info("Creating OS test execution store")
+        return CompositeTestExecutionStore(OsTestExecutionStore(cfg), FileTestExecutionStore(cfg))
     else:
-        logger.info("Creating file test_run store")
-        return FileTestRunStore(cfg)
+        logger.info("Creating file test execution store")
+        return FileTestExecutionStore(cfg)
 
 
 def results_store(cfg):
     """
-    Creates a proper test_run store based on the current configuration.
+    Creates a proper test_execution store based on the current configuration.
     :param cfg: Config object. Mandatory.
-    :return: A test_run store implementation.
+    :return: A test_execution store implementation.
     """
     logger = logging.getLogger(__name__)
     if cfg.opts("reporting", "datastore.type") == "opensearch":
@@ -1242,26 +1256,26 @@ def list_test_helper(store_item, title):
         else:
             return None
 
-    test_runs = []
-    for test_run in store_item:
-        test_runs.append([
-            test_run.test_run_id,
-            time.to_iso8601(test_run.test_run_timestamp),
-            test_run.workload,
-            format_dict(test_run.workload_params),
-            test_run.test_procedure_name,
-            test_run.cluster_config_name,
-            format_dict(test_run.user_tags),
-            test_run.workload_revision,
-            test_run.cluster_config_revision])
+    test_executions = []
+    for test_execution in store_item:
+        test_executions.append([
+            test_execution.test_execution_id,
+            time.to_iso8601(test_execution.test_execution_timestamp),
+            test_execution.workload,
+            format_dict(test_execution.workload_params),
+            test_execution.test_procedure_name,
+            test_execution.cluster_config_name,
+            format_dict(test_execution.user_tags),
+            test_execution.workload_revision,
+            test_execution.cluster_config_revision])
 
-    if len(test_runs) > 0:
+    if len(test_executions) > 0:
         console.println(f"\nRecent {title}:\n")
         console.println(tabulate.tabulate(
-            test_runs,
+            test_executions,
             headers=[
-                "TestRun ID",
-                "TestRun Timestamp",
+                "TestExecution ID",
+                "TestExecution Timestamp",
                 "Workload",
                 "Workload Parameters",
                 "TestProcedure",
@@ -1274,19 +1288,23 @@ def list_test_helper(store_item, title):
         console.println("")
         console.println(f"No recent {title} found.")
 
-def list_test_runs(cfg):
-    list_test_helper(test_run_store(cfg).list(), "test-runs")
+def list_test_executions(cfg):
+    list_test_helper(test_execution_store(cfg).list(), "test-executions")
 
 def list_aggregated_results(cfg):
-    list_test_helper(test_run_store(cfg).list_aggregations(), "aggregated-results")
+    list_test_helper(test_execution_store(cfg).list_aggregations(), "aggregated-results")
 
-def create_test_run(cfg, workload, test_procedure, workload_revision=None):
+def create_test_execution(cfg, workload, test_procedure, workload_revision=None):
     cluster_config = cfg.opts("builder", "cluster_config.names")
     environment = cfg.opts("system", "env.name")
-    test_run_id = cfg.opts("system", "test_run.id")
-    test_run_timestamp = cfg.opts("system", "time.start")
+    # Phase B: prefer the reverted internal cfg keys, fall back to the pre-revert
+    # keys so the tree stays runnable until the CLI producer flips.
+    test_execution_id = cfg.opts("system", "test_execution.id", mandatory=False) \
+        or cfg.opts("system", "test_run.id")
+    test_execution_timestamp = cfg.opts("system", "time.start")
     user_tags = extract_user_tags_from_config(cfg)
-    pipeline = cfg.opts("test_run", "pipeline")
+    pipeline = cfg.opts("test_execution", "pipeline", mandatory=False) \
+        or cfg.opts("test_run", "pipeline")
     workload_params = cfg.opts("workload", "params")
     cluster_config_params = cfg.opts("builder", "cluster_config.params")
     plugin_params = cfg.opts("builder", "plugin.params")
@@ -1299,17 +1317,17 @@ def create_test_run(cfg, workload, test_procedure, workload_revision=None):
     # In tests, we don't get the default command-line arg value for percentiles,
     # so supply them as defaults here as well
 
-    return TestRun(benchmark_version, benchmark_revision,
-    environment, test_run_id, test_run_timestamp,
+    return TestExecution(benchmark_version, benchmark_revision,
+    environment, test_execution_id, test_execution_timestamp,
     pipeline, user_tags, workload,
     workload_params, test_procedure, cluster_config, cluster_config_params,
     plugin_params, workload_revision, latency_percentiles=latency_percentiles,
     throughput_percentiles=throughput_percentiles)
 
 
-class TestRun:
+class TestExecution:
     def __init__(self, benchmark_version, benchmark_revision, environment_name,
-                 test_run_id, test_run_timestamp, pipeline, user_tags,
+                 test_execution_id, test_execution_timestamp, pipeline, user_tags,
                  workload, workload_params, test_procedure, cluster_config,
                  cluster_config_params, plugin_params,
                  workload_revision=None, cluster_config_revision=None,
@@ -1332,8 +1350,8 @@ class TestRun:
         self.benchmark_version = benchmark_version
         self.benchmark_revision = benchmark_revision
         self.environment_name = environment_name
-        self.test_run_id = test_run_id
-        self.test_run_timestamp = test_run_timestamp
+        self.test_execution_id = test_execution_id
+        self.test_execution_timestamp = test_execution_timestamp
         self.pipeline = pipeline
         self.user_tags = user_tags
         self.workload = workload
@@ -1378,8 +1396,8 @@ class TestRun:
             "benchmark-version": self.benchmark_version,
             "benchmark-revision": self.benchmark_revision,
             "environment": self.environment_name,
-            "test-run-id": self.test_run_id,
-            "test-run-timestamp": time.to_iso8601(self.test_run_timestamp),
+            "test-execution-id": self.test_execution_id,
+            "test-execution-timestamp": time.to_iso8601(self.test_execution_timestamp),
             "pipeline": self.pipeline,
             "user-tags": self.user_tags,
             "workload": self.workload_name,
@@ -1418,8 +1436,8 @@ class TestRun:
             "benchmark-version": self.benchmark_version,
             "benchmark-revision": self.benchmark_revision,
             "environment": self.environment_name,
-            "test-run-id": self.test_run_id,
-            "test-run-timestamp": time.to_iso8601(self.test_run_timestamp),
+            "test-execution-id": self.test_execution_id,
+            "test-execution-timestamp": time.to_iso8601(self.test_execution_timestamp),
             "distribution-version": self.distribution_version,
             "distribution-flavor": self.distribution_flavor,
             "user-tags": self.user_tags,
@@ -1458,8 +1476,13 @@ class TestRun:
         user_tags = d.get("user-tags", {})
         # TODO: cluster is optional for BWC. This can be removed after some grace period.
         cluster = d.get("cluster", {})
-        return TestRun(d["benchmark-version"], d.get("benchmark-revision"), d["environment"], d["test-run-id"],
-                    time.from_is8601(d["test-run-timestamp"]),
+        # back-compat: accept both 3.x test-execution-id and pre-3.x test-run-id.
+        # Explicit "in" checks (not .get) so a doc missing BOTH keys still raises KeyError.
+        test_execution_id = d["test-execution-id"] if "test-execution-id" in d else d["test-run-id"]
+        test_execution_timestamp = d["test-execution-timestamp"] if "test-execution-timestamp" in d \
+            else d["test-run-timestamp"]
+        return TestExecution(d["benchmark-version"], d.get("benchmark-revision"), d["environment"], test_execution_id,
+                    time.from_is8601(test_execution_timestamp),
                     d["pipeline"], user_tags, d["workload"], d.get("workload-params"),
                     d.get("test_procedure"), d["cluster-config-instance"],
                     d.get("cluster-config-instance-params"), d.get("plugin-params"),
@@ -1470,86 +1493,86 @@ class TestRun:
                     revision=cluster.get("revision"), results=d.get("results"), meta_data=d.get("meta", {}))
 
 
-class TestRunStore:
+class TestExecutionStore:
     def __init__(self, cfg):
         self.cfg = cfg
         self.environment_name = cfg.opts("system", "env.name")
 
-    def find_by_test_run_id(self, test_run_id):
+    def find_by_test_execution_id(self, test_execution_id):
         raise NotImplementedError("abstract method")
 
     def list(self):
         raise NotImplementedError("abstract method")
 
-    def store_test_run(self, test_run):
+    def store_test_execution(self, test_execution):
         raise NotImplementedError("abstract method")
 
     def _max_results(self):
-        return int(self.cfg.opts("system", "list.test_runs.max_results"))
+        # Phase B: prefer the reverted internal cfg key, fall back to the
+        # pre-revert key so the tree stays runnable until the CLI producer flips.
+        return int(self.cfg.opts("system", "list.test_executions.max_results", mandatory=False)
+                   or self.cfg.opts("system", "list.test_runs.max_results"))
 
 
-# Does not inherit from TestRunStore as it is only a delegator with the same API.
-class CompositeTestRunStore:
+# Does not inherit from TestExecutionStore as it is only a delegator with the same API.
+class CompositeTestExecutionStore:
     """
-    Internal helper class to store test runs as file and to OpenSearch in case users
-    want OpenSearch as a test runs store.
+    Internal helper class to store test executions as file and to OpenSearch in case users
+    want OpenSearch as a test executions store.
 
-    It provides the same API as TestRunStore. It delegates writes to all stores
-    and all read operations only the OpenSearch test run store.
+    It provides the same API as TestExecutionStore. It delegates writes to all stores
+    and all read operations only the OpenSearch test execution store.
     """
     def __init__(self, os_store, file_store):
         self.os_store = os_store
         self.file_store = file_store
 
-    def find_by_test_run_id(self, test_run_id):
-        return self.os_store.find_by_test_run_id(test_run_id)
+    def find_by_test_execution_id(self, test_execution_id):
+        return self.os_store.find_by_test_execution_id(test_execution_id)
 
-    def store_test_run(self, test_run):
-        self.file_store.store_test_run(test_run)
-        self.os_store.store_test_run(test_run)
+    def store_test_execution(self, test_execution):
+        self.file_store.store_test_execution(test_execution)
+        self.os_store.store_test_execution(test_execution)
 
-    def store_html_results(self, test_run):
-        self.file_store.store_html_results(test_run)
+    def store_html_results(self, test_execution):
+        self.file_store.store_html_results(test_execution)
 
     def list(self):
         return self.os_store.list()
 
 
-class FileTestRunStore(TestRunStore):
+class FileTestExecutionStore(TestExecutionStore):
     _browser_opened = {}
 
-    def __init__(self, cfg):
-        super().__init__(cfg)
-        self._max_results = lambda: int(cfg.opts("system", "list.test_runs.max_results"))
-    def store_test_run(self, test_run):
+    def store_test_execution(self, test_execution):
         open_browser = False
-        doc = test_run.as_dict()
-        test_run_path = paths.test_run_root(self.cfg, test_run_id=test_run.test_run_id)
-        io.ensure_dir(test_run_path)
-        with open(self._test_run_file(), mode="wt", encoding="utf-8") as f:
+        doc = test_execution.as_dict()
+        test_execution_path = paths.test_execution_root(self.cfg, test_execution_id=test_execution.test_execution_id)
+        io.ensure_dir(test_execution_path)
+        with open(self._test_execution_file(), mode="wt", encoding="utf-8") as f:
             f.write(json.dumps(doc, indent=True, ensure_ascii=False))
 
         # Check if visualization is enabled
         if self.cfg.opts("workload", "visualize", mandatory=False, default_value=False):
             # Reset the browser opened flag when we're storing the final results
-            if hasattr(test_run, "results") and test_run.results:
-                FileTestRunStore._browser_opened[test_run.test_run_id] = False
+            if hasattr(test_execution, "results") and test_execution.results:
+                FileTestExecutionStore._browser_opened[test_execution.test_execution_id] = False
                 open_browser = True
-            self.store_html_results(test_run, open_browser)
+            self.store_html_results(test_execution, open_browser)
 
-    def store_aggregated_run(self, test_run):
-        doc = test_run.as_dict()
-        aggregated_execution_path = paths.aggregated_results_root(self.cfg, test_run_id=test_run.test_run_id)
+    def store_aggregated_test_execution(self, test_execution):
+        doc = test_execution.as_dict()
+        aggregated_execution_path = paths.aggregated_results_root(self.cfg, test_execution_id=test_execution.test_execution_id)
         io.ensure_dir(aggregated_execution_path)
-        aggregated_file = os.path.join(aggregated_execution_path, "aggregated_test_run.json")
+        aggregated_file = os.path.join(aggregated_execution_path, "aggregated_test_execution.json")
         with open(aggregated_file, mode="wt", encoding="utf-8") as f:
             f.write(json.dumps(doc, indent=True, ensure_ascii=False))
 
-    def store_html_results(self, test_run, open_browser=True):
+    def store_html_results(self, test_execution, open_browser=True):
         # Check if custom output path is specified
         custom_output_path = self.cfg.opts("workload", "visualize.output.path", mandatory=False, default_value=None)
 
-        html_content = render_results_html(test_run, self.cfg)
+        html_content = render_results_html(test_execution, self.cfg)
 
         if custom_output_path:
             dest = os.path.expanduser(custom_output_path)
@@ -1563,7 +1586,9 @@ class FileTestRunStore(TestRunStore):
             return dest
         else:
             # Use default behavior
-            report_file = os.path.join(paths.test_run_root(self.cfg, test_run_id=test_run.test_run_id), "test_run_report.html")
+            report_file = os.path.join(
+                paths.test_execution_root(self.cfg, test_execution_id=test_execution.test_execution_id),
+                "test_execution_report.html")
             print("[DEBUG]: ", report_file)
             with open(report_file, mode="w", encoding="utf-8") as f:
                 f.write(html_content)
@@ -1572,46 +1597,79 @@ class FileTestRunStore(TestRunStore):
             console.info(f"HTML report saved to: {report_file}")
             return report_file
 
-    def _test_run_file(self, test_run_id=None, is_aggregated=False):
+    def _test_execution_file(self, test_execution_id=None, is_aggregated=False):
+        # Canonical (3.X-reverted) on-disk layout: test-executions/ dir +
+        # test_execution.json / aggregated_test_execution.json. Used for both
+        # WRITE and new-layout read.
         if is_aggregated:
-            return os.path.join(paths.aggregated_results_root(cfg=self.cfg, test_run_id=test_run_id),
-                                "aggregated_test_run.json")
+            return os.path.join(paths.aggregated_results_root(cfg=self.cfg, test_execution_id=test_execution_id),
+                                "aggregated_test_execution.json")
         else:
-            return os.path.join(paths.test_run_root(cfg=self.cfg, test_run_id=test_run_id), "test_run.json")
+            return os.path.join(paths.test_execution_root(cfg=self.cfg, test_execution_id=test_execution_id),
+                                "test_execution.json")
+
+    def _legacy_test_run_file(self, test_execution_id=None, is_aggregated=False):
+        # back-compat read-only helper for the pre-revert on-disk layout
+        # (test-runs/ dir + test_run.json / aggregated_test_run.json). This only
+        # widens read globs so historical runs stay listable; nothing writes here.
+        root_dir = self.cfg.opts("node", "root.dir")
+        glob_id = test_execution_id if test_execution_id else "*"
+        if is_aggregated:
+            return os.path.join(root_dir, "aggregated_results", glob_id, "aggregated_test_run.json")
+        else:
+            return os.path.join(root_dir, "test-runs", glob_id, "test_run.json")
 
     def list(self):
-        results = glob.glob(self._test_run_file(test_run_id="*"))
-        all_test_runs = self._to_test_runs(results)
-        return all_test_runs[:self._max_results()]
+        # back-compat: glob BOTH the reverted (test-executions/*/test_execution.json)
+        # and the pre-revert (test-runs/*/test_run.json) layouts so historical
+        # runs stay listable.
+        results = glob.glob(self._test_execution_file(test_execution_id="*")) + \
+            glob.glob(self._legacy_test_run_file(test_execution_id="*"))
+        all_test_executions = self._to_test_executions(results)
+        return all_test_executions[:self._max_results()]
 
     def list_aggregations(self):
-        aggregated_results = glob.glob(self._test_run_file(test_run_id="*", is_aggregated=True))
-        return self._to_test_runs(aggregated_results)
+        # back-compat: glob both reverted aggregated_test_execution.json and pre-revert aggregated_test_run.json.
+        aggregated_results = glob.glob(self._test_execution_file(test_execution_id="*", is_aggregated=True)) + \
+            glob.glob(self._legacy_test_run_file(test_execution_id="*", is_aggregated=True))
+        return self._to_test_executions(aggregated_results)
 
-    def find_by_test_run_id(self, test_run_id):
-        is_aggregated = test_run_id.startswith('aggregate')
-        test_run_file = self._test_run_file(test_run_id=test_run_id, is_aggregated=is_aggregated)
-        if io.exists(test_run_file):
-            test_runs = self._to_test_runs([test_run_file])
-            if test_runs:
-                return test_runs[0]
-        raise exceptions.NotFound("No test run with test run id [{}]".format(test_run_id))
+    def find_by_test_execution_id(self, test_execution_id):
+        is_aggregated = test_execution_id.startswith('aggregate')
+        # back-compat: look up the reverted layout first, then fall back to the
+        # pre-revert on-disk file so historical runs remain retrievable.
+        for candidate in (self._test_execution_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated),
+                          self._legacy_test_run_file(test_execution_id=test_execution_id, is_aggregated=is_aggregated)):
+            if io.exists(candidate):
+                test_executions = self._to_test_executions([candidate])
+                if test_executions:
+                    return test_executions[0]
+        raise exceptions.NotFound("No test execution with test execution id [{}]".format(test_execution_id))
 
-    def _to_test_runs(self, results):
-        test_runs = []
+    def _to_test_executions(self, results):
+        test_executions = []
         for result in results:
             # noinspection PyBroadException
             try:
                 with open(result, mode="rt", encoding="utf-8") as f:
-                    test_runs.append(TestRun.from_dict(json.loads(f.read())))
+                    test_executions.append(TestExecution.from_dict(json.loads(f.read())))
             except BaseException:
-                logging.getLogger(__name__).exception("Could not load test_run file [%s] (incompatible format?) Skipping...", result)
-        return sorted(test_runs, key=lambda r: r.test_run_timestamp, reverse=True)
+                logging.getLogger(__name__).exception(
+                    "Could not load test_execution file [%s] (incompatible format?) Skipping...", result)
+        return sorted(test_executions, key=lambda r: r.test_execution_timestamp, reverse=True)
 
 
-class OsTestRunStore(TestRunStore):
-    INDEX_PREFIX = "benchmark-test-runs-"
-    TEST_RUN_DOC_TYPE = "_doc"
+class OsTestExecutionStore(TestExecutionStore):
+    INDEX_PREFIX = "benchmark-test-executions-"
+    # back-compat: pre-revert wrote indices under this prefix. Reads must span it too.
+    LEGACY_INDEX_PREFIX = "benchmark-test-runs-"
+    TEST_EXECUTION_DOC_TYPE = "_doc"
+
+    @staticmethod
+    def _read_index_pattern():
+        # back-compat: comma-joined pattern so reads span BOTH the reverted
+        # benchmark-test-executions-* and the pre-revert benchmark-test-runs-* indices.
+        return "%s*,%s*" % (OsTestExecutionStore.INDEX_PREFIX, OsTestExecutionStore.LEGACY_INDEX_PREFIX)
 
     def __init__(self, cfg, client_factory_class=OsClientFactory, index_template_provider_class=IndexTemplateProvider):
         """
@@ -1626,19 +1684,19 @@ class OsTestRunStore(TestRunStore):
         self.client = client_factory_class(cfg).create()
         self.index_template_provider = index_template_provider_class(cfg)
 
-    def store_test_run(self, test_run):
-        doc = test_run.as_dict()
+    def store_test_execution(self, test_execution):
+        doc = test_execution.as_dict()
         # always update the mapping to the latest version
-        self.client.put_template("benchmark-test-runs", self.index_template_provider.test_runs_template())
+        self.client.put_template("benchmark-test-executions", self.index_template_provider.test_executions_template())
         self.client.index(
-            index=self.index_name(test_run),
-            doc_type=OsTestRunStore.TEST_RUN_DOC_TYPE,
+            index=self.index_name(test_execution),
+            doc_type=OsTestExecutionStore.TEST_EXECUTION_DOC_TYPE,
             item=doc,
-            id=test_run.test_run_id)
+            id=test_execution.test_execution_id)
 
-    def index_name(self, test_run):
-        test_run_timestamp = test_run.test_run_timestamp
-        return f"{OsTestRunStore.INDEX_PREFIX}{test_run_timestamp:%Y-%m}"
+    def index_name(self, test_execution):
+        test_execution_timestamp = test_execution.test_execution_timestamp
+        return f"{OsTestExecutionStore.INDEX_PREFIX}{test_execution_timestamp:%Y-%m}"
 
     def list(self):
         filters = [{
@@ -1654,55 +1712,72 @@ class OsTestRunStore(TestRunStore):
                 }
             },
             "size": self._max_results(),
+            # back-compat: docs may carry only the pre-3.x test-run-timestamp OR only the
+            # 3.x test-execution-timestamp. Sort over both; unmapped_type keeps the query from
+            # failing when one field is entirely absent from the matched indices.
             "sort": [
                 {
+                    "test-execution-timestamp": {
+                        "order": "desc",
+                        "unmapped_type": "date"
+                    }
+                },
+                {
                     "test-run-timestamp": {
-                        "order": "desc"
+                        "order": "desc",
+                        "unmapped_type": "date"
                     }
                 }
             ]
         }
-        result = self.client.search(index="%s*" % OsTestRunStore.INDEX_PREFIX, body=query)
+        result = self.client.search(index=OsTestExecutionStore._read_index_pattern(), body=query)
         hits = result["hits"]["total"]
         # OpenSearch 1.0+
         if isinstance(hits, dict):
             hits = hits["value"]
         if hits > 0:
-            return [TestRun.from_dict(v["_source"]) for v in result["hits"]["hits"]]
+            return [TestExecution.from_dict(v["_source"]) for v in result["hits"]["hits"]]
         else:
             return []
 
-    def find_by_test_run_id(self, test_run_id):
+    def find_by_test_execution_id(self, test_execution_id):
         query = {
             "query": {
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": test_run_id
+                            # back-compat: match docs written with either 3.x test-execution-id
+                            # or pre-3.x test-run-id.
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": test_execution_id}},
+                                    {"term": {"test-run-id": test_execution_id}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         }
                     ]
                 }
             }
         }
-        result = self.client.search(index="%s*" % OsTestRunStore.INDEX_PREFIX, body=query)
+        result = self.client.search(index=OsTestExecutionStore._read_index_pattern(), body=query)
         hits = result["hits"]["total"]
         # OpenSearch 1.0+
         if isinstance(hits, dict):
             hits = hits["value"]
         if hits == 1:
-            return TestRun.from_dict(result["hits"]["hits"][0]["_source"])
+            return TestExecution.from_dict(result["hits"]["hits"][0]["_source"])
         elif hits > 1:
             raise exceptions.BenchmarkAssertionError(
-                "Expected one test run to match test ex id [{}] but there were [{}] matches.".format(test_run_id, hits))
+                "Expected one test execution to match test ex id [{}] but there were [{}] matches.".format(
+                    test_execution_id, hits))
         else:
-            raise exceptions.NotFound("No test_run with test_run id [{}]".format(test_run_id))
+            raise exceptions.NotFound("No test execution with test execution id [{}]".format(test_execution_id))
 
 
 class OsResultsStore:
     """
-    Stores the results of a test_run in a format that is
+    Stores the results of a test_execution in a format that is
     better suited for reporting with OpenSearch Dashboards.
     """
     INDEX_PREFIX = "benchmark-results-"
@@ -1720,23 +1795,23 @@ class OsResultsStore:
         self.client = client_factory_class(cfg).create()
         self.index_template_provider = index_template_provider_class(cfg)
 
-    def store_results(self, test_run):
+    def store_results(self, test_execution):
         # always update the mapping to the latest version
         self.client.put_template("benchmark-results", self.index_template_provider.results_template())
-        self.client.bulk_index(index=self.index_name(test_run),
+        self.client.bulk_index(index=self.index_name(test_execution),
                                doc_type=OsResultsStore.RESULTS_DOC_TYPE,
-                               items=test_run.to_result_dicts())
+                               items=test_execution.to_result_dicts())
 
-    def index_name(self, test_run):
-        test_run_timestamp = test_run.test_run_timestamp
-        return f"{OsResultsStore.INDEX_PREFIX}{test_run_timestamp:%Y-%m}"
+    def index_name(self, test_execution):
+        test_execution_timestamp = test_execution.test_execution_timestamp
+        return f"{OsResultsStore.INDEX_PREFIX}{test_execution_timestamp:%Y-%m}"
 
 
 class NoopResultsStore:
     """
-    Does not store any results separately as these are stored as part of the test_run on the file system.
+    Does not store any results separately as these are stored as part of the test_execution on the file system.
     """
-    def store_results(self, test_run):
+    def store_results(self, test_execution):
         pass
 
 
@@ -1953,7 +2028,11 @@ class GlobalStatsCalculator:
                 "unit": unit
             }
 
-        if percentiles_list: # modified from single_latency()
+        if percentiles_list and stats: # modified from single_latency()
+            # Guard on `stats`: get_stats() returns None when the metric has no
+            # Normal samples (e.g. a task where every request errored). Without
+            # this guard `stats["count"]` raises TypeError and aborts the whole
+            # results calculation of an otherwise-completed run.
             sample_size = stats["count"]
             percentiles = self.store.get_percentiles(metric_name,
                                                      task=task_name,

--- a/osbenchmark/paths.py
+++ b/osbenchmark/paths.py
@@ -52,23 +52,30 @@ def benchmark_root():
     return os.path.dirname(os.path.realpath(__file__))
 
 
-def test_runs_root(cfg):
-    return os.path.join(cfg.opts("node", "root.dir"), "test-runs")
+def test_executions_root(cfg):
+    return os.path.join(cfg.opts("node", "root.dir"), "test-executions")
 
 
-def test_run_root(cfg, test_run_id=None):
-    if not test_run_id:
-        test_run_id = cfg.opts("system", "test_run.id")
-    return os.path.join(test_runs_root(cfg), test_run_id)
+def test_execution_root(cfg, test_execution_id=None):
+    if not test_execution_id:
+        test_execution_id = _test_execution_id(cfg)
+    return os.path.join(test_executions_root(cfg), test_execution_id)
 
-def aggregated_results_root(cfg, test_run_id=None):
-    if not test_run_id:
-        test_run_id = cfg.opts("system", "test_run.id")
-    return os.path.join(cfg.opts("node", "root.dir"), "aggregated_results", test_run_id)
+def aggregated_results_root(cfg, test_execution_id=None):
+    if not test_execution_id:
+        test_execution_id = _test_execution_id(cfg)
+    return os.path.join(cfg.opts("node", "root.dir"), "aggregated_results", test_execution_id)
 
 def install_root(cfg=None):
     install_id = cfg.opts("system", "install.id")
-    return os.path.join(test_runs_root(cfg), install_id)
+    return os.path.join(test_executions_root(cfg), install_id)
+
+
+def _test_execution_id(cfg):
+    # Phase B: read the reverted internal cfg key first, falling back to the
+    # pre-revert key so the tree stays runnable until the CLI producer flips.
+    return cfg.opts("system", "test_execution.id", mandatory=False) \
+        or cfg.opts("system", "test_run.id")
 
 
 # There is a weird bug manifesting in jenkins that is somehow saying the following line has an invalid docstring

--- a/osbenchmark/publisher.py
+++ b/osbenchmark/publisher.py
@@ -58,10 +58,10 @@ def summarize(results, cfg):
 def compare(cfg, baseline_id, contender_id):
     if not baseline_id or not contender_id:
         raise exceptions.SystemSetupError("compare needs baseline and a contender")
-    test_run_store = metrics.test_run_store(cfg)
+    test_execution_store = metrics.test_execution_store(cfg)
     ComparisonPublisher(cfg).publish(
-        test_run_store.find_by_test_run_id(baseline_id),
-        test_run_store.find_by_test_run_id(contender_id))
+        test_execution_store.find_by_test_execution_id(baseline_id),
+        test_execution_store.find_by_test_execution_id(contender_id))
 
 
 def print_internal(message):
@@ -437,15 +437,15 @@ class ComparisonPublisher:
         self.plain = False
 
     def publish(self, r1, r2):
-        # we don't verify anything about the test_runs as it is possible
+        # we don't verify anything about the test_executions as it is possible
         # that the user benchmarks two different workloads intentionally
         baseline_stats = metrics.GlobalStats(r1.results)
         contender_stats = metrics.GlobalStats(r2.results)
 
         print_internal("")
         print_internal("Comparing baseline")
-        print_internal("  TestRun ID: %s" % r1.test_run_id)
-        print_internal("  TestRun timestamp: %s" % r1.test_run_timestamp)
+        print_internal("  TestExecution ID: %s" % r1.test_execution_id)
+        print_internal("  TestExecution timestamp: %s" % r1.test_execution_timestamp)
         if r1.test_procedure_name:
             print_internal("  TestProcedure: %s" % r1.test_procedure_name)
         print_internal("  ClusterConfig: %s" % r1.cluster_config_name)
@@ -454,8 +454,8 @@ class ComparisonPublisher:
             print_internal("  User tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
-        print_internal("  TestRun ID: %s" % r2.test_run_id)
-        print_internal("  TestRun timestamp: %s" % r2.test_run_timestamp)
+        print_internal("  TestExecution ID: %s" % r2.test_execution_id)
+        print_internal("  TestExecution timestamp: %s" % r2.test_execution_timestamp)
         if r2.test_procedure_name:
             print_internal("  TestProcedure: %s" % r2.test_procedure_name)
         print_internal("  ClusterConfig: %s" % r2.cluster_config_name)

--- a/osbenchmark/resources/metrics-template.json
+++ b/osbenchmark/resources/metrics-template.json
@@ -31,10 +31,10 @@
       "relative-time-ms": {
         "type": "float"
       },
-      "test-run-id": {
+      "test-execution-id": {
         "type": "keyword"
       },
-      "test-run-timestamp": {
+      "test-execution-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/resources/results-template.json
+++ b/osbenchmark/resources/results-template.json
@@ -23,10 +23,10 @@
       "enabled": true
     },
     "properties": {
-      "test-run-id": {
+      "test-execution-id": {
         "type": "keyword"
       },
-      "test-run-timestamp": {
+      "test-execution-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/resources/test-executions-template.json
+++ b/osbenchmark/resources/test-executions-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "benchmark-test-runs-*"
+    "benchmark-test-executions-*"
   ],
   "settings": {
     "index": {
@@ -23,10 +23,10 @@
       "enabled": true
     },
     "properties": {
-      "test-run-id": {
+      "test-execution-id": {
         "type": "keyword"
       },
-      "test-run-timestamp": {
+      "test-execution-timestamp": {
         "type": "date",
         "format": "basic_date_time_no_millis",
         "fields": {

--- a/osbenchmark/test_execution_orchestrator.py
+++ b/osbenchmark/test_execution_orchestrator.py
@@ -118,7 +118,7 @@ class BenchmarkActor(actor.BenchmarkActor):
     @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_EngineStarted(self, msg, sender):
         self.logger.info("Builder has started engine successfully.")
-        self.coordinator.test_run.cluster_config_revision = msg.cluster_config_revision
+        self.coordinator.test_execution.cluster_config_revision = msg.cluster_config_revision
         self.main_worker_coordinator = self.createActor(
             worker_coordinator.WorkerCoordinatorActor,
             targetActorRequirements={"coordinator": True}
@@ -143,7 +143,7 @@ class BenchmarkActor(actor.BenchmarkActor):
     def receiveMsg_BenchmarkCancelled(self, msg, sender):
         self.coordinator.cancelled = True
         # even notify the start sender if it is the originator. The reason is that we call #ask() which waits for a reply.
-        # We also need to ask in order to avoid test_runs between this notification and the following ActorExitRequest.
+        # We also need to ask in order to avoid test_executions between this notification and the following ActorExitRequest.
         self.send(self.start_sender, msg)
 
     @actor.no_retry("test run orchestrator")  # pylint: disable=no-value-for-parameter
@@ -170,9 +170,9 @@ class BenchmarkCoordinator:
     def __init__(self, cfg):
         self.logger = logging.getLogger(__name__)
         self.cfg = cfg
-        self.test_run = None
+        self.test_execution = None
         self.metrics_store = None
-        self.test_run_store = None
+        self.test_execution_store = None
         self.cancelled = False
         self.error = False
         self.workload_revision = None
@@ -187,10 +187,18 @@ class BenchmarkCoordinator:
         # Distribution-version auto-detection probes the target with a raw opensearchpy
         # client and the legacy wait_for_rest_layer. For non-OpenSearch backends the
         # OS-flavored health/info routes either don't exist or differ enough to make
-        # this probe meaningless. Skip the whole branch for non-OS databases; the
-        # OS-min-version check below is also OS-specific.
+        # this probe meaningless, so non-OS databases take the branch below (which
+        # sets a default workload distribution version) and skip the OS-only probe.
         database_type = self.cfg.opts("database", "type", default_value="opensearch", mandatory=False)
-        if not sources and not self.cfg.exists("builder", "distribution.version") and database_type.lower() == "opensearch":
+        if database_type.lower() != "opensearch":
+            # Non-OpenSearch databases don't have distribution versions.
+            # Use latest workload branch (3.x) so we get the newest workload definitions.
+            non_os_version = "3.0.0"
+            if not self.cfg.exists("builder", "distribution.version"):
+                self.logger.info("Non-OpenSearch database type [%s], using default distribution version [%s] for template rendering.",
+                                 database_type, non_os_version)
+                self.cfg.add(config.Scope.benchmark, "builder", "distribution.version", non_os_version)
+        elif not sources and not self.cfg.exists("builder", "distribution.version"):
             distribution_version = builder.cluster_distribution_version(self.cfg)
             if distribution_version == 'oss':
                 self.logger.info("Automatically derived serverless collection, setting distribution version to 2.11.0")
@@ -222,37 +230,37 @@ class BenchmarkCoordinator:
         for info in self.current_test_procedure.serverless_info:
             console.info(info)
 
-        self.test_run = metrics.create_test_run(
+        self.test_execution = metrics.create_test_execution(
             self.cfg, self.current_workload,
             self.current_test_procedure,
             self.workload_revision)
 
         self.metrics_store = metrics.metrics_store(
             self.cfg,
-            workload=self.test_run.workload_name,
-            test_procedure=self.test_run.test_procedure_name,
+            workload=self.test_execution.workload_name,
+            test_procedure=self.test_execution.test_procedure_name,
             read_only=False
         )
-        self.test_run_store = metrics.test_run_store(self.cfg)
+        self.test_execution_store = metrics.test_execution_store(self.cfg)
 
     def on_preparation_complete(self, distribution_flavor, distribution_version, revision):
-        self.test_run.distribution_flavor = distribution_flavor
-        self.test_run.distribution_version = distribution_version
-        self.test_run.revision = revision
-        # store test_run initially (without any results) so other components can retrieve full metadata
-        self.test_run_store.store_test_run(self.test_run)
-        if self.test_run.test_procedure.auto_generated:
+        self.test_execution.distribution_flavor = distribution_flavor
+        self.test_execution.distribution_version = distribution_version
+        self.test_execution.revision = revision
+        # store test_execution initially (without any results) so other components can retrieve full metadata
+        self.test_execution_store.store_test_execution(self.test_execution)
+        if self.test_execution.test_procedure.auto_generated:
             console.info("Running test with workload [{}] and cluster_config {} with version [{}].\n"
-                         .format(self.test_run.workload_name,
-                         self.test_run.cluster_config,
-                         self.test_run.distribution_version))
+                         .format(self.test_execution.workload_name,
+                         self.test_execution.cluster_config,
+                         self.test_execution.distribution_version))
         else:
             console.info("Running test with workload [{}], test_procedure [{}] and cluster_config {} with version [{}].\n"
                          .format(
-                             self.test_run.workload_name,
-                             self.test_run.test_procedure_name,
-                             self.test_run.cluster_config,
-                             self.test_run.distribution_version
+                             self.test_execution.workload_name,
+                             self.test_execution.test_procedure_name,
+                             self.test_execution.cluster_config,
+                             self.test_execution.distribution_version
                              ))
 
     def on_task_finished(self, new_metrics):
@@ -266,10 +274,10 @@ class BenchmarkCoordinator:
         self.metrics_store.bulk_add(new_metrics)
         self.metrics_store.flush()
         if not self.cancelled and not self.error:
-            final_results = metrics.calculate_results(self.metrics_store, self.test_run)
-            self.test_run.add_results(final_results)
-            self.test_run_store.store_test_run(self.test_run)
-            metrics.results_store(self.cfg).store_results(self.test_run)
+            final_results = metrics.calculate_results(self.metrics_store, self.test_execution)
+            self.test_execution.add_results(final_results)
+            self.test_execution_store.store_test_execution(self.test_execution)
+            metrics.results_store(self.cfg).store_results(self.test_execution)
             publisher.summarize(final_results, self.cfg)
         else:
             self.logger.info("Suppressing output of summary results. Cancelled = [%r], Error = [%r].", self.cancelled, self.error)
@@ -365,9 +373,13 @@ def list_pipelines():
 def run(cfg):
     logger = logging.getLogger(__name__)
     # pipeline is no more mandatory, will default to benchmark-only
-    name = cfg.opts("test_run", "pipeline", mandatory=False)
-    test_run_id = cfg.opts("system", "test_run.id")
-    logger.info("Test run id [%s]", test_run_id)
+    # Phase B: prefer the reverted config section/key, fall back to the pre-revert
+    # ones so the tree stays runnable until the CLI producer flips.
+    name = cfg.opts("test_execution", "pipeline", mandatory=False) \
+        or cfg.opts("test_run", "pipeline", mandatory=False)
+    test_execution_id = cfg.opts("system", "test_execution.id", mandatory=False) \
+        or cfg.opts("system", "test_run.id")
+    logger.info("Test execution id [%s]", test_execution_id)
     if not name:
         # assume from-distribution pipeline if distribution.version has been specified
         if cfg.exists("builder", "distribution.version"):
@@ -376,7 +388,7 @@ def run(cfg):
             name = "benchmark-only"
             logger.info("User did not specify distribution.version or pipeline. Using default pipeline [%s].", name)
 
-        cfg.add(config.Scope.applicationOverride, "test_run", "pipeline", name)
+        cfg.add(config.Scope.applicationOverride, "test_execution", "pipeline", name)
     else:
         logger.info("User specified pipeline [%s].", name)
 
@@ -403,4 +415,4 @@ def run(cfg):
         logger.info("User has cancelled the benchmark.")
     except BaseException:
         tb = sys.exc_info()[2]
-        raise exceptions.BenchmarkError("This test_run ended with a fatal crash.").with_traceback(tb)
+        raise exceptions.BenchmarkError("This test_execution ended with a fatal crash.").with_traceback(tb)

--- a/osbenchmark/visualizations/benchmark_report_renderer.py
+++ b/osbenchmark/visualizations/benchmark_report_renderer.py
@@ -1,39 +1,39 @@
 
-def render_results_html(test_run, cfg) -> str:
+def render_results_html(test_execution, cfg) -> str:
     """
-    Build a “lighter” OpenSearch-themed HTML report for the given TestRun.
+    Build a “lighter” OpenSearch-themed HTML report for the given TestExecution.
     """
-    # 1) Normalize the test_run to a dict
-    if isinstance(test_run, dict):
-        doc = test_run
-    elif hasattr(test_run, "as_dict"):
-        doc = test_run.as_dict()
+    # 1) Normalize the test_execution to a dict
+    if isinstance(test_execution, dict):
+        doc = test_execution
+    elif hasattr(test_execution, "as_dict"):
+        doc = test_execution.as_dict()
     else:
         # fallback minimal dict
         doc = {
-            "test-run-id": test_run.test_run_id,
-            "benchmark-version": test_run.benchmark_version,
-            "benchmark-revision": test_run.benchmark_revision,
-            "environment": test_run.environment_name,
-            "pipeline": test_run.pipeline,
-            "workload": test_run.workload_name,
-            "test-procedure": getattr(test_run, "test_procedure_name", None),
+            "test-execution-id": test_execution.test_execution_id,
+            "benchmark-version": test_execution.benchmark_version,
+            "benchmark-revision": test_execution.benchmark_revision,
+            "environment": test_execution.environment_name,
+            "pipeline": test_execution.pipeline,
+            "workload": test_execution.workload_name,
+            "test-procedure": getattr(test_execution, "test_procedure_name", None),
             "cluster": {
-                "revision": test_run.revision,
-                "distribution-version": test_run.distribution_version,
-                "distribution-flavor": test_run.distribution_flavor,
-                "provision-config-revision": test_run.provision_config_revision,
+                "revision": test_execution.revision,
+                "distribution-version": test_execution.distribution_version,
+                "distribution-flavor": test_execution.distribution_flavor,
+                "provision-config-revision": test_execution.provision_config_revision,
             }
         }
-        if getattr(test_run, "results", None):
+        if getattr(test_execution, "results", None):
             # results might already be a dict or an object
-            if isinstance(test_run.results, dict):
-                doc["results"] = test_run.results
-            elif hasattr(test_run.results, "as_dict"):
-                doc["results"] = test_run.results.as_dict()
+            if isinstance(test_execution.results, dict):
+                doc["results"] = test_execution.results
+            elif hasattr(test_execution.results, "as_dict"):
+                doc["results"] = test_execution.results.as_dict()
 
     # 2) Pull top-level fields
-    test_id       = doc.get("test-run-id", "<unknown>")
+    test_id       = doc.get("test-execution-id", doc.get("test-run-id", "<unknown>"))
     osb_ver       = doc.get("benchmark-version", "")
     osb_rev       = doc.get("benchmark-revision", "")
     environment   = doc.get("environment", "")

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -246,7 +246,7 @@ class ConfigureFeedbackScaling:
     DEFAULT_CPU_CHECK_INTERVAL = 30
 
     def __init__(self, scale_step=None, scale_down_pct=None, sleep_seconds=None, max_clients=None, cpu_max=None,
-                cpu_window_seconds=None, cpu_check_interval=None, metrics_index=None, test_run_id=None, cfg=None):
+                cpu_window_seconds=None, cpu_check_interval=None, metrics_index=None, test_execution_id=None, cfg=None):
 
         config_object = load_redline_config()
 
@@ -260,7 +260,7 @@ class ConfigureFeedbackScaling:
         self.cpu_max=cpu_max
         self.cfg=cfg
         self.metrics_index=metrics_index
-        self.test_run_id=test_run_id
+        self.test_execution_id=test_execution_id
 
 class EnableFeedbackScaling:
     pass
@@ -317,7 +317,7 @@ class FeedbackActor(actor.BenchmarkActor):
         # client, index, and test run ID for querying users' data store
         self.os_client = None
         self.metrics_index = None
-        self.test_run_id=None
+        self.test_execution_id=None
 
     def receiveMsg_StartFeedbackActor(self, msg, sender) -> None:
         """
@@ -354,7 +354,7 @@ class FeedbackActor(actor.BenchmarkActor):
         # CPU feedback related items
         self.cpu_window_seconds = msg.cpu_window_seconds
         self.cpu_check_interval = msg.cpu_check_interval
-        self.test_run_id=msg.test_run_id
+        self.test_execution_id=msg.test_execution_id
         self.cfg=msg.cfg
         self.metrics_index = msg.metrics_index
         if msg.cpu_max:
@@ -540,7 +540,11 @@ class FeedbackActor(actor.BenchmarkActor):
                 "bool": {
                 "filter": [
                     { "term":  { "name": "node-stats" }},
-                    { "term":  { "test-run-id": self.test_run_id }},
+                    # back-compat: match docs written with either 3.x test-execution-id or pre-3.x test-run-id.
+                    { "bool": { "should": [
+                        { "term": { "test-execution-id": self.test_execution_id }},
+                        { "term": { "test-run-id": self.test_execution_id }}
+                    ], "minimum_should_match": 1 }},
                     { "range": { "@timestamp": { "gte": f"now-{self.cpu_window_seconds}s", "lte": "now" }}}
                 ]
                 }
@@ -1004,7 +1008,7 @@ class WorkerCoordinator:
     def prepare_telemetry(self, opensearch, enable):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
-        log_root = paths.test_run_root(self.config)
+        log_root = paths.test_execution_root(self.config)
         database_type = self.config.opts("database", "type", default_value="opensearch", mandatory=False)
 
         os_default = opensearch["default"]
@@ -1193,7 +1197,7 @@ class WorkerCoordinator:
                     worker_id += 1
         if redline_enabled:
             metrics_index = None
-            test_run_id = None
+            test_execution_id = None
             # we must have a metrics store connected for CPU based feedback
             cpu_max = self.config.opts("workload", "redline.max_cpu_usage", default_value=None, mandatory=False)
             if cpu_max and isinstance(self.metrics_store, metrics.InMemoryMetricsStore):
@@ -1203,7 +1207,7 @@ class WorkerCoordinator:
             elif cpu_max and isinstance(self.metrics_store, metrics.OsMetricsStore):
                 # pass over the index and test run ID so the feedbackActor can query the datastore
                 metrics_index = self.metrics_store.index
-                test_run_id = self.metrics_store.test_run_id
+                test_execution_id = self.metrics_store.test_execution_id
 
             scale_step = self.config.opts("workload", "redline.scale_step", default_value=0)
             scale_down_pct = self.config.opts("workload", "redline.scale_down_pct", default_value=0)
@@ -1221,7 +1225,7 @@ class WorkerCoordinator:
             cpu_check_interval=cpu_check_interval,
             cfg=self.config,
             metrics_index=metrics_index,
-            test_run_id=test_run_id
+            test_execution_id=test_execution_id
             ))
             self.target.start_feedbackActor(self.shared_client_dict)
 

--- a/osbenchmark/workload/loader.py
+++ b/osbenchmark/workload/loader.py
@@ -1123,7 +1123,10 @@ class QueryRandomizerWorkloadProcessor(WorkloadProcessor):
         # We could achieve this by passing in the task name to get_randomized_values as a kwarg?
         try:
             root = params["body"]["query"]
-        except KeyError:
+        except (KeyError, TypeError):
+            # KeyError: "body" or "query" key absent. TypeError: "body" is not a
+            # dict (e.g. a string or list), so subscripting by "query" fails.
+            # Both mean the operation body is malformed — report it cleanly.
             raise exceptions.SystemSetupError(
                 f"Cannot extract range query fields from these params: {params}\n, missing params[\"body\"][\"query\"]\n"
                 f"Make sure the operation in operations/default.json is well-formed")
@@ -1432,7 +1435,13 @@ class WorkloadPluginReader:
 
     def register_runner(self, name, runner, **kwargs):
         if self.runner_registry:
-            self.runner_registry(name, runner, **kwargs)
+            try:
+                self.runner_registry(name, runner, **kwargs)
+            except exceptions.BenchmarkAssertionError:
+                logging.getLogger(__name__).warning(
+                    "Workload plugin runner [%s] could not be registered (likely not async). "
+                    "Skipping — a database-specific runner may already handle this operation.", name)
+
 
     def register_scheduler(self, name, scheduler):
         if self.scheduler_registry:
@@ -1720,6 +1729,9 @@ class WorkloadSpecificationReader:
 
             for op in self._r(test_procedure_spec, "schedule", error_ctx=name):
                 if "clients_list" in op:
+                    if not isinstance(op["clients_list"], list) or not op["clients_list"]:
+                        self._error("'clients_list' must be a non-empty list of client counts "
+                                    "(e.g. [1, 2, 4]) but was %r." % (op["clients_list"],))
                     self.logger.info("Clients list specified: %s. Running multiple search tasks, "\
                                      "each scheduled with the corresponding number of clients from the list.", op["clients_list"])
                     for num_clients in op["clients_list"]:

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -264,6 +264,10 @@ class CreateIndexParamSource(ParamSource):
             if isinstance(filter_idx, str):
                 filter_idx = [filter_idx]
             settings = params.get("settings")
+            if settings is not None and not isinstance(settings, dict):
+                raise exceptions.InvalidSyntax(
+                    f"'settings' must be a JSON object (dict) but was "
+                    f"{type(settings).__name__}: {settings!r}.")
             for idx in workload.indices:
                 if not filter_idx or idx.name in filter_idx:
                     body = idx.body

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 import pytest
 from osbenchmark import config
 from osbenchmark import metrics
+from osbenchmark import exceptions
 from osbenchmark.aggregator import Aggregator, AggregatedResults
 
 @pytest.fixture
@@ -11,7 +12,7 @@ def mock_config():
     return mock_cfg
 
 @pytest.fixture
-def mock_test_runs():
+def mock_test_executions():
     return {
         "test1": Mock(),
         "test2": Mock()
@@ -19,6 +20,9 @@ def mock_test_runs():
 
 @pytest.fixture
 def mock_args():
+    # test_run_id (legacy CLI dest) on purpose: the aggregator reads
+    # test_execution_id first and falls back to test_run_id, so this keeps the
+    # deprecated-alias path covered.
     return Mock(
         results_file="",
         test_run_id="",
@@ -29,15 +33,15 @@ def mock_args():
 @pytest.fixture
 def mock_test_store():
     mock_store = Mock()
-    mock_store.find_by_test_run_id.side_effect = [
+    mock_store.find_by_test_execution_id.side_effect = [
         Mock(results={"key1": {"nested": 10}}, workload="workload1", test_procedure="test_proc1"),
         Mock(results={"key1": {"nested": 20}}, workload="workload1", test_procedure="test_proc1")
     ]
     return mock_store
 
 @pytest.fixture
-def aggregator(mock_config, mock_test_runs, mock_args, mock_test_store):
-    aggregator = Aggregator(mock_config, mock_test_runs, mock_args)
+def aggregator(mock_config, mock_test_executions, mock_args, mock_test_store):
+    aggregator = Aggregator(mock_config, mock_test_executions, mock_args)
     aggregator.test_store = mock_test_store
     return aggregator
 
@@ -53,12 +57,12 @@ def test_count_iterations_for_each_op(aggregator):
     mock_workload.test_procedures = [mock_test_procedure]
 
     mock_workload.find_test_procedure_or_default = Mock(return_value=mock_test_procedure)
-    mock_test_run = Mock(test_run_id="test1", workload_params={})
+    mock_test_execution = Mock(test_execution_id="test1", workload_params={})
 
     aggregator.loaded_workload = mock_workload
     aggregator.test_procedure_name = "test_procedure_name"
 
-    aggregator.count_iterations_for_each_op(mock_test_run)
+    aggregator.count_iterations_for_each_op(mock_test_execution)
 
     assert "test1" in aggregator.accumulated_iterations, "test1 not found in accumulated_iterations"
     assert "op1" in aggregator.accumulated_iterations["test1"], "op1 not found in accumulated_iterations for test1"
@@ -86,17 +90,17 @@ def test_accumulate_results(aggregator):
     assert "task1" in aggregator.accumulated_results
     assert all(metric in aggregator.accumulated_results["task1"] for metric in aggregator.metrics)
 
-def test_test_run_compatibility_check(aggregator):
+def test_test_execution_compatibility_check(aggregator):
     mock_test_store = Mock()
-    mock_test_store.find_by_test_run_id.side_effect = [
+    mock_test_store.find_by_test_execution_id.side_effect = [
         Mock(workload="workload1", test_procedure="test_proc1"),
         Mock(workload="workload1", test_procedure="test_proc1"),
         Mock(workload="workload1", test_procedure="test_proc1"),  # Add one more mock response
     ]
     aggregator.test_store = mock_test_store
-    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
 
-    assert aggregator.test_run_compatibility_check()
+    assert aggregator.test_execution_compatibility_check()
 
 def test_aggregate_json_by_key(aggregator):
     result = aggregator.aggregate_json_by_key("key1.nested")
@@ -114,7 +118,7 @@ def test_calculate_weighted_average(aggregator):
         "test1": {"op1": 2},
         "test2": {"op1": 3}
     }
-    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
 
     result = aggregator.calculate_weighted_average(task_metrics, task_name)
 
@@ -122,17 +126,17 @@ def test_calculate_weighted_average(aggregator):
     assert result["latency"]["avg"] == 16  # (10*2 + 20*3) / (2+3)
     assert result["latency"]["unit"] == "ms"
 
-def test_update_config_object_reads_attributes_that_test_runs_actually_have(aggregator):
-    # a real TestRun, not a Mock: a Mock creates whatever attribute is asked of it, so it cannot
-    # tell us whether update_config_object reads attributes that a test run really carries
-    test_run = metrics.TestRun(
+def test_update_config_object_reads_attributes_that_test_executions_actually_have(aggregator):
+    # a real TestExecution, not a Mock: a Mock creates whatever attribute is asked of it, so it
+    # cannot tell us whether update_config_object reads attributes that a test execution really carries
+    test_execution = metrics.TestExecution(
         benchmark_version="1.0.0", benchmark_revision="abc123", environment_name="unit-test",
-        test_run_id="test1", test_run_timestamp="20250101T000000Z", pipeline="benchmark-only",
+        test_execution_id="test1", test_execution_timestamp="20250101T000000Z", pipeline="benchmark-only",
         user_tags={}, workload="workload1", workload_params={}, test_procedure="test_proc1",
         cluster_config=["external"], cluster_config_params={"heap_size": "6g"}, plugin_params={},
         meta_data={})
 
-    aggregator.update_config_object(test_run)
+    aggregator.update_config_object(test_execution)
 
     aggregator.config.add.assert_any_call(config.Scope.applicationOverride, "builder",
                                           "cluster_config.params", {"heap_size": "6g"})
@@ -147,7 +151,7 @@ def test_calculate_weighted_average_with_null_metric_fields(aggregator):
         ]
     }
     aggregator.accumulated_iterations = {"test1": {"op1": 1}, "test2": {"op1": 1}}
-    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
 
     result = aggregator.calculate_weighted_average(task_metrics, "op1")
 
@@ -169,7 +173,7 @@ def test_calculate_weighted_average_with_partially_null_metric_fields(aggregator
         ]
     }
     aggregator.accumulated_iterations = {"test1": {"op1": 2}, "test2": {"op1": 3}}
-    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
 
     result = aggregator.calculate_weighted_average(task_metrics, "op1")
 
@@ -178,15 +182,15 @@ def test_calculate_weighted_average_with_partially_null_metric_fields(aggregator
     assert result["throughput"]["mean"] == 20
     assert result["throughput"]["unit"] == "ops/s"
 def _stub_run_for_aggregate(aggregator):
-    aggregator.test_store.find_by_test_run_id.side_effect = None
-    aggregator.test_store.find_by_test_run_id.return_value = Mock(
+    aggregator.test_store.find_by_test_execution_id.side_effect = None
+    aggregator.test_store.find_by_test_execution_id.return_value = Mock(
         results={}, workload="workload1", test_procedure="test_proc1")
 
 def test_aggregate_names_the_workload_repository(aggregator):
     _stub_run_for_aggregate(aggregator)
 
     with patch("osbenchmark.workload.load_workload"), patch.object(aggregator, "build_aggregated_results"), \
-            patch("osbenchmark.aggregator.FileTestRunStore"):
+            patch("osbenchmark.aggregator.FileTestExecutionStore"):
         aggregator.aggregate()
 
     aggregator.config.add.assert_any_call(config.Scope.applicationOverride, "workload",
@@ -199,7 +203,7 @@ def test_aggregate_leaves_a_workload_path_alone(aggregator):
     _stub_run_for_aggregate(aggregator)
 
     with patch("osbenchmark.workload.load_workload"), patch.object(aggregator, "build_aggregated_results"), \
-            patch("osbenchmark.aggregator.FileTestRunStore"):
+            patch("osbenchmark.aggregator.FileTestExecutionStore"):
         aggregator.aggregate()
 
     repository_calls = [c for c in aggregator.config.add.call_args_list
@@ -211,16 +215,54 @@ def test_calculate_rsd(aggregator):
     rsd = aggregator.calculate_rsd(values, "test_metric")
     assert isinstance(rsd, float)
 
-def test_test_run_compatibility_check_incompatible(aggregator):
+def test_weighted_average_raises_clean_error_on_task_not_in_schedule(aggregator):
+    # Robustness: a task present in the stored op_metrics but absent from the
+    # currently-loaded workload schedule (e.g. an operation was renamed/removed)
+    # must raise a clear SystemSetupError naming the task, not a bare KeyError.
+    task_metrics = {"throughput": [100, 200]}
+    aggregator.accumulated_iterations = {
+        "test1": {"op1": 2},
+        "test2": {},  # op1 missing here -> drifted workload
+    }
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
+
+    with pytest.raises(exceptions.SystemSetupError) as ctx:
+        aggregator.calculate_weighted_average(task_metrics, "op1")
+    assert "op1" in str(ctx.value)
+    assert "test2" in str(ctx.value)
+
+def test_build_results_dict_tolerates_metric_dict_missing_mean(aggregator, monkeypatch):
+    # Robustness: a stored latency/service_time dict without a 'mean' key (older
+    # or partial results) must not crash RSD computation with a KeyError. The
+    # only metric with dict values here is latency, carrying the missing/None
+    # 'mean' case. aggregate_json_by_key is stubbed so the test targets just the
+    # op_metrics RSD path, not the (separately-tested) json aggregation.
+    monkeypatch.setattr(aggregator, "aggregate_json_by_key", lambda key: 0)
+    all_metrics = ["throughput", "latency", "service_time", "client_processing_time",
+                   "processing_time", "error_rate", "duration"]
+    # One run's latency dict is missing the 'mean' key entirely (older/partial
+    # results). The RSD comprehension must skip it rather than KeyError.
+    dict_metric = [{"mean": 10, "unit": "ms"}, {"50_0": 5, "unit": "ms"}]
+    aggregator.accumulated_results = {
+        "op1": {m: (list(dict_metric) if m == "latency" else [1.0, 2.0]) for m in all_metrics}
+    }
+    aggregator.accumulated_iterations = {"test1": {"op1": 1}, "test2": {"op1": 1}}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
+
+    # Should not raise; the missing/None 'mean' entries are simply skipped.
+    result = aggregator.build_aggregated_results_dict()
+    assert any(op["task"] == "op1" for op in result["op_metrics"])
+
+def test_test_execution_compatibility_check_incompatible(aggregator):
     mock_test_store = Mock()
-    mock_test_store.find_by_test_run_id.side_effect = [
+    mock_test_store.find_by_test_execution_id.side_effect = [
         Mock(workload="workload1", test_procedure="test_proc1"),
         Mock(workload="workload2", test_procedure="test_proc1"),
     ]
     aggregator.test_store = mock_test_store
-    aggregator.test_runs = {"test1": Mock(), "test2": Mock()}
+    aggregator.test_executions = {"test1": Mock(), "test2": Mock()}
     with pytest.raises(ValueError):
-        aggregator.test_run_compatibility_check()
+        aggregator.test_execution_compatibility_check()
 
 def test_aggregated_results():
     results = {"key": "value"}

--- a/tests/aggregator_test.py
+++ b/tests/aggregator_test.py
@@ -215,6 +215,14 @@ def test_calculate_rsd(aggregator):
     rsd = aggregator.calculate_rsd(values, "test_metric")
     assert isinstance(rsd, float)
 
+def test_calculate_rsd_empty_or_all_none_returns_na(aggregator):
+    # Regression: aggregate crashed with ValueError when a metric had no valid
+    # samples across runs (e.g. index-only throughput.mean is None). RSD is
+    # undefined here; it must return "NA", not raise and abort the aggregation.
+    assert aggregator.calculate_rsd([], "empty.metric") == "NA"
+    assert aggregator.calculate_rsd([None, None], "allnone.metric") == "NA"
+    assert aggregator.calculate_rsd([42.0], "single.metric") == "NA"
+
 def test_weighted_average_raises_clean_error_on_task_not_in_schedule(aggregator):
     # Robustness: a task present in the stored op_metrics but absent from the
     # currently-loaded workload schedule (e.g. an operation was renamed/removed)

--- a/tests/builder/installers/bare_installer_test.py
+++ b/tests/builder/installers/bare_installer_test.py
@@ -13,7 +13,7 @@ class BareInstallerTests(TestCase):
         self.binaries = {}
         self.all_node_ips = ["10.17.22.22", "10.17.22.23"]
 
-        self.test_run_root = "fake_root"
+        self.test_execution_root = "fake_root"
         self.node_id = "abdefg"
         self.cluster_name = "my-cluster"
 
@@ -26,7 +26,7 @@ class BareInstallerTests(TestCase):
             root_path="fake",
             config_paths=["/tmp"],
             variables={
-                "test_run_root": self.test_run_root,
+                "test_execution_root": self.test_execution_root,
                 "cluster_name": self.cluster_name,
                 "node": {
                     "port": "9200"

--- a/tests/builder/installers/docker_installer_test.py
+++ b/tests/builder/installers/docker_installer_test.py
@@ -16,8 +16,8 @@ class DockerProvisionerTests(TestCase):
         self.node_name = "9dbc682e-d32a-4669-8fbe-56fb77120dd4"
         self.cluster_name = "my-cluster"
         self.port = "39200"
-        self.test_run_root = tempfile.gettempdir()
-        self.node_root_dir = os.path.join(self.test_run_root, self.node_name)
+        self.test_execution_root = tempfile.gettempdir()
+        self.node_root_dir = os.path.join(self.test_execution_root, self.node_name)
         self.node_data_dir = os.path.join(self.node_root_dir, "data", self.node_name)
         self.node_log_dir = os.path.join(self.node_root_dir, "logs", "server")
         self.node_heap_dump_dir = os.path.join(self.node_root_dir, "heapdump")
@@ -29,7 +29,7 @@ class DockerProvisionerTests(TestCase):
             config_paths="/tmp",
             variables={
                 "cluster_name": self.cluster_name,
-                "test_run_root": self.test_run_root,
+                "test_execution_root": self.test_execution_root,
                 "node": {
                     "port": self.port
                 },

--- a/tests/builder/installers/preparers/opensearch_preparer_test.py
+++ b/tests/builder/installers/preparers/opensearch_preparer_test.py
@@ -19,7 +19,7 @@ class OpenSearchPreparerTests(TestCase):
         self.binaries = {BinaryKeys.OPENSEARCH: "/data/builds/distributions"}
         self.all_node_ips = ["10.17.22.22", "10.17.22.23"]
 
-        self.test_run_root = "fake_root"
+        self.test_execution_root = "fake_root"
         self.cluster_name = "my-cluster"
 
         self.executor = Mock()
@@ -30,7 +30,7 @@ class OpenSearchPreparerTests(TestCase):
             root_path="fake",
             config_paths=["/tmp"],
             variables={
-                "test_run_root": self.test_run_root,
+                "test_execution_root": self.test_execution_root,
                 "cluster_name": self.cluster_name,
                 "node": {
                     "port": "9200"
@@ -47,10 +47,10 @@ class OpenSearchPreparerTests(TestCase):
         uuid.return_value = self.node_id
 
         node = self.preparer.prepare(self.host, self.binaries)
-        self.assertEqual(node.binary_path, os.path.join(self.test_run_root, self.node_id, "install/opensearch*"))
-        self.assertEqual(node.data_paths, [os.path.join(self.test_run_root, self.node_id, "install/opensearch*/data")])
+        self.assertEqual(node.binary_path, os.path.join(self.test_execution_root, self.node_id, "install/opensearch*"))
+        self.assertEqual(node.data_paths, [os.path.join(self.test_execution_root, self.node_id, "install/opensearch*/data")])
         self.assertEqual(node.port, 9200)
-        self.assertEqual(node.root_dir, os.path.join(self.test_run_root, self.node_id))
+        self.assertEqual(node.root_dir, os.path.join(self.test_execution_root, self.node_id))
         self.assertEqual(node.name, self.node_id)
 
     def test_config_vars(self):
@@ -70,5 +70,5 @@ class OpenSearchPreparerTests(TestCase):
             "minimum_master_nodes": 2,
             "install_root_path": "/fake_binary_path",
             "node": {"port": "9200"},
-            "test_run_root": self.test_run_root
+            "test_execution_root": self.test_execution_root
         }, config_vars)

--- a/tests/builder/launcher_test.py
+++ b/tests/builder/launcher_test.py
@@ -154,8 +154,8 @@ class TerminatedProcess:
 
 def get_metrics_store(cfg):
     ms = InMemoryMetricsStore(cfg)
-    ms.open(test_run_id=str(uuid.uuid4()),
-            test_run_timestamp=datetime.now(),
+    ms.open(test_execution_id=str(uuid.uuid4()),
+            test_execution_timestamp=datetime.now(),
             workload_name="test",
             test_procedure_name="test",
             cluster_config_name="test")

--- a/tests/builder/mechanic_test.py
+++ b/tests/builder/mechanic_test.py
@@ -113,10 +113,10 @@ class BuilderTests(TestCase):
 
     # We stub irrelevant methods for the test
     class TestBuilder(builder.Builder):
-        def _current_test_run(self):
-            return "test_run 17"
+        def _current_test_execution(self):
+            return "test_execution 17"
 
-        def _add_results(self, current_test_run, node):
+        def _add_results(self, current_test_execution, node):
             pass
 
     @mock.patch("osbenchmark.builder.provisioner.cleanup")

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -62,8 +62,8 @@ class DummyIndexTemplateProvider:
     def metrics_template(self):
         return "metrics-test-template"
 
-    def test_runs_template(self):
-        return "test-runs-test-template"
+    def test_executions_template(self):
+        return "test-executions-test-template"
 
     def results_template(self):
         return "results-test-template"
@@ -552,8 +552,8 @@ class OsMetricsTests(TestCase):
         self.metrics_store.put_value_cluster_level("indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "test-run-id": OsMetricsTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsMetricsTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
             "environment": "unittest",
             "sample-type": "normal",
@@ -584,8 +584,8 @@ class OsMetricsTests(TestCase):
                                                    absolute_time=0, relative_time=10)
         expected_doc = {
             "@timestamp": 0,
-            "test-run-id": OsMetricsTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsMetricsTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "relative-time-ms": 10000,
             "environment": "unittest",
             "sample-type": "normal",
@@ -625,8 +625,8 @@ class OsMetricsTests(TestCase):
         self.metrics_store.put_value_node_level("node0", "indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "test-run-id": OsMetricsTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsMetricsTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
             "environment": "unittest",
             "sample-type": "normal",
@@ -666,8 +666,8 @@ class OsMetricsTests(TestCase):
         })
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "test-run-id": OsMetricsTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsMetricsTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
             "environment": "unittest",
             "workload": "test",
@@ -714,8 +714,8 @@ class OsMetricsTests(TestCase):
             })
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "test-run-id": OsMetricsTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsMetricsTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
             "environment": "unittest",
             "workload": "test",
@@ -775,8 +775,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -825,8 +829,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -882,8 +890,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -930,8 +942,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -984,8 +1000,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -1043,8 +1063,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -1180,8 +1204,12 @@ class OsMetricsTests(TestCase):
                 "bool": {
                     "filter": [
                         {
-                            "term": {
-                                "test-run-id": OsMetricsTests.TEST_RUN_ID
+                            "bool": {
+                                "should": [
+                                    {"term": {"test-execution-id": OsMetricsTests.TEST_RUN_ID}},
+                                    {"term": {"test-run-id": OsMetricsTests.TEST_RUN_ID}}
+                                ],
+                                "minimum_should_match": 1
                             }
                         },
                         {
@@ -1212,7 +1240,7 @@ class OsMetricsTests(TestCase):
         return actual_error_rate
 
 
-class OsTestRunStoreTests(TestCase):
+class OsTestExecutionStoreTests(TestCase):
     TEST_RUN_TIMESTAMP = datetime.datetime(2016, 1, 31)
     TEST_RUN_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
@@ -1226,16 +1254,18 @@ class OsTestRunStoreTests(TestCase):
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "time.start", OsTestRunStoreTests.TEST_RUN_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "test_run.id", FileTestRunStoreTests.TEST_RUN_ID)
-        self.test_run_store = metrics.OsTestRunStore(self.cfg,
+        self.cfg.add(config.Scope.application, "system", "time.start", OsTestExecutionStoreTests.TEST_RUN_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "test_execution.id", FileTestExecutionStoreTests.TEST_RUN_ID)
+        self.test_execution_store = metrics.OsTestExecutionStore(self.cfg,
                                               client_factory_class=MockClientFactory,
                                               index_template_provider_class=DummyIndexTemplateProvider,
                                               )
         # get hold of the mocked client...
-        self.es_mock = self.test_run_store.client
+        self.es_mock = self.test_execution_store.client
 
-    def test_find_existing_test_run_by_test_run_id(self):
+    def test_find_existing_test_execution_by_test_execution_id(self):
+        # read-both: this stored doc uses the LEGACY test-run-id / test-run-timestamp
+        # keys, proving TestExecution.from_dict still parses pre-3.x OpenSearch docs.
         self.es_mock.search.return_value = {
             "hits": {
                 "total": {
@@ -1247,7 +1277,7 @@ class OsTestRunStoreTests(TestCase):
                         "_source": {
                             "benchmark-version": "0.4.4",
                             "environment": "unittest",
-                            "test-run-id": OsTestRunStoreTests.TEST_RUN_ID,
+                            "test-run-id": OsTestExecutionStoreTests.TEST_RUN_ID,
                             "test-run-timestamp": "20160131T000000Z",
                             "pipeline": "from-sources",
                             "workload": "unittest",
@@ -1264,10 +1294,45 @@ class OsTestRunStoreTests(TestCase):
             }
         }
 
-        test_run = self.test_run_store.find_by_test_run_id(test_run_id=OsTestRunStoreTests.TEST_RUN_ID)
-        self.assertEqual(test_run.test_run_id, OsTestRunStoreTests.TEST_RUN_ID)
+        test_execution = self.test_execution_store.find_by_test_execution_id(
+            test_execution_id=OsTestExecutionStoreTests.TEST_RUN_ID)
+        self.assertEqual(test_execution.test_execution_id, OsTestExecutionStoreTests.TEST_RUN_ID)
 
-    def test_does_not_find_missing_test_run_by_test_run_id(self):
+    def test_find_existing_test_execution_by_test_execution_id_new_format(self):
+        # read-both: same doc stored with the 3.x test-execution-id keys parses too.
+        self.es_mock.search.return_value = {
+            "hits": {
+                "total": {
+                    "value": 1,
+                    "relation": "eq"
+                },
+                "hits": [
+                    {
+                        "_source": {
+                            "benchmark-version": "3.0.0",
+                            "environment": "unittest",
+                            "test-execution-id": OsTestExecutionStoreTests.TEST_RUN_ID,
+                            "test-execution-timestamp": "20160131T000000Z",
+                            "pipeline": "from-sources",
+                            "workload": "unittest",
+                            "test_procedure": "index",
+                            "workload-revision": "abc1",
+                            "cluster-config-instance": "defaults",
+                            "results": {
+                                "young_gc_time": 100,
+                                "old_gc_time": 5,
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+        test_execution = self.test_execution_store.find_by_test_execution_id(
+            test_execution_id=OsTestExecutionStoreTests.TEST_RUN_ID)
+        self.assertEqual(test_execution.test_execution_id, OsTestExecutionStoreTests.TEST_RUN_ID)
+
+    def test_does_not_find_missing_test_execution_by_test_execution_id(self):
         self.es_mock.search.return_value = {
             "hits": {
                 "total": {
@@ -1278,10 +1343,10 @@ class OsTestRunStoreTests(TestCase):
             }
         }
 
-        with self.assertRaisesRegex(exceptions.NotFound, r"No test_run with test_run id \[.*\]"):
-            self.test_run_store.find_by_test_run_id(test_run_id="some invalid test_run id")
+        with self.assertRaisesRegex(exceptions.NotFound, r"No test execution with test execution id \[.*\]"):
+            self.test_execution_store.find_by_test_execution_id(test_execution_id="some invalid test execution id")
 
-    def test_store_test_run(self):
+    def test_store_test_execution(self):
         schedule = [
             workload.Task("index #1", workload.Operation("index", workload.OperationType.Bulk))
         ]
@@ -1290,9 +1355,9 @@ class OsTestRunStoreTests(TestCase):
                         indices=[workload.Index(name="tests", types=["_doc"])],
                         test_procedures=[workload.TestProcedure(name="index", default=True, schedule=schedule)])
 
-        test_run = metrics.TestRun(benchmark_version="0.4.4", benchmark_revision="123abc", environment_name="unittest",
-                            test_run_id=OsTestRunStoreTests.TEST_RUN_ID,
-                            test_run_timestamp=OsTestRunStoreTests.TEST_RUN_TIMESTAMP,
+        test_execution = metrics.TestExecution(benchmark_version="0.4.4", benchmark_revision="123abc", environment_name="unittest",
+                            test_execution_id=OsTestExecutionStoreTests.TEST_RUN_ID,
+                            test_execution_timestamp=OsTestExecutionStoreTests.TEST_RUN_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, workload=t, workload_params={"shard-count": 3},
                             test_procedure=t.default_test_procedure,
                             cluster_config="defaults",
@@ -1300,7 +1365,7 @@ class OsTestRunStoreTests(TestCase):
                             plugin_params=None,
                             workload_revision="abc1", cluster_config_revision="abc12333", distribution_version="5.0.0",
                             distribution_flavor="default", revision="aaaeeef",
-                            results=OsTestRunStoreTests.DictHolder(
+                            results=OsTestExecutionStoreTests.DictHolder(
                                 {
                                     "young_gc_time": 100,
                                     "old_gc_time": 5,
@@ -1319,14 +1384,14 @@ class OsTestRunStoreTests(TestCase):
                                 })
                             )
 
-        self.test_run_store.store_test_run(test_run)
+        self.test_execution_store.store_test_execution(test_execution)
 
         expected_doc = {
             "benchmark-version": "0.4.4",
             "benchmark-revision": "123abc",
             "environment": "unittest",
-            "test-run-id": OsTestRunStoreTests.TEST_RUN_ID,
-            "test-run-timestamp": "20160131T000000Z",
+            "test-execution-id": OsTestExecutionStoreTests.TEST_RUN_ID,
+            "test-execution-timestamp": "20160131T000000Z",
             "pipeline": "from-sources",
             "user-tags": {
                 "os": "Linux"
@@ -1364,9 +1429,9 @@ class OsTestRunStoreTests(TestCase):
                 ]
             }
         }
-        self.es_mock.index.assert_called_with(index="benchmark-test-runs-2016-01",
+        self.es_mock.index.assert_called_with(index="benchmark-test-executions-2016-01",
                                               doc_type="_doc",
-                                              id=OsTestRunStoreTests.TEST_RUN_ID,
+                                              id=OsTestExecutionStoreTests.TEST_RUN_ID,
                                               item=expected_doc)
 
 
@@ -1377,7 +1442,7 @@ class OsResultsStoreTests(TestCase):
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
-        self.cfg.add(config.Scope.application, "system", "time.start", OsTestRunStoreTests.TEST_RUN_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "time.start", OsTestExecutionStoreTests.TEST_RUN_TIMESTAMP)
         self.results_store = metrics.OsResultsStore(self.cfg,
                                                     client_factory_class=MockClientFactory,
                                                     index_template_provider_class=DummyIndexTemplateProvider,
@@ -1396,9 +1461,9 @@ class OsResultsStoreTests(TestCase):
                             name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
                         meta_data={"workload-type": "saturation-degree", "saturation": "oversaturation"})
 
-        test_run = metrics.TestRun(benchmark_version="0.4.4", benchmark_revision="123abc", environment_name="unittest",
-                            test_run_id=OsResultsStoreTests.TEST_RUN_ID,
-                            test_run_timestamp=OsResultsStoreTests.TEST_RUN_TIMESTAMP,
+        test_execution = metrics.TestExecution(benchmark_version="0.4.4", benchmark_revision="123abc", environment_name="unittest",
+                            test_execution_id=OsResultsStoreTests.TEST_RUN_ID,
+                            test_execution_timestamp=OsResultsStoreTests.TEST_RUN_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, workload=t, workload_params=None,
                             test_procedure=t.default_test_procedure,
                             cluster_config="4gheap",
@@ -1430,15 +1495,15 @@ class OsResultsStoreTests(TestCase):
                                 })
                             )
 
-        self.results_store.store_results(test_run)
+        self.results_store.store_results(test_execution)
 
         expected_docs = [
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1467,8 +1532,8 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1503,8 +1568,8 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": "123abc",
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1546,9 +1611,9 @@ class OsResultsStoreTests(TestCase):
                             name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
                         meta_data={"workload-type": "saturation-degree", "saturation": "oversaturation"})
 
-        test_run = metrics.TestRun(benchmark_version="0.4.4", benchmark_revision=None, environment_name="unittest",
-                            test_run_id=OsResultsStoreTests.TEST_RUN_ID,
-                            test_run_timestamp=OsResultsStoreTests.TEST_RUN_TIMESTAMP,
+        test_execution = metrics.TestExecution(benchmark_version="0.4.4", benchmark_revision=None, environment_name="unittest",
+                            test_execution_id=OsResultsStoreTests.TEST_RUN_ID,
+                            test_execution_timestamp=OsResultsStoreTests.TEST_RUN_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, workload=t, workload_params=None,
                             test_procedure=t.default_test_procedure,
                             cluster_config="4gheap",
@@ -1582,15 +1647,15 @@ class OsResultsStoreTests(TestCase):
                 })
                             )
 
-        self.results_store.store_results(test_run)
+        self.results_store.store_results(test_execution)
 
         expected_docs = [
             {
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {
@@ -1615,8 +1680,8 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {
@@ -1647,8 +1712,8 @@ class OsResultsStoreTests(TestCase):
                 "benchmark-version": "0.4.4",
                 "benchmark-revision": None,
                 "environment": "unittest",
-                "test-run-id": OsResultsStoreTests.TEST_RUN_ID,
-                "test-run-timestamp": "20160131T000000Z",
+                "test-execution-id": OsResultsStoreTests.TEST_RUN_ID,
+                "test-execution-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {
@@ -1945,7 +2010,7 @@ class InMemoryMetricsStoreTests(TestCase):
         self.assertEqual(0.2, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
 
 
-class FileTestRunStoreTests(TestCase):
+class FileTestExecutionStoreTests(TestCase):
     TEST_RUN_TIMESTAMP = datetime.datetime(2016, 1, 31)
     TEST_RUN_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
@@ -1960,19 +2025,19 @@ class FileTestRunStoreTests(TestCase):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "list.test_runs.max_results", 100)
-        self.cfg.add(config.Scope.application, "system", "time.start", FileTestRunStoreTests.TEST_RUN_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "list.test_executions.max_results", 100)
+        self.cfg.add(config.Scope.application, "system", "time.start", FileTestExecutionStoreTests.TEST_RUN_TIMESTAMP)
         self.cfg.add(
-            config.Scope.application, "system", "test_run.id",
-            FileTestRunStoreTests.TEST_RUN_ID)
-        self.test_run_store = metrics.FileTestRunStore(self.cfg)
+            config.Scope.application, "system", "test_execution.id",
+            FileTestExecutionStoreTests.TEST_RUN_ID)
+        self.test_execution_store = metrics.FileTestExecutionStore(self.cfg)
 
-    def test_test_run_not_found(self):
-        with self.assertRaisesRegex(exceptions.NotFound, r"No test run with test run id \[.*\]"):
+    def test_test_execution_not_found(self):
+        with self.assertRaisesRegex(exceptions.NotFound, r"No test execution with test execution id \[.*\]"):
             # did not store anything yet
-            self.test_run_store.find_by_test_run_id(FileTestRunStoreTests.TEST_RUN_ID)
+            self.test_execution_store.find_by_test_execution_id(FileTestExecutionStoreTests.TEST_RUN_ID)
 
-    def test_store_test_run(self):
+    def test_store_test_execution(self):
         schedule = [
             workload.Task("index #1", workload.Operation("index", workload.OperationType.Bulk))
         ]
@@ -1981,10 +2046,10 @@ class FileTestRunStoreTests(TestCase):
                         indices=[workload.Index(name="tests", types=["_doc"])],
                         test_procedures=[workload.TestProcedure(name="index", default=True, schedule=schedule)])
 
-        test_run = metrics.TestRun(
+        test_execution = metrics.TestExecution(
             benchmark_version="0.4.4", benchmark_revision="123abc", environment_name="unittest",
-                            test_run_id=FileTestRunStoreTests.TEST_RUN_ID,
-                            test_run_timestamp=FileTestRunStoreTests.TEST_RUN_TIMESTAMP,
+                            test_execution_id=FileTestExecutionStoreTests.TEST_RUN_ID,
+                            test_execution_timestamp=FileTestExecutionStoreTests.TEST_RUN_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, workload=t, workload_params={"clients": 12},
                             test_procedure=t.default_test_procedure,
                             cluster_config="4gheap",
@@ -1994,7 +2059,7 @@ class FileTestRunStoreTests(TestCase):
                             cluster_config_revision="abc12333",
                             distribution_version="5.0.0",
                             distribution_flavor="default", revision="aaaeeef",
-                            results=FileTestRunStoreTests.DictHolder(
+                            results=FileTestExecutionStoreTests.DictHolder(
                                 {
                                     "young_gc_time": 100,
                                     "old_gc_time": 5,
@@ -2013,13 +2078,13 @@ class FileTestRunStoreTests(TestCase):
                                 })
                             )
 
-        self.test_run_store.store_test_run(test_run)
+        self.test_execution_store.store_test_execution(test_execution)
 
-        retrieved_test_run = self.test_run_store.find_by_test_run_id(
-            test_run_id=FileTestRunStoreTests.TEST_RUN_ID)
-        self.assertEqual(test_run.test_run_id, retrieved_test_run.test_run_id)
-        self.assertEqual(test_run.test_run_timestamp, retrieved_test_run.test_run_timestamp)
-        self.assertEqual(1, len(self.test_run_store.list()))
+        retrieved_test_execution = self.test_execution_store.find_by_test_execution_id(
+            test_execution_id=FileTestExecutionStoreTests.TEST_RUN_ID)
+        self.assertEqual(test_execution.test_execution_id, retrieved_test_execution.test_execution_id)
+        self.assertEqual(test_execution.test_execution_timestamp, retrieved_test_execution.test_execution_timestamp)
+        self.assertEqual(1, len(self.test_execution_store.list()))
 
 
 class StatsCalculatorTests(TestCase):
@@ -2087,7 +2152,7 @@ class StatsCalculatorTests(TestCase):
             "unit": "ms"
         }, level=metrics.MetaInfoScope.cluster)
 
-        stats = metrics.calculate_results(store, metrics.create_test_run(cfg, t, test_procedure))
+        stats = metrics.calculate_results(store, metrics.create_test_execution(cfg, t, test_procedure))
 
         del store
 
@@ -2198,6 +2263,24 @@ class GlobalStatsCalculatorTests(TestCase):
         result = GlobalStatsCalculator(store=self.metrics_store, workload=Workload(name='geonames', meta_data={}),
                                        test_procedure=test_procedure)()
         assert "delete-index" in [op_metric.get('task') for op_metric in result.op_metrics]
+
+    def test_summary_stats_with_percentiles_and_no_samples_does_not_crash(self):
+        # Robustness: when a task has no Normal samples (e.g. every request
+        # errored), get_stats() returns None. Requesting percentiles must NOT
+        # crash on stats["count"] — it should return empty/None stats instead.
+        store = mock.Mock()
+        store.get_mean.return_value = None
+        store.get_median.return_value = None
+        store.get_unit.return_value = "ms"
+        store.get_stats.return_value = None  # no samples
+
+        calc = GlobalStatsCalculator(store=store, workload=Workload(name='geonames', meta_data={}),
+                                     test_procedure=TestProcedure(name='p', schedule=[], meta_data={}))
+        # Would previously raise TypeError: 'NoneType' object is not subscriptable
+        result = calc.summary_stats("throughput", "op1", "search", percentiles_list=[50, 99])
+        self.assertIsNone(result["mean"])
+        # No percentiles were computed (get_percentiles must not even be called).
+        store.get_percentiles.assert_not_called()
 
 
 class GlobalStatsTests(TestCase):
@@ -2607,7 +2690,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_runs_template(),
+            _index_template_provider.test_executions_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2627,7 +2710,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_runs_template(),
+            _index_template_provider.test_executions_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2649,7 +2732,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_runs_template(),
+            _index_template_provider.test_executions_template(),
             _index_template_provider.results_template(),
         ]
 
@@ -2672,7 +2755,7 @@ class TestIndexTemplateProvider:
             # pylint: disable=unused-variable
             templates = [
                 _index_template_provider.metrics_template(),
-                _index_template_provider.test_runs_template(),
+                _index_template_provider.test_executions_template(),
                 _index_template_provider.results_template(),
             ]
         assert ctx.value.args[0] == (
@@ -2693,7 +2776,7 @@ class TestIndexTemplateProvider:
 
         templates = [
             _index_template_provider.metrics_template(),
-            _index_template_provider.test_runs_template(),
+            _index_template_provider.test_executions_template(),
             _index_template_provider.results_template(),
         ]
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1332,6 +1332,34 @@ class OsTestExecutionStoreTests(TestCase):
             test_execution_id=OsTestExecutionStoreTests.TEST_RUN_ID)
         self.assertEqual(test_execution.test_execution_id, OsTestExecutionStoreTests.TEST_RUN_ID)
 
+    def test_from_dict_parses_1x_provision_config_fields(self):
+        # 1.x back-compat: a genuine 1.x doc uses test-run-id/timestamp AND the
+        # pre-2.x provision-config-* field names. from_dict must parse it without a
+        # KeyError and recover the provision-config-* values into the cluster_config* attrs.
+        d = {
+            "benchmark-version": "1.19.0",
+            "environment": "unittest",
+            "test-run-id": OsTestExecutionStoreTests.TEST_RUN_ID,
+            "test-run-timestamp": "20160131T000000Z",
+            "pipeline": "from-sources",
+            "workload": "unittest",
+            "test_procedure": "index",
+            "workload-revision": "abc1",
+            "provision-config-instance": "4gheap",
+            "provision-config-instance-params": {"foo": "bar"},
+            "cluster": {
+                "revision": "aaaeeef",
+                "distribution-version": "5.0.0",
+                "distribution-flavor": "oss",
+                "provision-config-revision": "abc12333",
+            },
+        }
+        test_execution = metrics.TestExecution.from_dict(d)
+        self.assertEqual(OsTestExecutionStoreTests.TEST_RUN_ID, test_execution.test_execution_id)
+        self.assertEqual("4gheap", test_execution.cluster_config)
+        self.assertEqual({"foo": "bar"}, test_execution.cluster_config_params)
+        self.assertEqual("abc12333", test_execution.cluster_config_revision)
+
     def test_does_not_find_missing_test_execution_by_test_execution_id(self):
         self.es_mock.search.return_value = {
             "hits": {
@@ -2085,6 +2113,43 @@ class FileTestExecutionStoreTests(TestCase):
         self.assertEqual(test_execution.test_execution_id, retrieved_test_execution.test_execution_id)
         self.assertEqual(test_execution.test_execution_timestamp, retrieved_test_execution.test_execution_timestamp)
         self.assertEqual(1, len(self.test_execution_store.list()))
+
+    def test_list_and_find_1x_underscore_layout(self):
+        # 1.x back-compat: a run produced by OSB 1.x lives on disk under the UNDERSCORE
+        # directory test_executions/<id>/test_execution.json and uses the pre-2.x
+        # provision-config-* vocab. Both list() and find_by_test_execution_id must read it.
+        one_x_id = "1a2b3c4d-0000-0000-0000-000000000001"
+        root_dir = self.cfg.opts("node", "root.dir")
+        run_dir = os.path.join(root_dir, "test_executions", one_x_id)
+        os.makedirs(run_dir, exist_ok=True)
+        one_x_doc = {
+            "benchmark-version": "1.19.0",
+            "environment": "unittest-env",
+            "test-run-id": one_x_id,
+            "test-run-timestamp": "20160131T000000Z",
+            "pipeline": "from-sources",
+            "workload": "unittest",
+            "test_procedure": "index",
+            "workload-revision": "abc1",
+            "provision-config-instance": "4gheap",
+            "provision-config-instance-params": {"foo": "bar"},
+            "cluster": {
+                "revision": "aaaeeef",
+                "distribution-version": "5.0.0",
+                "distribution-flavor": "oss",
+                "provision-config-revision": "abc12333",
+            },
+        }
+        with open(os.path.join(run_dir, "test_execution.json"), mode="wt", encoding="utf-8") as f:
+            f.write(json.dumps(one_x_doc))
+
+        retrieved = self.test_execution_store.find_by_test_execution_id(test_execution_id=one_x_id)
+        self.assertEqual(one_x_id, retrieved.test_execution_id)
+        self.assertEqual("4gheap", retrieved.cluster_config)
+
+        listed = self.test_execution_store.list()
+        self.assertEqual(1, len(listed))
+        self.assertEqual(one_x_id, listed[0].test_execution_id)
 
 
 class StatsCalculatorTests(TestCase):

--- a/tests/test_execution_orchestrator_test.py
+++ b/tests/test_execution_orchestrator_test.py
@@ -28,7 +28,7 @@ import unittest.mock as mock
 
 import pytest
 
-from osbenchmark import config, exceptions, test_run_orchestrator
+from osbenchmark import config, exceptions, test_execution_orchestrator
 
 
 @pytest.fixture
@@ -42,18 +42,18 @@ def running_in_docker():
 @pytest.fixture
 def benchmark_only_pipeline():
     test_pipeline_name = "benchmark-only"
-    original = test_run_orchestrator.pipelines[test_pipeline_name]
-    pipeline = test_run_orchestrator.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock.Mock())
+    original = test_execution_orchestrator.pipelines[test_pipeline_name]
+    pipeline = test_execution_orchestrator.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock.Mock())
     yield pipeline
     # restore prior pipeline!
-    test_run_orchestrator.pipelines[test_pipeline_name] = original
+    test_execution_orchestrator.pipelines[test_pipeline_name] = original
 
 
 @pytest.fixture
 def unittest_pipeline():
-    pipeline = test_run_orchestrator.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock.Mock())
+    pipeline = test_execution_orchestrator.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock.Mock())
     yield pipeline
-    del test_run_orchestrator.pipelines[pipeline.name]
+    del test_execution_orchestrator.pipelines[pipeline.name]
 
 
 def test_finds_available_pipelines():
@@ -64,7 +64,7 @@ def test_finds_available_pipelines():
         ["benchmark-only", "Assumes an already running OpenSearch instance, runs a benchmark and publishes results"],
     ]
 
-    assert expected == test_run_orchestrator.available_pipelines()
+    assert expected == test_execution_orchestrator.available_pipelines()
 
 
 def test_prevents_running_an_unknown_pipeline():
@@ -76,7 +76,7 @@ def test_prevents_running_an_unknown_pipeline():
     with pytest.raises(
             exceptions.SystemSetupError,
             match=r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines."):
-        test_run_orchestrator.run(cfg)
+        test_execution_orchestrator.run(cfg)
 
 
 def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_only_pipeline):
@@ -84,7 +84,7 @@ def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_o
     cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
     cfg.add(config.Scope.benchmark, "test_run", "pipeline", "benchmark-only")
 
-    test_run_orchestrator.run(cfg)
+    test_execution_orchestrator.run(cfg)
 
     benchmark_only_pipeline.target.assert_called_once_with(cfg)
 
@@ -102,7 +102,7 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
                 "For more details read the docs for the benchmark-only pipeline in "
                 "https://opensearch.org/docs\n"
             )):
-        test_run_orchestrator.run(cfg)
+        test_execution_orchestrator.run(cfg)
 
 
 def test_runs_a_known_pipeline(unittest_pipeline):
@@ -111,7 +111,7 @@ def test_runs_a_known_pipeline(unittest_pipeline):
     cfg.add(config.Scope.benchmark, "test_run", "pipeline", "unit-test-pipeline")
     cfg.add(config.Scope.benchmark, "builder", "distribution.version", "")
 
-    test_run_orchestrator.run(cfg)
+    test_execution_orchestrator.run(cfg)
 
     unittest_pipeline.target.assert_called_once_with(cfg)
 
@@ -120,6 +120,6 @@ def test_runs_a_default_pipeline(benchmark_only_pipeline):
     cfg = config.Config()
     cfg.add(config.Scope.benchmark, "system", "test_run.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
 
-    test_run_orchestrator.run(cfg)
+    test_execution_orchestrator.run(cfg)
 
     benchmark_only_pipeline.target.assert_called_once_with(cfg)

--- a/tests/worker_coordinator/worker_coordinator_test.py
+++ b/tests/worker_coordinator/worker_coordinator_test.py
@@ -1966,7 +1966,7 @@ class AsyncExecutorHelperMethodsTests(TestCase):
         context_mock = mock.Mock()
         message_producer_mock.new_request_context.return_value = context_mock
 
-        with mock.patch('osbenchmark.database.clients.opensearch.opensearch.MessageProducerFactory.create',
+        with mock.patch('osbenchmark.client.MessageProducerFactory.create',
                         new=mock.AsyncMock(return_value=message_producer_mock)) as factory_mock:
             result = await self.executor._prepare_context_manager(params)
             factory_mock.assert_called_once_with(params)
@@ -2236,7 +2236,7 @@ class FeedbackActorTests(TestCase):
 
     def test_check_cpu_usage_adds_error_when_threshold_exceeded(self):
         self.actor.max_cpu_threshold = 80
-        self.actor.test_run_id = "abc123"
+        self.actor.test_execution_id = "abc123"
         self.actor.cpu_window_seconds = 60
         self.actor.metrics_index = "metrics-index"
         self.actor.error_queue = queue.Queue()
@@ -2266,7 +2266,7 @@ class FeedbackActorTests(TestCase):
 
     def test_check_cpu_usage_no_errors_when_under_threshold(self):
         self.actor.max_cpu_threshold = 80
-        self.actor.test_run_id = "abc123"
+        self.actor.test_execution_id = "abc123"
         self.actor.cpu_window_seconds = 60
         self.actor.metrics_index = "metrics-index"
         self.actor.error_queue = queue.Queue()
@@ -2287,7 +2287,7 @@ class FeedbackActorTests(TestCase):
 
     def test_check_cpu_usage_drops_error_when_queue_full(self):
         self.actor.max_cpu_threshold = 80
-        self.actor.test_run_id = "abc123"
+        self.actor.test_execution_id = "abc123"
         self.actor.cpu_window_seconds = 60
         self.actor.metrics_index = "metrics-index"
 

--- a/tests/workload/loader_test.py
+++ b/tests/workload/loader_test.py
@@ -2135,6 +2135,14 @@ class WorkloadRandomizationTests(TestCase):
                 f"Make sure the operation in operations/default.json is well-formed",
                          ctx.exception.args[0])
 
+        # Robustness: a non-dict "body" (e.g. a string) must also produce a
+        # clean SystemSetupError, not an uncaught TypeError from subscripting a
+        # string by "query".
+        with self.assertRaises(exceptions.SystemSetupError):
+            processor.extract_fields_and_paths(
+                {"body": "my_query"},
+                loader.QueryRandomizerWorkloadProcessor.DEFAULT_QUERY_RANDOMIZATION_INFO)
+
         # Test a non-default value for query_randomization_info
         geo_point_query = {
             "name": "bbox",
@@ -2289,6 +2297,46 @@ class WorkloadSpecificationReaderTests(TestCase):
             reader("unittest", workload_specification, "/mappings")
         self.assertEqual(
             "Workload 'unittest' is invalid. Mandatory element 'document-count' is missing.", ctx.exception.args[0])
+
+    @mock.patch("osbenchmark.workload.loader.register_all_params_in_workload")
+    def test_parse_with_scalar_clients_list_raises_clean_error(self, mocked_params_checker):
+        # Robustness: clients_list given a scalar (int) instead of a list must
+        # raise a clean WorkloadSyntaxError, not an uncaught TypeError from
+        # iterating an int.
+        workload_specification = {
+            "description": "description for unit test",
+            "indices": [{"name": "test-index", "body": "index.json", "types": ["docs"]}],
+            "corpora": [
+                {
+                    "name": "test",
+                    "documents": [
+                        {
+                            "source-file": "documents-main.json.bz2",
+                            "document-count": 10,
+                            "compressed-bytes": 100,
+                            "uncompressed-bytes": 10000
+                        }
+                    ]
+                }
+            ],
+            "operations": [
+                {"name": "search-op", "operation-type": "search", "body": {"query": {"match_all": {}}}}
+            ],
+            "test_procedures": [
+                {
+                    "name": "default-test_procedure",
+                    "schedule": [
+                        {"clients_list": 8, "operation": "search-op"}  # scalar, not [8]
+                    ]
+                }
+            ]
+        }
+        reader = loader.WorkloadSpecificationReader(source=io.DictStringFileSourceFactory({
+            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+        }))
+        with self.assertRaises(loader.WorkloadSyntaxError) as ctx:
+            reader("unittest", workload_specification, "/mappings")
+        self.assertIn("clients_list", ctx.exception.args[0])
 
     @mock.patch("osbenchmark.workload.loader.register_all_params_in_workload")
     def test_parse_with_mixed_warmup_iterations_and_measurement(self, mocked_params_checker):

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -1666,6 +1666,18 @@ class CreateIndexParamSourceTests(TestCase):
             }
         }, body)
 
+    def test_create_index_non_dict_settings_raises_clean_error(self):
+        # Robustness: a string (or other non-dict) 'settings' param would hit
+        # dict.update("...") -> ValueError. Must raise a clean InvalidSyntax.
+        index = workload.Index(name="index1", types=["type1"], body={
+            "settings": {"index.number_of_replicas": 0},
+        })
+        with self.assertRaises(exceptions.InvalidSyntax) as ctx:
+            params.CreateIndexParamSource(
+                workload.Workload(name="unit-test", indices=[index]),
+                params={"settings": "number_of_replicas=0"})
+        self.assertIn("settings", ctx.exception.args[0])
+
     def test_create_index_from_workload_without_settings(self):
         index1 = workload.Index(name="index1", types=["type1"])
         index2 = workload.Index(name="index2", types=["type1"], body={
@@ -3611,6 +3623,7 @@ class VectorSearchPartitionPartitionParamSourceTestCase(TestCase):
                     "request-params": {},
                 }
             )
+
 
     def _check_params(
             self,


### PR DESCRIPTION
### Description

First of the stacked OpenSearch Benchmark 3.0 PRs. This reverts the 2.x-era terminology back to the 3.0 (and original 1.x) vocabulary, with full back-compat so existing automation and historical data keep working.

**CLI**
- `execute-test` is the primary subcommand again; `run` / `execute` remain as deprecated aliases (they warn, then dispatch).
- `--test-execution-id` is primary; `--test-run-id` remains as a legacy alias.

**Internal rename**
- `test_run` / `TestRun` → `test_execution` / `TestExecution` across metrics, aggregator, worker_coordinator, builder, paths, publisher, and the orchestrator (module `test_run_orchestrator.py` → `test_execution_orchestrator.py`).
- On disk: `test-runs/` → `test-executions/`; `test_run.json` → `test_execution.json`.
- Datastore (OpenSearch): indices `benchmark-test-runs-*` → `benchmark-test-executions-*`; stored field `test-run-id` → `test-execution-id`.

**Back-compat — reads accept BOTH, writes emit the new vocabulary**
- `TestExecution.from_dict` accepts either `test-execution-id`/`test-run-id` and `test-execution-timestamp`/`test-run-timestamp`.
- The node-stats CPU-window query and `list` accept both old and new names.
- **Seamless 1.x → 3.0 migration:** the reader also accepts genuine 1.x artifacts — the pre-2.x `provision-config-instance` (+ `-params`, + `cluster.provision-config-revision`) field names as fallbacks for the reverted `cluster-config-*` names, and the 1.x on-disk `test_executions/` (underscore) directory layout. Without this, a 1.x record silently dropped from `list` on the file path and crashed `list` on the OpenSearch-datastore path (both funnel through `from_dict`). Reads only — 3.0 always writes the new vocabulary.

No behavior change beyond naming and widened back-compat reads. Multi-engine support and the CloudWatch datastore build on this foundation in subsequent stacked PRs.

**Note for reviewers**
- `version.txt` is intentionally left at 2.4.0; the 3.0.0 bump lands in its own dedicated PR at release time (matching repo convention, e.g. #1090).
- Pre-existing minor flag inconsistency, not introduced here: `aggregate` uses `--test-executions-id` (plural) while `execute-test` uses `--test-execution-id` (singular); both have working legacy aliases. Can be smoothed here or left.

### Issues Resolved

Restores the original 1.x `execute-test` / `test_execution` vocabulary that 2.x had renamed.

### Testing
- [x] New functionality includes testing

- **Unit:** full suite passes (1435 passed / 5 skipped; engine + metrics_stores suites belong to later stacked PRs). Includes 13+ back-compat assertions exercising the legacy `test-run-id` key, plus two new tests for genuine 1.x artifacts (`from_dict` parsing the `provision-config-*` vocab, and reading the 1.x underscore on-disk layout).
- **Live e2e** on real AWS infra (OpenSearch 2.19.1): full `execute-test` write→read round-trip confirming the new `test-executions/` dir, `test_execution.json`, and `test-execution-id`/`test-execution-timestamp` fields with no legacy keys emitted; OpenSearch-datastore path creating `benchmark-{metrics,results,test-executions}-*` indices with all metric docs queryable by `test-execution-id`; read-both proven on a live index (synthetic legacy `test-run-id` doc matched by the back-compat query); `list` / `compare` / `aggregate` / `visualize` exercised via both new and legacy flags; a full (non-test-mode) benchmark producing real throughput/latency.
- **1.x → 3.0 migration proven live:** genuine 1.x artifacts produced by OpenSearch Benchmark 1.18.0 (on-disk `test_executions/` underscore dir + a datastore run doc carrying `provision-config-instance`) were read by this branch — `list`, `find`, and `compare` all succeed on the on-disk run, and the datastore `list` reads the 1.x doc without the previous `from_dict` crash.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
