### PR TITLE
Support per-percentage ground truth datasets via filter_percentage param

### DIFF
--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -109,6 +109,11 @@ class HDF5DataSet(DataSet):
     def _load(self):
         if self.data is None:
             file = h5py.File(self.dataset_path)
+            if self.context not in file:
+                raise ConfigurationError(
+                    f"Dataset key '{self.context}' does not exist in {self.dataset_path}. "
+                    f"Available keys: {sorted(file.keys())}. If filter_percentage is set, "
+                    f"ensure the dataset was generated with that percentage.")
             self.data = cast(h5py.Dataset, file[self.context])
 
     def read(self, chunk_size: int):

--- a/osbenchmark/utils/dataset.py
+++ b/osbenchmark/utils/dataset.py
@@ -72,17 +72,20 @@ class DataSet(ABC):
         """
 
 
-def get_data_set(data_set_format: str, path: str, context: Context):
+def get_data_set(data_set_format: str, path: str, context: Context, key_suffix: str = None):
     """
     Factory method to get instance of Dataset for given format.
     Args:
         data_set_format: File format like hdf5, bigann
         path: Data set file path
         context: Dataset Context Enum
+        key_suffix: Optional suffix appended to the HDF5 key name, e.g.
+            Context.NEIGHBORS with key_suffix "10pct" reads "neighbors_10pct".
+            Used by filtered benchmarks storing per-percentage ground truth.
     Returns: DataSet instance
     """
     if data_set_format == HDF5DataSet.FORMAT_NAME:
-        return HDF5DataSet(path, context)
+        return HDF5DataSet(path, context, key_suffix)
     if data_set_format == BigANNVectorDataSet.FORMAT_NAME:
         return create_big_ann_dataset(path)
     raise ConfigurationError("Invalid data set format")
@@ -95,9 +98,11 @@ class HDF5DataSet(DataSet):
 
     FORMAT_NAME = "hdf5"
 
-    def __init__(self, dataset_path: str, context: Context):
+    def __init__(self, dataset_path: str, context: Context, key_suffix: str = None):
         self.dataset_path = dataset_path
         self.context = self.parse_context(context)
+        if key_suffix:
+            self.context = f"{self.context}_{key_suffix}"
         self.current = self.BEGINNING
         self.data = None
 

--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1162,6 +1162,12 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         self.filter_type = self.query_params.get(self.PARAMS_NAME_FILTER_TYPE)
         self.filter_body = self.query_params.get(self.PARAMS_NAME_FILTER_BODY)
         self.space_type = params.get(self.PARAMS_NAME_SPACE_TYPE, "l2")
+        # Suffix selecting per-percentage ground truth datasets, e.g. "10pct"
+        # reads neighbors_10pct and faiss_max_distance_10pct instead of the
+        # unsuffixed keys. Used by filtered benchmarks.
+        self.filter_percentage = None
+        if "filter_percentage" in params:
+            self.filter_percentage = parse_string_parameter("filter_percentage", params)
 
         if self.radial_search_type:
             index_body = params.get("target_index_body", "")
@@ -1238,14 +1244,16 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
             neighbors_context = Context.NEIGHBORS
 
         partition.neighbors_data_set = get_data_set(
-            self.neighbors_data_set_format, self.neighbors_data_set_path, neighbors_context)
+            self.neighbors_data_set_format, self.neighbors_data_set_path, neighbors_context,
+            self.filter_percentage)
         partition.neighbors_data_set.seek(partition.offset)
 
         if self.radial_search_type:
             threshold_context = self.RADIAL_THRESHOLD_CONTEXTS[
                 (self.radial_engine, self.radial_search_type)]
             partition.threshold_data_set = get_data_set(
-                self.neighbors_data_set_format, self.neighbors_data_set_path, threshold_context)
+                self.neighbors_data_set_format, self.neighbors_data_set_path, threshold_context,
+                self.filter_percentage)
             partition.threshold_data_set.seek(partition.offset)
 
         return partition

--- a/tests/utils/dataset_test.py
+++ b/tests/utils/dataset_test.py
@@ -3,8 +3,12 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
+import os
 import tempfile
 from unittest import TestCase
+
+import h5py
+import numpy as np
 
 from osbenchmark.utils.dataset import Context, get_data_set, HDF5DataSet, BigANNVectorDataSet
 from osbenchmark.utils.parse import ConfigurationError
@@ -66,3 +70,26 @@ class DataSetTestCase(TestCase):
     def testUnSupportedDataSetFormat(self):
         with self.assertRaises(ConfigurationError) as _:
             get_data_set("random", "/some/path", Context.INDEX)
+
+    def testHDF5KeySuffix(self):
+        with tempfile.TemporaryDirectory() as data_set_dir:
+            data_set_path = os.path.join(data_set_dir, "key-suffix.hdf5")
+            neighbors = np.zeros((DEFAULT_NUM_VECTORS, DEFAULT_DIMENSION), dtype=np.int32)
+            neighbors_10pct = np.ones((DEFAULT_NUM_VECTORS, DEFAULT_DIMENSION), dtype=np.int32)
+            max_distance_10pct = np.full((DEFAULT_NUM_VECTORS, DEFAULT_DIMENSION), 2.0, dtype=np.float32)
+            with h5py.File(data_set_path, "w") as file:
+                file.create_dataset("neighbors", data=neighbors)
+                file.create_dataset("neighbors_10pct", data=neighbors_10pct)
+                file.create_dataset("faiss_max_distance_10pct", data=max_distance_10pct)
+
+            # without suffix, the unsuffixed key is read
+            data_set_instance = get_data_set("hdf5", data_set_path, Context.NEIGHBORS)
+            self.assertTrue(np.array_equal(data_set_instance.read(1)[0], neighbors[0]))
+
+            # with suffix, the suffixed keys are read
+            data_set_instance = get_data_set("hdf5", data_set_path, Context.NEIGHBORS, "10pct")
+            self.assertTrue(np.array_equal(data_set_instance.read(1)[0], neighbors_10pct[0]))
+
+            data_set_instance = get_data_set(
+                "hdf5", data_set_path, Context.FAISS_MAX_DISTANCE, "10pct")
+            self.assertTrue(np.array_equal(data_set_instance.read(1)[0], max_distance_10pct[0]))

--- a/tests/utils/dataset_test.py
+++ b/tests/utils/dataset_test.py
@@ -93,3 +93,16 @@ class DataSetTestCase(TestCase):
             data_set_instance = get_data_set(
                 "hdf5", data_set_path, Context.FAISS_MAX_DISTANCE, "10pct")
             self.assertTrue(np.array_equal(data_set_instance.read(1)[0], max_distance_10pct[0]))
+
+    def testHDF5MissingKeyRaisesConfigurationError(self):
+        with tempfile.TemporaryDirectory() as data_set_dir:
+            data_set_path = os.path.join(data_set_dir, "missing-key.hdf5")
+            with h5py.File(data_set_path, "w") as file:
+                file.create_dataset(
+                    "neighbors", data=np.zeros((DEFAULT_NUM_VECTORS, DEFAULT_DIMENSION), dtype=np.int32))
+
+            data_set_instance = get_data_set("hdf5", data_set_path, Context.NEIGHBORS, "5pct")
+            with self.assertRaises(ConfigurationError) as ctx:
+                data_set_instance.read(1)
+            self.assertIn("neighbors_5pct", str(ctx.exception))
+            self.assertIn("Available keys", str(ctx.exception))


### PR DESCRIPTION
### Description
Adds optional key_suffix to HDF5 dataset reads. When filter_percentage is set (e.g. "10pct"), the neighbors and radial threshold datasets are read from suffixed keys (neighbors_10pct, faiss_max_distance_10pct), allowing one dataset file to hold precomputed answer sets for multiple filter percentages.

### Testing
- Added a unit test covering suffixed key resolution (`neighbors_10pct`,`faiss_max_distance_10pct`) and unchanged unsuffixed reads
- Ran the full filtered radial curve (18 configurations) against a live cluster; exact-search runs return recall 1.0
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
