### PR TITLE
add node role to metrics metadata

### DIFF
--- a/osbenchmark/telemetry.py
+++ b/osbenchmark/telemetry.py
@@ -964,9 +964,11 @@ class NodeStatsRecorder:
         current_sample = self.sample()
         for node_stats in current_sample:
             node_name = node_stats["name"]
+            roles = node_stats["roles"]
             metrics_store_meta_data = {
                 "cluster": self.cluster_name,
-                "node_name": node_name
+                "node_name": node_name,
+                "roles": roles
             }
             collected_node_stats = collections.OrderedDict()
             collected_node_stats["name"] = "node-stats"

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2133,7 +2133,8 @@ class NodeStatsRecorderTests(TestCase):
         metrics_store = metrics.OsMetricsStore(cfg)
         node_name = [NodeStatsRecorderTests.node_stats_response["nodes"][node]["name"]
                      for node in NodeStatsRecorderTests.node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [self.node_stats_response["nodes"][node]["roles"] for node in self.node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         telemetry_params = {}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
@@ -2384,7 +2385,8 @@ class NodeStatsRecorderTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.OsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
         telemetry_params = {
             "node-stats-include-indices": True
         }
@@ -2726,7 +2728,8 @@ class NodeStatsRecorderTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.OsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles":roles}
         telemetry_params = {
             "node-stats-include-indices-metrics": "refresh,docs"
         }


### PR DESCRIPTION
### Description
add node role to metrics metadata to easily analyze metrics for clusters with multiple node roles. 

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
