### PR TITLE
Add new telemetry for cross-cluster-replication feature

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 FROM python:3.11.2-slim AS build-stage
 
 RUN apt-get -y update && \
-    apt-get install -y curl git gcc pbzip2 pigz make jq && \
+    apt-get install -y curl git gcc lbzip2 pbzip2 pigz make jq && \
     apt-get -y upgrade
 
 COPY . opensearch-benchmark
@@ -37,7 +37,7 @@ COPY --from=build-stage /opensearch-benchmark/dist/*.whl ./
 
 RUN set -ex; \
     apt-get -y update; \
-    apt-get install -y git pbzip2; \
+    apt-get install -y git lbzip2 pbzip2; \
     apt-get -y upgrade; \
     rm -rf /var/lib/apt/lists/*; \
     PIP_ONLY_BINARY=h5py pip install *.whl; \

--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -40,7 +40,8 @@ def list_telemetry():
     console.println("Available telemetry devices:\n")
     devices = [[device.command, device.human_name, device.help] for device in [JitCompiler, Gc, FlightRecorder,
                                                                                Heapdump, NodeStats, RecoveryStats,
-                                                                               CcrStats, SegmentStats, TransformStats,
+                                                                               CcrStats, CcrStatsV2, SegmentStats,
+                                                                               TransformStats,
                                                                                SearchableSnapshotsStats,
                                                                                SegmentReplicationStats, ShardStats]]
     console.println(tabulate.tabulate(devices, ["Command", "Name", "Description"]))
@@ -482,6 +483,156 @@ class CcrStatsRecorder:
         return len(leader_checkpoint_queue) * self.sample_interval
 
 
+class CcrStatsV2(TelemetryDevice):
+    internal = False
+    command = "ccr-stats-v2"
+    human_name = "CCR Stats v2"
+    help = ("Regularly samples Cross Cluster Replication (CCR) follower stats at index level using the "
+            "_remote_replication/secondary_stats API. Replication lag is reported directly by the API, "
+            "so no leader stats are collected and no lag is calculated by OSB.")
+
+    """
+    Gathers CCR follower stats on a cluster level
+    """
+    def __init__(self, telemetry_params, clients, metrics_store):
+        """
+        :param telemetry_params: The configuration object for telemetry_params.
+            May optionally specify:
+            ``ccr-stats-v2-indices``: index/index-pattern or list of indices or index-patterns per cluster to publish
+            statistics from. Not all clusters need to be specified, but any name used must be present in target.hosts.
+            Alternatively, the index or index pattern can be specified as a string in case only one cluster is involved.
+            Example:
+            {"ccr-stats-v2-indices": {"follower": ["big5"]}}
+            ``ccr-stats-v2-sample-interval``: positive integer controlling the sampling interval. Default: 1 second.
+        :param clients: A dict of clients to all clusters.
+        :param metrics_store: The configured metrics store we write to.
+        """
+        super().__init__()
+        self.telemetry_params = telemetry_params
+        self.clients = clients
+        self.sample_interval = telemetry_params.get("ccr-stats-v2-sample-interval", 1)
+        if self.sample_interval <= 0:
+            raise exceptions.SystemSetupError(
+                "The telemetry parameter 'ccr-stats-v2-sample-interval' must be greater than zero but was {}.".format(
+                    self.sample_interval))
+        self.specified_cluster_names = self.clients.keys()
+        indices_per_cluster = self.telemetry_params.get("ccr-stats-v2-indices", None)
+        # allow the user to specify either an index pattern as string or as a JSON object
+        if isinstance(indices_per_cluster, str):
+            self.indices_per_cluster = {opts.TargetHosts.DEFAULT: [indices_per_cluster]}
+        else:
+            self.indices_per_cluster = indices_per_cluster
+
+        if self.indices_per_cluster:
+            for cluster_name in self.indices_per_cluster.keys():
+                if cluster_name not in clients:
+                    raise exceptions.SystemSetupError(
+                        "The telemetry parameter 'ccr-stats-v2-indices' must be a JSON Object with keys matching "
+                        "the cluster names [{}] specified in --target-hosts "
+                        "but it had [{}].".format(",".join(sorted(clients.keys())), cluster_name))
+            self.specified_cluster_names = self.indices_per_cluster.keys()
+
+        self.metrics_store = metrics_store
+        self.samplers = []
+
+    def on_benchmark_start(self):
+        for cluster_name in self.specified_cluster_names:
+            recorder = CcrStatsV2Recorder(cluster_name, self.clients[cluster_name], self.metrics_store,
+                                          self.sample_interval,
+                                          self.indices_per_cluster[cluster_name] if self.indices_per_cluster else None)
+            sampler = SamplerThread(recorder)
+            self.samplers.append(sampler)
+            sampler.daemon = True
+            # we don't require starting recorders precisely at the same time
+            sampler.start()
+
+    def on_benchmark_stop(self):
+        if self.samplers:
+            for sampler in self.samplers:
+                sampler.finish()
+
+
+class CcrStatsV2Recorder:
+    """
+    Collects and pushes CCR follower stats for the specified cluster to the metric store.
+    """
+
+    def __init__(self, cluster_name, client, metrics_store, sample_interval, indices=None):
+        """
+        :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
+        :param client: The OpenSearch client for this cluster.
+        :param metrics_store: The configured metrics store we write to.
+        :param sample_interval: integer controlling the interval, in seconds, between collecting samples.
+        :param indices: optional list of indices or index-patterns to filter results from.
+        """
+        self.cluster_name = cluster_name
+        self.client = client
+        self.metrics_store = metrics_store
+        self.sample_interval = sample_interval
+        self.indices = indices
+        self.logger = logging.getLogger(__name__)
+
+    def __str__(self):
+        return "ccr stats v2"
+
+    def record(self):
+        """
+        Collect CCR follower stats for indices (optionally) specified in telemetry parameters and push to metrics store.
+        """
+        try:
+            stats = self.client.transport.perform_request(
+                "GET", "/_remote_replication/secondary_stats", params={"level": "indices"})
+        except opensearchpy.TransportError:
+            msg = "A transport error occurred while collecting CCR secondary stats on cluster [{}]".format(self.cluster_name)
+            self.logger.exception(msg)
+            raise exceptions.BenchmarkError(msg)
+
+        for index_name, index_stats in stats.get("indices", {}).items():
+            if not self._match_list_or_pattern(index_name):
+                continue
+            self.record_stats_per_index(index_name, index_stats)
+
+    def record_stats_per_index(self, name, stats):
+        """
+        :param name: The index name.
+        :param stats: A dict with returned CCR follower stats for the index.
+        """
+        doc = {
+            "name": "ccr-stats-v2",
+            "index": name,
+        }
+        # ingest all fields from the index-level stats block, flattening any nested objects (e.g. bootstrap)
+        doc.update(self._flatten(stats))
+
+        index_metadata = {
+            "cluster": self.cluster_name,
+            "index": name
+        }
+        self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=index_metadata)
+
+    def _flatten(self, stats, prefix=""):
+        flattened = {}
+        for key, value in stats.items():
+            new_key = "{}_{}".format(prefix, key) if prefix else key
+            if isinstance(value, dict):
+                flattened.update(self._flatten(value, new_key))
+            else:
+                flattened[new_key] = value
+        return flattened
+
+    def _match_list_or_pattern(self, idx):
+        """
+        Match idx against self.indices. If no indices filter was specified, everything matches.
+
+        :param idx: String that may include shell style wildcards (https://docs.python.org/3/library/fnmatch.html)
+        :return: Boolean whether idx matches anything from self.indices (or True if no filter is set).
+        """
+        if not self.indices:
+            return True
+        for index_param in self.indices:
+            if fnmatch.fnmatch(idx, index_param):
+                return True
+        return False
 
 
 class RecoveryStats(TelemetryDevice):

--- a/osbenchmark/utils/io.py
+++ b/osbenchmark/utils/io.py
@@ -345,13 +345,16 @@ def decompress(zip_name, target_directory):
     if extension == ".zip":
         _do_decompress(target_directory, zipfile.ZipFile(zip_name))
     elif extension == ".bz2":
-        decompressor_args = ["pbzip2", "-d", "-k", "-m10000", "-c"]
+        # Prefer lbzip2: unlike pbzip2, it parallelizes decompression of any bz2 file, including
+        # single-stream files not produced by pbzip2 (as is the case for most published corpora).
+        # The candidate commands are tried in order, falling back to the single-threaded standard library.
+        decompressor_commands = [["lbzip2", "-d", "-k", "-c"], ["pbzip2", "-d", "-k", "-m10000", "-c"]]
         decompressor_lib = bz2.open
-        _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
+        _do_decompress_manually(target_directory, zip_name, decompressor_commands, decompressor_lib)
     elif extension == ".gz":
-        decompressor_args = ["pigz", "-d", "-k", "-c"]
+        decompressor_commands = [["pigz", "-d", "-k", "-c"]]
         decompressor_lib = gzip.open
-        _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
+        _do_decompress_manually(target_directory, zip_name, decompressor_commands, decompressor_lib)
     elif extension in [".tar", ".tar.gz", ".tgz", ".tar.bz2"]:
         _do_decompress(target_directory, tarfile.open(zip_name))
     elif extension == ".zst":
@@ -360,16 +363,19 @@ def decompress(zip_name, target_directory):
         raise RuntimeError("Unsupported file extension [%s]. Cannot decompress [%s]" % (extension, zip_name))
 
 
-def _do_decompress_manually(target_directory, filename, decompressor_args, decompressor_lib):
-    decompressor_bin = decompressor_args[0]
+def _do_decompress_manually(target_directory, filename, decompressor_commands, decompressor_lib):
     base_path_without_extension = basename(splitext(filename)[0])
 
-    if is_executable(decompressor_bin):
+    # Try each external command in order of preference. The first one that is both available on the
+    # PATH and succeeds wins; otherwise we fall back to the single-threaded standard library.
+    available = [cmd for cmd in decompressor_commands if is_executable(cmd[0])]
+    for decompressor_args in available:
         if _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
             return
-    else:
+
+    if not available:
         logging.getLogger(__name__).warning("%s not found in PATH. Using standard library, decompression will take longer.",
-                                            decompressor_bin)
+                                            " or ".join(cmd[0] for cmd in decompressor_commands))
 
     _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
 

--- a/osbenchmark/worker_coordinator/worker_coordinator.py
+++ b/osbenchmark/worker_coordinator/worker_coordinator.py
@@ -1022,6 +1022,7 @@ class WorkerCoordinator:
                     telemetry.MlBucketProcessingTime(os_default, self.metrics_store),
                     telemetry.SegmentStats(log_root, os_default),
                     telemetry.CcrStats(telemetry_params, opensearch, self.metrics_store),
+                    telemetry.CcrStatsV2(telemetry_params, opensearch, self.metrics_store),
                     telemetry.RecoveryStats(telemetry_params, opensearch, self.metrics_store),
                     telemetry.TransformStats(telemetry_params, opensearch, self.metrics_store),
                     telemetry.SearchableSnapshotsStats(telemetry_params, opensearch, self.metrics_store),

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -695,6 +695,163 @@ class CcrStatsRecorderTests(TestCase):
         recorder.record()
         assert metrics_store_put_doc.call_count == 1
 
+
+class CcrStatsV2Tests(TestCase):
+    def test_negative_sample_interval_forbidden(self):
+        clients = {"default": Client(), "cluster_b": Client()}
+        cfg = create_config()
+        metrics_store = metrics.OsMetricsStore(cfg)
+        telemetry_params = {
+            "ccr-stats-v2-sample-interval": -1 * random.random()
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The telemetry parameter 'ccr-stats-v2-sample-interval' must be greater than zero but was .*\."):
+            telemetry.CcrStatsV2(telemetry_params, clients, metrics_store)
+
+    def test_wrong_cluster_name_in_ccr_stats_v2_indices_forbidden(self):
+        clients = {"default": Client(), "cluster_b": Client()}
+        cfg = create_config()
+        metrics_store = metrics.OsMetricsStore(cfg)
+        telemetry_params = {
+            "ccr-stats-v2-indices": {
+                "default": ["big5"],
+                "wrong_cluster_name": ["big5"]
+            }
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The telemetry parameter 'ccr-stats-v2-indices' must be a JSON Object with keys matching "
+                                    r"the cluster names \[{}] specified in --target-hosts "
+                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
+                                    ):
+            telemetry.CcrStatsV2(telemetry_params, clients, metrics_store)
+
+
+class CcrStatsV2RecorderTests(TestCase):
+    def secondary_stats_response(self, index_name):
+        return {
+            "_nodes": {"total": 1, "successful": 1, "failed": 0},
+            "total_shards": 96,
+            "healthy_shards": 96,
+            "failed_shards": 0,
+            "unmeasured_shards": 0,
+            "indices_count": 1,
+            "num_failed_indices": 0,
+            "max_lag_ops": 0,
+            "approximate_max_lag_time_millis": 9391,
+            "total_received_total": 4337701,
+            "total_receive_failures": 0,
+            "total_receive_throttles": 0,
+            "total_heartbeats": 429508,
+            "total_ops_read": 1020000000,
+            "total_ops_written": 1020000000,
+            "total_bytes_read": 1016099382267,
+            "total_replay_time_millis": 304443504,
+            "oldest_lease_age_millis": 28335,
+            "num_bootstrapping_indices": 0,
+            "metadata": {
+                "my-relationship": {
+                    "controller_node": "ip-10-1-132-89.us-west-2.compute.internal",
+                    "last_applied_metadata_version": 76,
+                    "last_successful_poll_millis": 1786122358940,
+                    "lag_seconds": 7
+                }
+            },
+            "indices": {
+                index_name: {
+                    "bootstrap": {
+                        "duration_millis": 142,
+                        "attempts": 1
+                    },
+                    "total_shards": 96,
+                    "healthy_shards": 96,
+                    "failed_shards": 0,
+                    "unmeasured_shards": 0,
+                    "max_lag_ops": 0,
+                    "approximate_max_lag_time_millis": 9391,
+                    "total_received_total": 4337701,
+                    "total_receive_failures": 0,
+                    "total_receive_throttles": 0,
+                    "total_heartbeats": 429508,
+                    "total_ops_read": 1020000000,
+                    "total_ops_written": 1020000000,
+                    "total_bytes_read": 1016099382267,
+                    "total_replay_time_millis": 304443504,
+                    "oldest_lease_age_millis": 28335
+                }
+            }
+        }
+
+    @mock.patch("osbenchmark.metrics.OsMetricsStore.put_doc")
+    def test_stores_all_indices_fields(self, metrics_store_put_doc):
+        index_name = "big5"
+        mock_responses = [self.secondary_stats_response(index_name)]
+        client = Client(transport_client=TransportClient(responses=copy.copy(mock_responses)))
+        cfg = create_config()
+        metrics_store = metrics.OsMetricsStore(cfg)
+        recorder = telemetry.CcrStatsV2Recorder("follower", client, metrics_store, 1)
+        recorder.record()
+
+        expected_doc = {
+            "name": "ccr-stats-v2",
+            "index": index_name,
+            "bootstrap_duration_millis": 142,
+            "bootstrap_attempts": 1,
+            "total_shards": 96,
+            "healthy_shards": 96,
+            "failed_shards": 0,
+            "unmeasured_shards": 0,
+            "max_lag_ops": 0,
+            "approximate_max_lag_time_millis": 9391,
+            "total_received_total": 4337701,
+            "total_receive_failures": 0,
+            "total_receive_throttles": 0,
+            "total_heartbeats": 429508,
+            "total_ops_read": 1020000000,
+            "total_ops_written": 1020000000,
+            "total_bytes_read": 1016099382267,
+            "total_replay_time_millis": 304443504,
+            "oldest_lease_age_millis": 28335
+        }
+        index_metadata = {
+            "cluster": "follower",
+            "index": index_name
+        }
+        metrics_store_put_doc.assert_called_once_with(expected_doc, level=MetaInfoScope.cluster, meta_data=index_metadata)
+
+    @mock.patch("osbenchmark.metrics.OsMetricsStore.put_doc")
+    def test_filters_indices_by_pattern(self, metrics_store_put_doc):
+        response = self.secondary_stats_response("big5")
+        response["indices"]["nyc_taxis"] = dict(response["indices"]["big5"])
+        client = Client(transport_client=TransportClient(responses=[response]))
+        cfg = create_config()
+        metrics_store = metrics.OsMetricsStore(cfg)
+        recorder = telemetry.CcrStatsV2Recorder("follower", client, metrics_store, 1, ["big5*"])
+        recorder.record()
+
+        assert metrics_store_put_doc.call_count == 1
+        recorded_doc = metrics_store_put_doc.call_args.args[0]
+        assert recorded_doc["index"] == "big5"
+
+    @mock.patch("osbenchmark.metrics.OsMetricsStore.put_doc")
+    def test_stores_all_indices_when_no_filter(self, metrics_store_put_doc):
+        response = self.secondary_stats_response("big5")
+        response["indices"]["nyc_taxis"] = dict(response["indices"]["big5"])
+        client = Client(transport_client=TransportClient(responses=[response]))
+        cfg = create_config()
+        metrics_store = metrics.OsMetricsStore(cfg)
+        recorder = telemetry.CcrStatsV2Recorder("follower", client, metrics_store, 1)
+        recorder.record()
+
+        assert metrics_store_put_doc.call_count == 2
+
+    def test_error_on_transport_error(self):
+        client = Client(transport_client=TransportClient(responses=[], force_error=True))
+        metrics_store = metrics.OsMetricsStore(create_config())
+        with self.assertRaisesRegex(exceptions.BenchmarkError,
+                                    r"A transport error occurred while collecting CCR secondary stats on cluster \[follower\]"):
+            telemetry.CcrStatsV2Recorder("follower", client, metrics_store, 1).record()
+
+
 class RecoveryStatsTests(TestCase):
     @mock.patch("osbenchmark.metrics.OsMetricsStore.put_doc")
     def test_no_metrics_if_no_pending_recoveries(self, metrics_store_put_doc):

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -23,6 +23,7 @@
 # under the License.
 # pylint: disable=protected-access
 
+import bz2
 import logging
 import os
 import subprocess
@@ -124,6 +125,37 @@ class TestDecompression:
 
         mocked_warn_logger.assert_called_once_with(expected_err, archive_path, decompress_cmd, stderr_msg)
         assert result is False
+
+    @mock.patch.object(io, "_do_decompress_manually_external", return_value=True)
+    @mock.patch.object(io, "is_executable", return_value=True)
+    def test_prefers_first_available_command(self, mocked_is_executable, mocked_external):
+        # When both lbzip2 and pbzip2 are available, the first (lbzip2) must be used.
+        commands = [["lbzip2", "-d", "-k", "-c"], ["pbzip2", "-d", "-k", "-m10000", "-c"]]
+        io._do_decompress_manually("/tmp", "/tmp/docs.json.bz2", commands, bz2.open)
+
+        assert mocked_external.call_count == 1
+        assert mocked_external.call_args[0][3] == ["lbzip2", "-d", "-k", "-c"]
+
+    @mock.patch.object(io, "_do_decompress_manually_external", return_value=True)
+    def test_falls_back_to_next_available_command(self, mocked_external):
+        # lbzip2 missing, pbzip2 present: pbzip2 must be used, no stdlib fallback.
+        commands = [["lbzip2", "-d", "-k", "-c"], ["pbzip2", "-d", "-k", "-m10000", "-c"]]
+        with mock.patch.object(io, "is_executable", side_effect=lambda name: name == "pbzip2"):
+            io._do_decompress_manually("/tmp", "/tmp/docs.json.bz2", commands, bz2.open)
+
+        assert mocked_external.call_count == 1
+        assert mocked_external.call_args[0][3] == ["pbzip2", "-d", "-k", "-m10000", "-c"]
+
+    @mock.patch.object(io, "_do_decompress_manually_with_lib")
+    @mock.patch.object(io, "_do_decompress_manually_external", return_value=False)
+    @mock.patch.object(io, "is_executable", return_value=True)
+    def test_falls_back_to_lib_when_all_external_fail(self, mocked_is_executable, mocked_external, mocked_lib):
+        # Both tools available but each fails at runtime: every candidate is tried, then stdlib.
+        commands = [["lbzip2", "-d", "-k", "-c"], ["pbzip2", "-d", "-k", "-m10000", "-c"]]
+        io._do_decompress_manually("/tmp", "/tmp/docs.json.bz2", commands, mock.MagicMock())
+
+        assert mocked_external.call_count == 2
+        assert mocked_lib.call_count == 1
 
     def read(self, f):
         with open(f, 'r') as content_file:


### PR DESCRIPTION
### Description
Adds a ccr-stats-v2 telemetry device that samples CCR follower stats at index level via the `_remote_replication/secondary_stats` API. Replication lag is reported directly by the API, so no leader stats are collected and no lag is calculated by OSB.

Prefer lbzip2 for parallel bz2 decompression. 

For .bz2 archives, try lbzip2 before pbzip2, falling back to the standard library. Unlike pbzip2, lbzip2 parallelizes decompression of any bz2 file, including the single-stream files used by most published corpora (e.g. big5), so decompression is no longer pinned to a single core.

Generalizes _do_decompress_manually to accept an ordered list of candidate external commands, and adds lbzip2 to the Docker image.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
