### PR TITLE
Support filters with nested fields in vector search bulk ingest and query construction

### DIFF
--- a/osbenchmark/workload/params.py
+++ b/osbenchmark/workload/params.py
@@ -1335,7 +1335,7 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
 
         if self.is_nested:
             outer_field_name, _inner_field_name = self.get_split_fields()
-            return {
+            knn_search_query = {
                 "nested": {
                     "path": outer_field_name,
                     "query": knn_search_query
@@ -1348,6 +1348,9 @@ class VectorSearchPartitionParamSource(VectorDataSetPartitionParamSource):
         return knn_search_query
 
     def _knn_query_with_filter(self, vector, knn_query, filter_type, filter_body) -> dict:
+        if filter_type == "script" and self.is_nested:
+            raise exceptions.ConfigurationError("Script filter is not supported with nested fields")
+
         if filter_type == "script":
             return {
                 "script_score": {
@@ -1433,6 +1436,20 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
 
         return partition
 
+    def attributes_for_row(self, attributes: np.ndarray, row: int) -> Dict[str, Any]:
+        """Filter attribute fields for one dataset row, keyed by attribute name.
+
+        For nested data sets the attributes are vector-aligned (every child
+        vector row repeats its parent document's values), so any row of a
+        parent's children yields that parent's attributes.
+        """
+        fields = {}
+        for idx, attribute_name in enumerate(self.filter_attributes):
+            attribute = attributes[row][idx].decode()
+            if attribute != "None":
+                fields[attribute_name] = attribute
+        return fields
+
     def bulk_transform_add_attributes(self, partition: np.ndarray, action, attributes: np.ndarray) ->   List[Dict[str, Any]]:
         """attributes is a (partition_len x 3) matrix. """
         actions = []
@@ -1501,8 +1518,7 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
         if not self.is_nested and not self.filter_attributes:
             return self.bulk_transform_non_nested(partition, action)
 
-        # TODO: Assumption: we won't add attributes if we're also doing a nested query.
-        if self.filter_attributes:
+        if self.filter_attributes and not self.is_nested:
             return self.bulk_transform_add_attributes(partition, action, attributes)
         actions = []
 
@@ -1516,6 +1532,8 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
             self.action_parent_id = parents_ids[first_index_of_parent_ids]
             if add_id_field_to_body:
                 self.action_buffer.update({self.id_field_name: int(self.action_parent_id)})
+            if self.filter_attributes:
+                self.action_buffer.update(self.attributes_for_row(attributes, first_index_of_parent_ids))
 
         part_list = partition.tolist()
         for i in range(len(partition)):
@@ -1541,6 +1559,8 @@ class BulkVectorsFromDataSetParamSource(VectorDataSetPartitionParamSource):
                 if add_id_field_to_body:
 
                     self.action_buffer.update({self.id_field_name: int(current_parent_id)})
+                if self.filter_attributes:
+                    self.action_buffer.update(self.attributes_for_row(attributes, i))
 
                 self.action_buffer[outer_field_name].append(nested)
 

--- a/tests/workload/params_test.py
+++ b/tests/workload/params_test.py
@@ -4312,6 +4312,172 @@ class VectorsNestedCase(TestCase):
                 continue
             self.assertTrue(expected_id_field in req_body)
 
-    def test_nested_vector_query_body(self):
-        # assert that _build_vector_search_query_body returns the correct thing.
-        pass
+    def _create_query_data_set(self):
+        data_set_path = create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.QUERY,
+            self.data_set_dir
+        )
+        create_data_set(
+            self.DEFAULT_NUM_VECTORS,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.NEIGHBORS,
+            self.data_set_dir,
+            data_set_path
+        )
+        return data_set_path
+
+    def _nested_query_param_source(self, data_set_path, k, filter_type, filter_body):
+        test_param_source_params = {
+            "field": self.DEFAULT_VECTOR_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "k": k,
+            "filter_type": filter_type,
+            "filter_body": filter_body,
+        }
+        return VectorSearchPartitionParamSource(
+            workload.Workload(name="unit-test"),
+            test_param_source_params, {
+                "index": self.DEFAULT_INDEX_NAME,
+                "request-params": {},
+            }
+        )
+
+    def test_nested_efficient_filter(self):
+        k = 12
+        efficient_filter_body = {
+            "term": {"filter10pct": "true"}
+        }
+        query_param_source = self._nested_query_param_source(
+            self._create_query_data_set(), k, "efficient", efficient_filter_body)
+        query_param_source_partition = query_param_source.partition(0, 1)
+
+        for _ in range(self.DEFAULT_NUM_VECTORS):
+            self._check_query_params(
+                query_param_source_partition.params(),
+                self.DEFAULT_VECTOR_FIELD_NAME,
+                self.DEFAULT_DIMENSION,
+                k,
+                expected_filter=efficient_filter_body,
+            )
+
+        with self.assertRaises(StopIteration):
+            query_param_source_partition.params()
+
+    def test_nested_bool_filter(self):
+        k = 12
+        bool_filter_body = {
+            "term": {"filter10pct": "true"}
+        }
+        query_param_source = self._nested_query_param_source(
+            self._create_query_data_set(), k, "boolean", bool_filter_body)
+        query_param_source_partition = query_param_source.partition(0, 1)
+
+        for _ in range(self.DEFAULT_NUM_VECTORS):
+            params_dict = query_param_source_partition.params()
+            query = params_dict.get("body").get("query")
+            bool_query = query.get("bool")
+            self.assertIsInstance(bool_query, dict)
+            self.assertEqual(bool_query.get("filter"), bool_filter_body)
+
+            must = bool_query.get("must")
+            self.assertIsInstance(must, list)
+            self.assertEqual(len(must), 1)
+            nested = must[0].get("nested")
+            self.assertIsInstance(nested, dict)
+
+            outer, _inner = self.DEFAULT_VECTOR_FIELD_NAME.split(".")
+            self.assertEqual(nested.get("path"), outer)
+            field = nested.get("query").get("knn").get(self.DEFAULT_VECTOR_FIELD_NAME)
+            self.assertEqual(field.get("k"), k)
+            self.assertEqual(len(list(field.get("vector"))), self.DEFAULT_DIMENSION)
+            # the filter wraps the nested query; it must not leak into the knn clause
+            self.assertIsNone(field.get("filter"))
+
+        with self.assertRaises(StopIteration):
+            query_param_source_partition.params()
+
+    def test_nested_script_filter_raises(self):
+        k = 12
+        query_param_source = self._nested_query_param_source(
+            self._create_query_data_set(), k, "script", {"term": {"filter10pct": "true"}})
+        query_param_source_partition = query_param_source.partition(0, 1)
+
+        with self.assertRaises(exceptions.ConfigurationError):
+            query_param_source_partition.params()
+
+    def test_params_default_with_attributes(self):
+        attributes_list = ['taste', 'color', 'age']
+        num_vectors = 49
+        bulk_size = 15
+        parent_group_size = 10
+        data_set_path = create_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.INDEX,
+            self.data_set_dir,
+        )
+        parent_data_set_path = create_parent_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.PARENTS,
+            self.data_set_dir,
+        )
+        create_attributes_data_set(
+            num_vectors,
+            self.DEFAULT_DIMENSION,
+            self.DEFAULT_TYPE,
+            Context.ATTRIBUTES,
+            self.data_set_dir,
+            parent_data_set_path,
+        )
+        with h5py.File(parent_data_set_path, "r") as f:
+            raw_attributes = f["attributes"][:]
+
+        test_param_source_params = {
+            "index": self.DEFAULT_INDEX_NAME,
+            "field": self.DEFAULT_VECTOR_FIELD_NAME,
+            "data_set_format": self.DEFAULT_TYPE,
+            "data_set_path": data_set_path,
+            "bulk_size": bulk_size,
+            "id-field-name": self.DEFAULT_ID_FIELD_NAME,
+            "filter_attributes": attributes_list,
+        }
+        bulk_param_source = BulkVectorsFromDataSetParamSource(
+            workload.Workload(name="unit-test"), test_param_source_params
+        )
+        bulk_param_source.parent_data_set_path = parent_data_set_path
+        bulk_param_source_partition = bulk_param_source.partition(0, 1)
+
+        vectors_consumed = 0
+        while vectors_consumed < num_vectors:
+            expected_num_vectors = min(num_vectors - vectors_consumed, bulk_size)
+            actual_params = bulk_param_source_partition.params()
+            expected_num_docs = len(actual_params["body"]) // 2
+
+            self._check_params_nested(
+                actual_params,
+                self.DEFAULT_INDEX_NAME,
+                self.DEFAULT_VECTOR_FIELD_NAME,
+                self.DEFAULT_DIMENSION,
+                expected_num_vectors,
+                expected_num_docs,
+                self.DEFAULT_ID_FIELD_NAME,
+            )
+            # every parent doc carries the attributes of its first child row
+            for header, req_body in zip(*[iter(actual_params["body"])] * 2):
+                parent_id = header["index"]["_id"]
+                first_child_row = (parent_id - 1) * parent_group_size
+                for idx, attribute_name in enumerate(attributes_list):
+                    expected_attribute = raw_attributes[first_child_row][idx].decode()
+                    self.assertEqual(req_body.get(attribute_name), expected_attribute)
+            vectors_consumed += expected_num_vectors
+
+        with self.assertRaises(StopIteration):
+            bulk_param_source_partition.params()


### PR DESCRIPTION
### Description
Added a nested + filter_attributes bulk ingest path (previously mutually exclusive — attributes silently produced flat one-doc-per-vector ingest for nested fields) and made filter_type: boolean wrap the nested query in a bool filter clause instead of being silently dropped. script + nested now raises a ConfigurationError.

### Testing
4 new unit tests (both filter query shapes, script error, nested ingest with attributes across bulk boundaries); verified end-to-end on a live cluster: 1M nested docs ingested, recall measured against filtered ground truth at 9 selectivities on both engines.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
