### PR TITLE
Bump base image to python:3.11-slim-trixie to clear sqlite3 CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 #
 # Stage 1: build packages and compile where needed
 #
-FROM python:3.11.2-slim AS build-stage
+FROM python:3.11-slim-trixie AS build-stage
 
 RUN apt-get -y update && \
     apt-get install -y curl git gcc lbzip2 pbzip2 pigz make jq && \
@@ -22,7 +22,7 @@ RUN cd opensearch-benchmark; \
 #
 # Stage 2: create image
 #
-FROM python:3.11.2-slim AS image-stage
+FROM python:3.11-slim-trixie AS image-stage
 ENV BENCHMARK_RUNNING_IN_DOCKER=True
 
 RUN groupadd --gid 1000 opensearch-benchmark && \


### PR DESCRIPTION
## Description

Moves both build stages from `python:3.11.2-slim` (Debian 11 bullseye) to `python:3.11-slim-trixie` (Debian 13). The bullseye base ships a `sqlite3` affected by `CVE-2025-6965` and `CVE-2025-7458` with no fix available on that Debian release. The trixie base carries `sqlite3` 3.46.1-7+deb13u1, which includes the fixes for both. Python stays at 3.11.

Fixes #1112.

## Verification

Scanned the trixie based image with Trivy: **19 total findings, 3 fixable HIGH, 0 CRITICAL**, and the two `sqlite3` CVEs no longer present. The remaining 3 fixable HIGH findings are in openssl, jaraco.context, and wheel, unrelated to this change. Image scanned:

```
python:3.11-slim-trixie@sha256:be1575ed968de893bd54f4c56315ff7c4736ce522c1bca08fd521731aafc0d76
```

## Notes

Using the floating trixie tag so routine rebuilds keep picking up base patches. If reproducible builds are preferred, this can be pinned by digest instead, ideally paired with Dependabot so the pin still advances. Happy to switch it to a pinned digest if maintainers would rather.
